### PR TITLE
Reduce secp iterations

### DIFF
--- a/cairo_programs/secp_integration_tests.cairo
+++ b/cairo_programs/secp_integration_tests.cairo
@@ -89,6 +89,6 @@ end
 
 func main{range_check_ptr}():
     # These values have triggered a bug in the past
-    run_tests(3, 5)
+    run_tests(4, 5)
     return()
 end


### PR DESCRIPTION
# Reduce secp integration tests iterations

## Description

Secp_integration_test was taking too long to complete in normal test runs, so the amount of iterations was reduced
