### PR TITLE
Add macros and refactor hint tests

### DIFF
--- a/src/hint_processor/builtin_hint_processor/blake2s_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/blake2s_utils.rs
@@ -279,12 +279,9 @@ mod tests {
         vm.memory = memory![((1, 0), (2, 5))];
         //Create hint data
         let ids_data = ids_data!["output"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::CantSubOffset(5, 26))
         );
     }
@@ -294,26 +291,16 @@ mod tests {
         let hint_code = "from starkware.cairo.common.cairo_blake2s.blake2s_utils import compute_blake2s_func\ncompute_blake2s_func(segments=segments, output_ptr=ids.output)";
         //Create vm
         let mut vm = vm!();
-        for _ in 0..2 {
-            vm.segments.add(&mut vm.memory, None);
-        }
         //Initialize fp
         vm.run_context.fp = 1;
         //Insert ids into memory (output)
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 0)),
-                &MaybeRelocatable::from((2, 26)),
-            )
-            .unwrap();
+        vm.memory = memory![((1, 0), (2, 26))];
+        add_segments!(vm, 1);
         //Create hint data
         let ids_data = ids_data!["output"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((2, 0))
             ))
@@ -331,12 +318,9 @@ mod tests {
         vm.memory = memory![((1, 0), 12)];
         //Create hint data
         let ids_data = ids_data!["output"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::ExpectedRelocatable(
                 MaybeRelocatable::from((1, 0))
             ))
@@ -364,12 +348,9 @@ mod tests {
         ];
         //Create hint data
         let ids_data = ids_data!["output"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::BigintToU32Fail)
         );
     }
@@ -385,12 +366,9 @@ mod tests {
         vm.memory = memory![((1, 0), (2, 26)), ((2, 0), (5, 5))];
         //Create hint data
         let ids_data = ids_data!["output"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((2, 0))
             ))
@@ -406,17 +384,11 @@ mod tests {
         vm.run_context.fp = 1;
         //Insert ids into memory (output)
         vm.memory = memory![((1, 0), (2, 0))];
-        vm.segments.add(&mut vm.memory, None);
+        add_segments!(vm, 1);
         //Create hint data
         let ids_data = ids_data!["blake2s_ptr_end"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
-            Ok(())
-        );
+        assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
         //Check the inserted data
         let expected_data: [u32; 204] = [
             1795745351, 3144134277, 1013904242, 2773480762, 1359893119, 2600822924, 528734635,
@@ -458,12 +430,9 @@ mod tests {
         //Insert ids into memory (output)
         vm.memory = memory![((1, 0), (2, 0)), ((2, 0), (2, 0))];
         let ids_data = ids_data!["blake2s_ptr_end"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((2, 0)),
@@ -481,12 +450,9 @@ mod tests {
         let mut vm = vm!();
         //Initialize fp
         vm.run_context.fp = 1;
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), HashMap::new());
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, HashMap::new(), hint_code),
             Err(VirtualMachineError::FailedToGetIds)
         );
     }
@@ -502,47 +468,20 @@ mod tests {
         vm.memory = memory![((1, 0), (2, 0)), ((1, 1), 0), ((1, 2), 0)];
         vm.segments.add(&mut vm.memory, None);
         let ids_data = ids_data!["data", "high", "low"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
-            Ok(())
-        );
+        assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
         //Check data ptr
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 0))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 1))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 2))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 3))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 4))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 5))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 6))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 7))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
+        check_memory![
+            vm.memory,
+            ((2, 0), 0),
+            ((2, 1), 0),
+            ((2, 2), 0),
+            ((2, 3), 0),
+            ((2, 4), 0),
+            ((2, 5), 0),
+            ((2, 6), 0),
+            ((2, 7), 0)
+        ];
         assert_eq!(vm.memory.get(&MaybeRelocatable::from((2, 8))), Ok(None));
     }
 
@@ -557,47 +496,20 @@ mod tests {
         vm.memory = memory![((1, 0), (2, 0)), ((1, 1), 25), ((1, 2), 20)];
         vm.segments.add(&mut vm.memory, None);
         let ids_data = ids_data!["data", "high", "low"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
-            Ok(())
-        );
+        assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
         //Check data ptr
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 0))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(20))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 1))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 2))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 3))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 4))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(25))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 5))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 6))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 7))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
+        check_memory![
+            vm.memory,
+            ((2, 0), 20),
+            ((2, 1), 0),
+            ((2, 2), 0),
+            ((2, 3), 0),
+            ((2, 4), 25),
+            ((2, 5), 0),
+            ((2, 6), 0),
+            ((2, 7), 0)
+        ];
         assert_eq!(vm.memory.get(&MaybeRelocatable::from((2, 8))), Ok(None));
     }
 
@@ -610,49 +522,22 @@ mod tests {
         vm.run_context.fp = 3;
         //Insert ids into memory
         vm.memory = memory![((1, 0), (2, 0)), ((1, 1), 0), ((1, 2), 0)];
-        vm.segments.add(&mut vm.memory, None);
+        add_segments!(vm, 1);
         let ids_data = ids_data!["data", "high", "low"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
-            Ok(())
-        );
+        assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
         //Check data ptr
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 0))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 1))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 2))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 3))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 4))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 5))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 6))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 7))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
+        check_memory![
+            vm.memory,
+            ((2, 0), 0),
+            ((2, 1), 0),
+            ((2, 2), 0),
+            ((2, 3), 0),
+            ((2, 4), 0),
+            ((2, 5), 0),
+            ((2, 6), 0),
+            ((2, 7), 0)
+        ];
         assert_eq!(vm.memory.get(&MaybeRelocatable::from((2, 8))), Ok(None));
     }
 
@@ -667,47 +552,20 @@ mod tests {
         vm.memory = memory![((1, 0), (2, 0)), ((1, 1), 25), ((1, 2), 20)];
         vm.segments.add(&mut vm.memory, None);
         let ids_data = ids_data!["data", "high", "low"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
-            Ok(())
-        );
+        assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
         //Check data ptr
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 0))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 1))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 2))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 3))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(25))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 4))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 5))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 6))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 7))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(20))))
-        );
+        check_memory![
+            vm.memory,
+            ((2, 0), 0),
+            ((2, 1), 0),
+            ((2, 2), 0),
+            ((2, 3), 25),
+            ((2, 4), 0),
+            ((2, 5), 0),
+            ((2, 6), 0),
+            ((2, 7), 20)
+        ];
         assert_eq!(vm.memory.get(&MaybeRelocatable::from((2, 8))), Ok(None));
     }
 }

--- a/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -512,6 +512,7 @@ mod tests {
     use crate::utils::test_utils::*;
     use crate::vm::errors::{exec_scope_errors::ExecScopeError, memory_errors::MemoryError};
     use crate::vm::vm_core::VirtualMachine;
+    use crate::vm::vm_memory::memory::Memory;
     use crate::{any_box, bigint};
     use num_bigint::{BigInt, Sign};
     use std::any::Any;
@@ -590,7 +591,7 @@ mod tests {
         // insert ids.len into memory
         vm.memory = memory![((1, 1), 5)];
         let ids_data = ids_data!["len"];
-        assert!(run_hint!(vm, HashMap::new(), hint_code).is_ok());
+        assert!(run_hint!(vm, ids_data, hint_code).is_ok());
     }
 
     #[test]
@@ -607,7 +608,7 @@ mod tests {
 
         let ids_data = ids_data!["len"];
         assert_eq!(
-            run_hint!(vm, HashMap::new(), hint_code),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((1, 1))
             ))
@@ -645,7 +646,7 @@ mod tests {
         vm.memory = memory![((0, 2), 5)];
         let ids_data = ids_data!["continue_copying"];
         assert_eq!(
-            run_hint!(vm, HashMap::new(), hint_code),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::VariableNotInScopeError(
                 "n".to_string()
             ))
@@ -669,7 +670,7 @@ mod tests {
         let ids_data = ids_data!["continue_copying"];
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
         assert_eq!(
-            run_hint!(vm, HashMap::new(), hint_code),
+            run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((1, 1)),
@@ -793,7 +794,7 @@ mod tests {
             ((1, 2), (2, 0))
         ];
         let ids_data = ids_data!["length", "data", "high", "low"];
-        assert!(run_hint!(vm, HashMap::new(), hint_code).is_err());
+        assert!(run_hint!(vm, ids_data, hint_code).is_err());
     }
 
     #[test]
@@ -839,7 +840,7 @@ mod tests {
             ((1, 8), 0)
         ];
         let ids_data = non_continuous_ids_data![("keccak_state", -7), ("high", -3), ("low", -2)];
-        assert!(run_hint!(vm, HashMap::new(), hint_code).is_ok());
+        assert!(run_hint!(vm, ids_data, hint_code).is_ok());
     }
 
     #[test]
@@ -854,13 +855,12 @@ mod tests {
             ((1, 1), (1, 2)),
             ((1, 2), (1, 4)),
             ((1, 3), (1, 5)),
-            ((1, 4), 1),
             ((1, 5), 2),
             ((1, 8), 0)
         ];
         let ids_data = non_continuous_ids_data![("keccak_state", -7), ("high", -3), ("low", -2)];
         assert_eq!(
-            run_hint!(vm, HashMap::new(), hint_code),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::NoneInMemoryRange)
         );
     }
@@ -877,11 +877,11 @@ mod tests {
             ((1, 1), (1, 2)),
             ((1, 2), (1, 4)),
             ((1, 3), (1, 5)),
-            ((1, 4), 1),
+            ((1, 4), (1, 5)),
             ((1, 5), 2),
             ((1, 8), 0)
         ];
         let ids_data = non_continuous_ids_data![("keccak_state", -7), ("high", -3), ("low", -2)];
-        assert!(run_hint!(vm, HashMap::new(), hint_code).is_err());
+        assert!(run_hint!(vm, ids_data, hint_code).is_err());
     }
 }

--- a/src/hint_processor/builtin_hint_processor/cairo_keccak/keccak_hints.rs
+++ b/src/hint_processor/builtin_hint_processor/cairo_keccak/keccak_hints.rs
@@ -278,14 +278,7 @@ mod tests {
 
         //Create ids
         let ids_data = ids_data!["low", "high", "inputs"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
-            Ok(())
-        );
+        assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
     }
 
     #[test]

--- a/src/hint_processor/builtin_hint_processor/cairo_keccak/keccak_hints.rs
+++ b/src/hint_processor/builtin_hint_processor/cairo_keccak/keccak_hints.rs
@@ -253,6 +253,7 @@ mod tests {
     use crate::hint_processor::proxies::exec_scopes_proxy::get_exec_scopes_proxy;
     use crate::hint_processor::proxies::vm_proxy::get_vm_proxy;
     use crate::types::exec_scope::ExecutionScopes;
+    use crate::types::relocatable::Relocatable;
     use crate::utils::test_utils::*;
     use crate::vm::errors::memory_errors::MemoryError;
     use crate::vm::runners::builtin_runner::RangeCheckBuiltinRunner;
@@ -265,17 +266,14 @@ mod tests {
     fn keccak_write_args_valid_test() {
         let hint_code = "segments.write_arg(ids.inputs, [ids.low % 2 ** 64, ids.low // 2 ** 64])\nsegments.write_arg(ids.inputs + 2, [ids.high % 2 ** 64, ids.high // 2 ** 64])";
         let mut vm = vm_with_range_check!();
-
         vm.memory = memory![
             ((1, 0), 233),
             ((1, 1), 351),
             ((1, 2), (2, 0)),
             ((2, 4), 5_i32)
         ];
-
         //Initialize fp
         vm.run_context.fp = 3;
-
         //Create ids
         let ids_data = ids_data!["low", "high", "inputs"];
         assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
@@ -285,24 +283,12 @@ mod tests {
     fn keccak_write_args_write_error() {
         let hint_code = "segments.write_arg(ids.inputs, [ids.low % 2 ** 64, ids.low // 2 ** 64])\nsegments.write_arg(ids.inputs + 2, [ids.high % 2 ** 64, ids.high // 2 ** 64])";
         let mut vm = vm_with_range_check!();
-
-        for _ in 0..1 {
-            vm.segments.add(&mut vm.memory, None);
-        }
-
         vm.memory = memory![((1, 0), 233), ((1, 1), 351), ((1, 2), (2, 0))];
-
         //Initialize fp
         vm.run_context.fp = 3;
-
         //Create ids
         let ids_data = ids_data!["low", "high", "inputs"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        let error =
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data));
-
+        let error = run_hint!(vm, ids_data, hint_code);
         assert!(matches!(error, Err(VirtualMachineError::MemoryError(_))));
     }
 
@@ -315,16 +301,9 @@ mod tests {
         vm.segments.add(&mut vm.memory, None);
         vm.memory = memory![((1, 0), 24)];
 
-        vm.run_context.fp = 1;
-        vm.run_context.ap = 1;
+        run_context!(vm, 0, 1, 1);
         let ids_data = ids_data!["n_bytes"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
-            Ok(())
-        );
+        assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
     }
 
     #[test]
@@ -337,17 +316,10 @@ mod tests {
         vm.segments.add(&mut vm.memory, None);
         vm.memory = memory![((1, 0), 24)];
 
-        vm.run_context.fp = 1;
-        vm.run_context.ap = 1;
+        run_context!(vm, 0, 1, 1);
 
         let ids_data = ids_data!["n_bytes"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
-            Ok(())
-        );
+        assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
     }
 
     #[test]
@@ -359,16 +331,9 @@ mod tests {
         vm.segments.add(&mut vm.memory, None);
         vm.memory = memory![((1, 0), 24)];
 
-        vm.run_context.fp = 1;
-        vm.run_context.ap = 1;
+        run_context!(vm, 0, 1, 1);
 
         let ids_data = ids_data!["n_bytes"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
-            Ok(())
-        );
+        assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
     }
 }

--- a/src/hint_processor/builtin_hint_processor/dict_hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/dict_hint_utils.rs
@@ -283,8 +283,8 @@ mod tests {
 
     use num_bigint::{BigInt, Sign};
 
+    use crate::hint_processor::builtin_hint_processor::dict_manager::DictManager;
     use crate::hint_processor::builtin_hint_processor::dict_manager::DictTracker;
-    use crate::hint_processor::builtin_hint_processor::dict_manager::{DictManager, Dictionary};
     use crate::types::relocatable::MaybeRelocatable;
     use crate::types::relocatable::Relocatable;
     use crate::utils::test_utils::*;
@@ -359,19 +359,13 @@ mod tests {
         let mut vm = vm!();
         //Initialize fp
         vm.run_context.fp = 3;
-        //Create tracker
-        let mut tracker = DictTracker::new_empty(&relocatable!(2, 0));
-        tracker.insert_value(&bigint!(5_i32), &bigint!(12_i32));
-        //Create manager
-        let mut dict_manager = DictManager::new();
-        dict_manager.trackers.insert(2, tracker);
         //Insert ids into memory
         vm.memory = memory![((1, 0), 5), ((1, 2), (2, 0))];
         let ids_data = ids_data!["key", "value", "dict_ptr"];
         add_segments!(vm, 1);
         let mut exec_scopes = ExecutionScopes::new();
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        add_dict_manager!(exec_scopes_proxy, dict_manager);
+        dict_manager!(exec_scopes_proxy, 2, (5, 12));
         //Execute the hint
         assert_eq!(
             run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
@@ -392,22 +386,13 @@ mod tests {
         let mut vm = vm!();
         //Initialize fp
         vm.run_context.fp = 3;
-        //Initialize dictionary
-        let mut dictionary = HashMap::<BigInt, BigInt>::new();
-        dictionary.insert(bigint!(5), bigint!(12));
-        //Create tracker
-        let mut tracker = DictTracker::new_empty(&relocatable!(2, 0));
-        tracker.data = Dictionary::SimpleDictionary(dictionary);
-        //Create manager
-        let mut dict_manager = DictManager::new();
-        dict_manager.trackers.insert(2, tracker);
         //Insert ids into memory
         vm.memory = memory![((1, 0), 6), ((1, 2), (2, 0))];
         let ids_data = ids_data!["key", "value", "dict_ptr"];
         //Execute the hint
         let mut exec_scopes = ExecutionScopes::new();
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        add_dict_manager!(exec_scopes_proxy, dict_manager);
+        dict_manager!(exec_scopes_proxy, 2, (5, 12));
         assert_eq!(
             run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
             Err(VirtualMachineError::NoValueForKey(bigint!(6)))
@@ -420,10 +405,9 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 3;
         //Create manager
-        let dict_manager = DictManager::new();
-        let mut exec_scopes = ExecutionScopes::new();
+        let mut exec_scopes = scope![("dict_manager", Rc::new(RefCell::new(DictManager::new())))];
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        add_dict_manager!(exec_scopes_proxy, dict_manager);
+
         //Insert ids into memory
         vm.memory = memory![((1, 0), 6), ((1, 2), (2, 0))];
         add_segments!(vm, 1);
@@ -488,15 +472,9 @@ mod tests {
         let mut vm = vm!();
         //Initialize fp
         vm.run_context.fp = 3;
-        //Create tracker
-        //current_ptr = dict_ptr = (2, 0)
-        let tracker = DictTracker::new_default_dict(&relocatable!(2, 0), &bigint!(2), None);
-        //Create manager
-        let mut dict_manager = DictManager::new();
-        dict_manager.trackers.insert(2, tracker);
         let mut exec_scopes = ExecutionScopes::new();
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        add_dict_manager!(exec_scopes_proxy, dict_manager);
+        dict_manager_default!(exec_scopes_proxy, 2, 2);
         //Insert ids into memory
         vm.memory = memory![((1, 0), 5), ((1, 1), 17), ((1, 2), (2, 0))];
         add_segments!(vm, 1);
@@ -525,17 +503,9 @@ mod tests {
         let mut vm = vm!();
         //Initialize fp
         vm.run_context.fp = 3;
-        //Create tracker
-        //current_ptr = dict_ptr = (2, 0)
-        let mut tracker = DictTracker::new_default_dict(&relocatable!(2, 0), &bigint!(2), None);
-        //Add key-value pair (5, 10)
-        tracker.insert_value(&bigint!(5_i32), &bigint!(10_i32));
-        //Create manager
-        let mut dict_manager = DictManager::new();
-        dict_manager.trackers.insert(2, tracker);
         let mut exec_scopes = ExecutionScopes::new();
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        add_dict_manager!(exec_scopes_proxy, dict_manager);
+        dict_manager_default!(exec_scopes_proxy, 2, 2, (5, 10));
         //Insert ids into memory
         vm.memory = memory![((1, 0), 5), ((1, 1), 17), ((1, 2), (2, 0))];
         add_segments!(vm, 1);
@@ -564,17 +534,9 @@ mod tests {
         let mut vm = vm!();
         //Initialize fp
         vm.run_context.fp = 3;
-        //Create tracker
-        //current_ptr = dict_ptr = (2, 0)
-        let mut tracker = DictTracker::new_empty(&relocatable!(2, 0));
-        //Add key-value pair (5, 10)
-        tracker.insert_value(&bigint!(5), &bigint!(10));
-        //Create manager
-        let mut dict_manager = DictManager::new();
-        dict_manager.trackers.insert(2, tracker);
         let mut exec_scopes = ExecutionScopes::new();
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        add_dict_manager!(exec_scopes_proxy, dict_manager);
+        dict_manager!(exec_scopes_proxy, 2, (5, 10));
         //Insert ids into memory
         vm.memory = memory![((1, 0), 5), ((1, 1), 17), ((1, 2), (2, 0))];
         add_segments!(vm, 1);
@@ -604,15 +566,9 @@ mod tests {
         let mut vm = vm!();
         //Initialize fp
         vm.run_context.fp = 3;
-        //Create tracker
-        //current_ptr = dict_ptr = (2, 0)
-        let tracker = DictTracker::new_empty(&relocatable!(2, 0));
-        //Create manager
-        let mut dict_manager = DictManager::new();
-        dict_manager.trackers.insert(2, tracker);
         let mut exec_scopes = ExecutionScopes::new();
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        add_dict_manager!(exec_scopes_proxy, dict_manager);
+        dict_manager!(exec_scopes_proxy, 2);
         //Insert ids into memory
         vm.memory = memory![((1, 0), 5), ((1, 1), 17), ((1, 2), (2, 0))];
         add_segments!(vm, 1);
@@ -635,17 +591,9 @@ mod tests {
         let mut vm = vm!();
         //Initialize fp
         vm.run_context.fp = 4;
-        //Create tracker
-        //current_ptr = dict_ptr = (2, 0)
-        let mut tracker = DictTracker::new_empty(&relocatable!(2, 0));
-        //Add key-value pair (5, 10)
-        tracker.insert_value(&bigint!(5), &bigint!(10));
-        //Create manager
-        let mut dict_manager = DictManager::new();
-        dict_manager.trackers.insert(2, tracker);
         let mut exec_scopes = ExecutionScopes::new();
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        add_dict_manager!(exec_scopes_proxy, dict_manager);
+        dict_manager!(exec_scopes_proxy, 2, (5, 10));
         //Insert ids into memory
         vm.memory = memory![((1, 0), 5), ((1, 1), 10), ((1, 2), 20), ((1, 3), (2, 0))];
         add_segments!(vm, 1);
@@ -671,17 +619,9 @@ mod tests {
         let mut vm = vm!();
         //Initialize fp
         vm.run_context.fp = 4;
-        //Create tracker
-        //current_ptr = dict_ptr = (2, 0)
-        let mut tracker = DictTracker::new_empty(&relocatable!(2, 0));
-        //Add key-value pair (5, 10)
-        tracker.insert_value(&bigint!(5), &bigint!(10));
-        //Create manager
-        let mut dict_manager = DictManager::new();
-        dict_manager.trackers.insert(2, tracker);
         let mut exec_scopes = ExecutionScopes::new();
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        add_dict_manager!(exec_scopes_proxy, dict_manager);
+        dict_manager!(exec_scopes_proxy, 2, (5, 10));
         //Insert ids into memory
         vm.memory = memory![((1, 0), 5), ((1, 1), 10), ((1, 2), 10), ((1, 3), (2, 0))];
         add_segments!(vm, 1);
@@ -707,17 +647,9 @@ mod tests {
         let mut vm = vm!();
         //Initialize fp
         vm.run_context.fp = 4;
-        //Create tracker
-        //current_ptr = dict_ptr = (2, 0)
-        let mut tracker = DictTracker::new_empty(&relocatable!(2, 0));
-        //Add key-value pair (5, 10)
-        tracker.insert_value(&bigint!(5), &bigint!(10));
-        //Create manager
-        let mut dict_manager = DictManager::new();
-        dict_manager.trackers.insert(2, tracker);
         let mut exec_scopes = ExecutionScopes::new();
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        add_dict_manager!(exec_scopes_proxy, dict_manager);
+        dict_manager!(exec_scopes_proxy, 2, (5, 10));
         //Insert ids into memory
         vm.memory = memory![((1, 0), 5), ((1, 1), 11), ((1, 2), 20), ((1, 3), (2, 0))];
         add_segments!(vm, 1);
@@ -739,22 +671,13 @@ mod tests {
 
     #[test]
     fn run_dict_update_simple_invalid_wrong_key() {
-        let hint_code = "# Verify dict pointer and prev value.\ndict_tracker = __dict_manager.get_tracker(ids.dict_ptr)\ncurrent_value = dict_tracker.data[ids.key]\nassert current_value == ids.prev_value, \\\n    f'Wrong previous value in dict. Got {ids.prev_value}, expected {current_value}.'\n\n# Update value.\ndict_tracker.data[ids.key] = ids.new_value\ndict_tracker.current_ptr += ids.DictAccess.SIZE"
-            ;
+        let hint_code = "# Verify dict pointer and prev value.\ndict_tracker = __dict_manager.get_tracker(ids.dict_ptr)\ncurrent_value = dict_tracker.data[ids.key]\nassert current_value == ids.prev_value, \\\n    f'Wrong previous value in dict. Got {ids.prev_value}, expected {current_value}.'\n\n# Update value.\ndict_tracker.data[ids.key] = ids.new_value\ndict_tracker.current_ptr += ids.DictAccess.SIZE";
         let mut vm = vm!();
         //Initialize fp
         vm.run_context.fp = 4;
-        //Create tracker
-        //current_ptr = dict_ptr = (2, 0)
-        let mut tracker = DictTracker::new_empty(&relocatable!(2, 0));
-        //Add key-value pair (5, 10)
-        tracker.insert_value(&bigint!(5), &bigint!(10));
-        //Create manager
-        let mut dict_manager = DictManager::new();
-        dict_manager.trackers.insert(2, tracker);
         let mut exec_scopes = ExecutionScopes::new();
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        add_dict_manager!(exec_scopes_proxy, dict_manager);
+        dict_manager!(exec_scopes_proxy, 2, (5, 10));
         //Insert ids into memory
         vm.memory = memory![((1, 0), 6), ((1, 1), 10), ((1, 2), 10), ((1, 3), (2, 0))];
         add_segments!(vm, 1);
@@ -776,18 +699,9 @@ mod tests {
         let mut vm = vm!();
         //Initialize fp
         vm.run_context.fp = 4;
-        //Create tracker
-        //current_ptr = dict_ptr = (2, 0)
-        let mut tracker =
-            DictTracker::new_default_dict(&relocatable!(2, 0), &bigint!(17), Some(HashMap::new()));
-        //Add key-value pair (5, 10)
-        tracker.insert_value(&bigint!(5), &bigint!(10));
-        //Create manager
-        let mut dict_manager = DictManager::new();
-        dict_manager.trackers.insert(2, tracker);
         let mut exec_scopes = ExecutionScopes::new();
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        add_dict_manager!(exec_scopes_proxy, dict_manager);
+        dict_manager!(exec_scopes_proxy, 2, (5, 10));
         //Insert ids into memory
         vm.memory = memory![((1, 0), 5), ((1, 1), 10), ((1, 2), 20), ((1, 3), (2, 0))];
         add_segments!(vm, 1);
@@ -813,18 +727,9 @@ mod tests {
         let mut vm = vm!();
         //Initialize fp
         vm.run_context.fp = 4;
-        //Create tracker
-        //current_ptr = dict_ptr = (2, 0)
-        let mut tracker =
-            DictTracker::new_default_dict(&relocatable!(2, 0), &bigint!(17), Some(HashMap::new()));
-        //Add key-value pair (5, 10)
-        tracker.insert_value(&bigint!(5), &bigint!(10));
-        //Create manager
-        let mut dict_manager = DictManager::new();
-        dict_manager.trackers.insert(2, tracker);
         let mut exec_scopes = ExecutionScopes::new();
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        add_dict_manager!(exec_scopes_proxy, dict_manager);
+        dict_manager!(exec_scopes_proxy, 2, (5, 10));
         //Insert ids into memory
         vm.memory = memory![((1, 0), 5), ((1, 1), 10), ((1, 2), 10), ((1, 3), (2, 0))];
         add_segments!(vm, 1);
@@ -850,18 +755,9 @@ mod tests {
         let mut vm = vm!();
         //Initialize fp
         vm.run_context.fp = 4;
-        //Create tracker
-        //current_ptr = dict_ptr = (2, 0)
-        let mut tracker =
-            DictTracker::new_default_dict(&relocatable!(2, 0), &bigint!(17), Some(HashMap::new()));
-        //Add key-value pair (5, 10)
-        tracker.insert_value(&bigint!(5), &bigint!(10));
-        //Create manager
-        let mut dict_manager = DictManager::new();
-        dict_manager.trackers.insert(2, tracker);
         let mut exec_scopes = ExecutionScopes::new();
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        add_dict_manager!(exec_scopes_proxy, dict_manager);
+        dict_manager!(exec_scopes_proxy, 2, (5, 10));
         //Insert ids into memory
         vm.memory = memory![((1, 0), 5), ((1, 1), 11), ((1, 2), 10), ((1, 3), (2, 0))];
         add_segments!(vm, 1);
@@ -887,18 +783,9 @@ mod tests {
         let mut vm = vm!();
         //Initialize fp
         vm.run_context.fp = 4;
-        //Create tracker
-        //current_ptr = dict_ptr = (2, 0)
-        let mut tracker =
-            DictTracker::new_default_dict(&relocatable!(2, 0), &bigint!(17), Some(HashMap::new()));
-        //Add key-value pair (5, 10)
-        tracker.insert_value(&bigint!(5), &bigint!(10));
-        //Create manager
-        let mut dict_manager = DictManager::new();
-        dict_manager.trackers.insert(2, tracker);
         let mut exec_scopes = ExecutionScopes::new();
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        add_dict_manager!(exec_scopes_proxy, dict_manager);
+        dict_manager_default!(exec_scopes_proxy, 2, 17, (5, 10));
         //Insert ids into memory
         vm.memory = memory![((1, 0), 6), ((1, 1), 10), ((1, 2), 10), ((1, 3), (2, 0))];
         add_segments!(vm, 1);
@@ -924,16 +811,9 @@ mod tests {
         let mut vm = vm!();
         //Initialize fp
         vm.run_context.fp = 4;
-        //Create tracker
-        //current_ptr = dict_ptr = (2, 0)
-        let tracker =
-            DictTracker::new_default_dict(&relocatable!(2, 0), &bigint!(17), Some(HashMap::new()));
-        //Create manager
-        let mut dict_manager = DictManager::new();
-        dict_manager.trackers.insert(2, tracker);
         let mut exec_scopes = ExecutionScopes::new();
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        add_dict_manager!(exec_scopes_proxy, dict_manager);
+        dict_manager_default!(exec_scopes_proxy, 2, 17);
         //Insert ids into memory
         vm.memory = memory![((1, 0), 5), ((1, 1), 17), ((1, 2), 20), ((1, 3), (2, 0))];
         add_segments!(vm, 1);
@@ -959,14 +839,6 @@ mod tests {
         let mut vm = vm!();
         //Initialize fp
         vm.run_context.fp = 1;
-        //Initialize dictionary
-        let dictionary = HashMap::<BigInt, BigInt>::new();
-        //Create tracker
-        let mut tracker = DictTracker::new_empty(&relocatable!(2, 0));
-        tracker.data = Dictionary::SimpleDictionary(dictionary);
-        //Create manager
-        let mut dict_manager = DictManager::new();
-        dict_manager.trackers.insert(2, tracker);
         //ids.dict_access
         vm.memory = memory![((1, 0), (2, 0))];
         add_segments!(vm, 1);
@@ -974,7 +846,7 @@ mod tests {
         //Execute the hint
         let mut exec_scopes = ExecutionScopes::new();
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        add_dict_manager!(exec_scopes_proxy, dict_manager);
+        dict_manager!(exec_scopes_proxy, 2);
         assert_eq!(
             run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
             Ok(())
@@ -999,24 +871,13 @@ mod tests {
         let mut vm = vm!();
         //Initialize fp
         vm.run_context.fp = 1;
-        //Initialize dictionary
-        let mut dictionary = HashMap::<BigInt, BigInt>::new();
-        dictionary.insert(bigint!(1), bigint!(2));
-        dictionary.insert(bigint!(3), bigint!(4));
-        dictionary.insert(bigint!(5), bigint!(6));
-        //Create tracker
-        let mut tracker = DictTracker::new_empty(&relocatable!(2, 0));
-        tracker.data = Dictionary::SimpleDictionary(dictionary);
-        //Create manager
-        let mut dict_manager = DictManager::new();
-        dict_manager.trackers.insert(2, tracker);
         vm.memory = memory![((1, 0), (2, 0))];
         add_segments!(vm, 1);
         let ids_data = ids_data!["dict_accesses_end"];
         //Execute the hint
         let mut exec_scopes = ExecutionScopes::new();
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        add_dict_manager!(exec_scopes_proxy, dict_manager);
+        dict_manager!(exec_scopes_proxy, 2, (1, 2), (3, 4), (5, 6));
         assert_eq!(
             run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
             Ok(())
@@ -1047,9 +908,9 @@ mod tests {
         vm.run_context.fp = 1;
         //Create manager
         let dict_manager = DictManager::new();
-        let mut exec_scopes = ExecutionScopes::new();
+        let mut exec_scopes = scope![("dict_manager", Rc::new(RefCell::new(dict_manager)))];
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        add_dict_manager!(exec_scopes_proxy, dict_manager);
+
         vm.memory = memory![((1, 0), (2, 0))];
         add_segments!(vm, 1);
         let ids_data = ids_data!["dict_accesses_end"];
@@ -1068,9 +929,8 @@ mod tests {
         vm.run_context.fp = 2;
         //Create manager
         let dict_manager = DictManager::new();
-        let mut exec_scopes = ExecutionScopes::new();
+        let mut exec_scopes = scope![("dict_manager", Rc::new(RefCell::new(dict_manager)))];
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        add_dict_manager!(exec_scopes_proxy, dict_manager);
         vm.memory = memory![((1, 0), (2, 0)), ((1, 1), (2, 3))];
         add_segments!(vm, 1);
         //Create ids
@@ -1088,18 +948,9 @@ mod tests {
         let mut vm = vm!();
         //Initialize fp
         vm.run_context.fp = 2;
-        //Initialize dictionary
-        let mut dictionary = HashMap::<BigInt, BigInt>::new();
-        dictionary.insert(bigint!(1), bigint!(2));
-        //Create tracker
-        let mut tracker = DictTracker::new_empty(&relocatable!(2, 0));
-        tracker.data = Dictionary::SimpleDictionary(dictionary);
-        //Create manager
-        let mut dict_manager = DictManager::new();
-        dict_manager.trackers.insert(2, tracker);
         let mut exec_scopes = ExecutionScopes::new();
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        add_dict_manager!(exec_scopes_proxy, dict_manager);
+        dict_manager![exec_scopes_proxy, 2, (1, 2)];
         //ids.squash_dict_start
         vm.memory = memory![((1, 0), (2, 0)), ((1, 1), (2, 3))];
         add_segments!(vm, 1);
@@ -1111,16 +962,7 @@ mod tests {
             Ok(())
         );
         //Check the updated pointer
-        assert_eq!(
-            exec_scopes_proxy
-                .get_dict_manager()
-                .unwrap()
-                .borrow()
-                .get_tracker(&relocatable!(2, 3))
-                .unwrap()
-                .current_ptr,
-            relocatable!(2, 3)
-        );
+        check_dict_ptr!(exec_scopes_proxy, 2, (2, 3));
     }
 
     #[test]
@@ -1129,18 +971,9 @@ mod tests {
         let mut vm = vm!();
         //Initialize fp
         vm.run_context.fp = 2;
-        //Initialize dictionary
-        let mut dictionary = HashMap::<BigInt, BigInt>::new();
-        dictionary.insert(bigint!(1), bigint!(2));
-        //Create tracker
-        let mut tracker = DictTracker::new_empty(&relocatable!(2, 0));
-        tracker.data = Dictionary::SimpleDictionary(dictionary);
-        //Create manager
-        let mut dict_manager = DictManager::new();
-        dict_manager.trackers.insert(2, tracker);
         let mut exec_scopes = ExecutionScopes::new();
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        add_dict_manager!(exec_scopes_proxy, dict_manager);
+        dict_manager!(exec_scopes_proxy, 2, (1, 2));
         vm.memory = memory![((1, 0), (2, 3)), ((1, 1), (2, 6))];
         add_segments!(vm, 1);
         //Create ids

--- a/src/hint_processor/builtin_hint_processor/find_element_hint.rs
+++ b/src/hint_processor/builtin_hint_processor/find_element_hint.rs
@@ -234,39 +234,23 @@ mod tests {
     #[test]
     fn element_found_by_search() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::new());
-        let hint_data =
-            HintProcessorData::new_default(hint_code::FIND_ELEMENT.to_string(), ids_data);
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code::FIND_ELEMENT.to_string()),
             Ok(())
         );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 3))),
-            Ok(Some(&MaybeRelocatable::Int(bigint!(1))))
-        )
+        check_memory![vm.memory, ((1, 3), 1)];
     }
 
     #[test]
     fn element_found_by_oracle() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::new());
-        let hint_data =
-            HintProcessorData::new_default(hint_code::FIND_ELEMENT.to_string(), ids_data);
-        let mut exec_scopes = ExecutionScopes::new();
-        exec_scopes.assign_or_update_variable("find_element_index", any_box!(bigint!(1)));
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
+        let mut exec_scopes = scope![("find_element_index", bigint!(1))];
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code::FIND_ELEMENT, exec_scopes_proxy),
             Ok(())
         );
-
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 3))),
-            Ok(Some(&MaybeRelocatable::Int(bigint!(1))))
-        )
+        check_memory![vm.memory, ((1, 3), 1)];
     }
 
     #[test]
@@ -275,12 +259,8 @@ mod tests {
             "key".to_string(),
             MaybeRelocatable::from(bigint!(7)),
         )]));
-        let hint_data =
-            HintProcessorData::new_default(hint_code::FIND_ELEMENT.to_string(), ids_data);
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code::FIND_ELEMENT),
             Err(VirtualMachineError::NoValueForKey(bigint!(7)))
         );
     }
@@ -288,15 +268,10 @@ mod tests {
     #[test]
     fn element_not_found_oracle() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::new());
-        let hint_data =
-            HintProcessorData::new_default(hint_code::FIND_ELEMENT.to_string(), ids_data);
-        let mut exec_scopes = ExecutionScopes::new();
-        exec_scopes.assign_or_update_variable("find_element_index", any_box!(bigint!(2)));
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
+        let mut exec_scopes = scope![("find_element_index", bigint!(2))];
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code::FIND_ELEMENT, exec_scopes_proxy),
             Err(VirtualMachineError::KeyNotFound)
         );
     }
@@ -306,12 +281,8 @@ mod tests {
         let mut vm = vm!();
         vm.run_context.fp = 5;
         let ids_data = ids_data!["array_ptr", "elm_size", "n_elms", "index", "key"];
-        let hint_data =
-            HintProcessorData::new_default(hint_code::FIND_ELEMENT.to_string(), ids_data);
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code::FIND_ELEMENT),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((1, 4))
             ))
@@ -324,12 +295,8 @@ mod tests {
             "elm_size".to_string(),
             MaybeRelocatable::from((7, 8)),
         )]));
-        let hint_data =
-            HintProcessorData::new_default(hint_code::FIND_ELEMENT.to_string(), ids_data);
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code::FIND_ELEMENT),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((1, 1))
             ))
@@ -342,12 +309,8 @@ mod tests {
             "elm_size".to_string(),
             MaybeRelocatable::Int(bigint!(0)),
         )]));
-        let hint_data =
-            HintProcessorData::new_default(hint_code::FIND_ELEMENT.to_string(), ids_data);
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code::FIND_ELEMENT),
             Err(VirtualMachineError::ValueOutOfRange(bigint!(0)))
         );
     }
@@ -358,12 +321,8 @@ mod tests {
             "elm_size".to_string(),
             MaybeRelocatable::Int(bigint!(-1)),
         )]));
-        let hint_data =
-            HintProcessorData::new_default(hint_code::FIND_ELEMENT.to_string(), ids_data);
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code::FIND_ELEMENT),
             Err(VirtualMachineError::ValueOutOfRange(bigint!(-1)))
         );
     }
@@ -373,12 +332,8 @@ mod tests {
         let relocatable = MaybeRelocatable::from((1, 2));
         let (mut vm, ids_data) =
             init_vm_ids_data(HashMap::from([("n_elms".to_string(), relocatable.clone())]));
-        let hint_data =
-            HintProcessorData::new_default(hint_code::FIND_ELEMENT.to_string(), ids_data);
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code::FIND_ELEMENT),
             Err(VirtualMachineError::ExpectedInteger(relocatable))
         );
     }
@@ -389,12 +344,8 @@ mod tests {
             "n_elms".to_string(),
             MaybeRelocatable::Int(bigint!(-1)),
         )]));
-        let hint_data =
-            HintProcessorData::new_default(hint_code::FIND_ELEMENT.to_string(), ids_data);
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code::FIND_ELEMENT),
             Err(VirtualMachineError::ValueOutOfRange(bigint!(-1)))
         );
     }
@@ -402,28 +353,16 @@ mod tests {
     #[test]
     fn find_elm_empty_scope() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::new());
-        let hint_data =
-            HintProcessorData::new_default(hint_code::FIND_ELEMENT.to_string(), ids_data);
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
-            Ok(())
-        );
+        assert_eq!(run_hint!(vm, ids_data, hint_code::FIND_ELEMENT), Ok(()));
     }
 
     #[test]
     fn find_elm_n_elms_gt_max_size() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::new());
-        let hint_data =
-            HintProcessorData::new_default(hint_code::FIND_ELEMENT.to_string(), ids_data);
-        let mut exec_scopes = ExecutionScopes::new();
-        exec_scopes.assign_or_update_variable("find_element_max_size", any_box!(bigint!(1)));
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
+        let mut exec_scopes = scope![("find_element_max_size", bigint!(1))];
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code::FIND_ELEMENT, exec_scopes_proxy),
             Err(VirtualMachineError::FindElemMaxSize(bigint!(1), bigint!(2)))
         );
     }
@@ -433,12 +372,8 @@ mod tests {
         let relocatable = MaybeRelocatable::from((1, 4));
         let (mut vm, ids_data) =
             init_vm_ids_data(HashMap::from([("key".to_string(), relocatable.clone())]));
-        let hint_data =
-            HintProcessorData::new_default(hint_code::FIND_ELEMENT.to_string(), ids_data);
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code::FIND_ELEMENT),
             Err(VirtualMachineError::ExpectedInteger(relocatable))
         );
     }
@@ -446,19 +381,12 @@ mod tests {
     #[test]
     fn search_sorted_lower() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::new());
-        let hint_data =
-            HintProcessorData::new_default(hint_code::SEARCH_SORTED_LOWER.to_string(), ids_data);
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code::SEARCH_SORTED_LOWER),
             Ok(())
         );
 
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 3))),
-            Ok(Some(&MaybeRelocatable::Int(bigint!(1))))
-        )
+        check_memory![vm.memory, ((1, 3), 1)];
     }
 
     #[test]
@@ -467,19 +395,11 @@ mod tests {
             "key".to_string(),
             MaybeRelocatable::Int(bigint!(7)),
         )]));
-        let hint_data =
-            HintProcessorData::new_default(hint_code::SEARCH_SORTED_LOWER.to_string(), ids_data);
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code::SEARCH_SORTED_LOWER),
             Ok(())
         );
-
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 3))),
-            Ok(Some(&MaybeRelocatable::Int(bigint!(2))))
-        )
+        check_memory![vm.memory, ((1, 3), 2)];
     }
 
     #[test]
@@ -488,12 +408,8 @@ mod tests {
             "elm_size".to_string(),
             MaybeRelocatable::from((7, 8)),
         )]));
-        let hint_data =
-            HintProcessorData::new_default(hint_code::SEARCH_SORTED_LOWER.to_string(), ids_data);
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code::SEARCH_SORTED_LOWER),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((1, 1))
             ))
@@ -506,12 +422,8 @@ mod tests {
             "elm_size".to_string(),
             MaybeRelocatable::Int(bigint!(0)),
         )]));
-        let hint_data =
-            HintProcessorData::new_default(hint_code::SEARCH_SORTED_LOWER.to_string(), ids_data);
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code::SEARCH_SORTED_LOWER),
             Err(VirtualMachineError::ValueOutOfRange(bigint!(0)))
         );
     }
@@ -522,12 +434,8 @@ mod tests {
             "elm_size".to_string(),
             MaybeRelocatable::Int(bigint!(-1)),
         )]));
-        let hint_data =
-            HintProcessorData::new_default(hint_code::SEARCH_SORTED_LOWER.to_string(), ids_data);
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code::SEARCH_SORTED_LOWER),
             Err(VirtualMachineError::ValueOutOfRange(bigint!(-1)))
         );
     }
@@ -538,12 +446,8 @@ mod tests {
             "n_elms".to_string(),
             MaybeRelocatable::from((2, 2)),
         )]));
-        let hint_data =
-            HintProcessorData::new_default(hint_code::SEARCH_SORTED_LOWER.to_string(), ids_data);
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code::SEARCH_SORTED_LOWER),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((1, 2))
             ))
@@ -556,12 +460,8 @@ mod tests {
             "n_elms".to_string(),
             MaybeRelocatable::Int(bigint!(-1)),
         )]));
-        let hint_data =
-            HintProcessorData::new_default(hint_code::SEARCH_SORTED_LOWER.to_string(), ids_data);
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code::SEARCH_SORTED_LOWER),
             Err(VirtualMachineError::ValueOutOfRange(bigint!(-1)))
         );
     }
@@ -569,12 +469,8 @@ mod tests {
     #[test]
     fn search_sorted_lower_empty_scope() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::new());
-        let hint_data =
-            HintProcessorData::new_default(hint_code::SEARCH_SORTED_LOWER.to_string(), ids_data);
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code::SEARCH_SORTED_LOWER),
             Ok(())
         );
     }
@@ -582,15 +478,15 @@ mod tests {
     #[test]
     fn search_sorted_lower_n_elms_gt_max_size() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::new());
-        let hint_data =
-            HintProcessorData::new_default(hint_code::SEARCH_SORTED_LOWER.to_string(), ids_data);
-        let mut exec_scopes = ExecutionScopes::new();
-        exec_scopes.assign_or_update_variable("find_element_max_size", any_box!(bigint!(1)));
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
+        let mut exec_scopes = scope![("find_element_max_size", bigint!(1))];
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(
+                vm,
+                ids_data,
+                hint_code::SEARCH_SORTED_LOWER,
+                exec_scopes_proxy
+            ),
             Err(VirtualMachineError::FindElemMaxSize(bigint!(1), bigint!(2)))
         );
     }

--- a/src/hint_processor/builtin_hint_processor/math_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/math_utils.rs
@@ -432,59 +432,40 @@ mod tests {
     };
     use num_bigint::Sign;
     use std::any::Any;
+
+    from_bigint_str![39, 40, 77];
     #[test]
     fn run_is_nn_hint_false() {
         let hint_code = "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1";
         let mut vm = vm_with_range_check!();
-        for _ in 0..2 {
-            vm.segments.add(&mut vm.memory, None);
-        }
-        //Initialize ap, fp
-        vm.run_context.ap = 0;
+        //Initialize fp
         vm.run_context.fp = 10;
         //Insert ids into memory
         vm.memory = memory![((1, 9), (-1))];
-        vm.segments.add(&mut vm.memory, None);
+        add_segments!(vm, 1);
         //Create ids_data & hint_data
         let ids_data = ids_data!["a"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        hint_processor
-            .execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data))
-            .expect("Error while executing hint");
-        //Check that ap now contains false (0)
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 0))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(1))))
-        );
+        run_hint!(vm, ids_data, hint_code).expect("Error while executing hint");
+        //Check that ap now contains false (1)
+        check_memory![vm.memory, ((1, 0), 1)];
     }
 
     #[test]
     fn run_is_nn_hint_true() {
         let hint_code = "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1";
         let mut vm = vm_with_range_check!();
-        //Initialize ap, fp
-        vm.run_context.ap = 0;
+        //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
         vm.memory = memory![((1, 4), 1)];
-        vm.segments.add(&mut vm.memory, None);
+        add_segments!(vm, 1);
         //Create ids_data
         let ids_data = ids_data!["a"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        hint_processor
-            .execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data))
-            .expect("Error while executing hint");
-        //Check that ap now contains true (1)
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 0))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
+        run_hint!(vm, ids_data, hint_code).expect("Error while executing hint");
+        //Check that ap now contains true (0)
+        check_memory![vm.memory, ((1, 0), 0)];
     }
 
     #[test]
@@ -493,58 +474,37 @@ mod tests {
     fn run_is_nn_hint_true_border_case() {
         let hint_code = "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1";
         let mut vm = vm_with_range_check!();
-        for _ in 0..2 {
-            vm.segments.add(&mut vm.memory, None);
-        }
-        //Initialize ap, fp
-        vm.run_context.ap = 0;
+        //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 4)),
-                //(-prime) + 1
-                &MaybeRelocatable::from(
-                    BigInt::new(Sign::Minus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]) + bigint!(1),
-                ),
+        vm.memory = memory![(
+            (1, 4),
+            (
+                b"-3618502788666131213697322783095070105623107215331596699973092056135872020480",
+                10
             )
-            .unwrap();
+        )];
         //Create ids_data
         let ids_data = ids_data!["a"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        hint_processor
-            .execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data))
-            .expect("Error while executing hint");
-        //Check that ap now contains true (1)
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 0))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
+        run_hint!(vm, ids_data, hint_code).expect("Error while executing hint");
+        //Check that ap now contains true (0)
+        check_memory![vm.memory, ((1, 0), 0)];
     }
 
     #[test]
     fn run_is_nn_hint_no_range_check_builtin() {
         let hint_code = "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1";
         let mut vm = vm!();
-        for _ in 0..2 {
-            vm.segments.add(&mut vm.memory, None);
-        }
-        //Initialize ap, fp
-        vm.run_context.ap = 0;
+        //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
         vm.memory = memory![((1, 4), 1)];
         //Create ids_data
         let ids_data = ids_data!["a"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::NoRangeCheckBuiltin)
         );
     }
@@ -553,19 +513,13 @@ mod tests {
     fn run_is_nn_hint_incorrect_ids() {
         let hint_code = "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1";
         let mut vm = vm_with_range_check!();
-        for _ in 0..2 {
-            vm.segments.add(&mut vm.memory, None);
-        }
+        add_segments!(vm, 2);
         //Initialize ap
-        vm.run_context.ap = 0;
         //Create ids_data & hint_data
         let ids_data = ids_data!["b"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::FailedToGetIds)
         );
     }
@@ -574,21 +528,15 @@ mod tests {
     fn run_is_nn_hint_cant_get_ids_from_memory() {
         let hint_code = "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1";
         let mut vm = vm_with_range_check!();
-        for _ in 0..2 {
-            vm.segments.add(&mut vm.memory, None);
-        }
-        //Initialize ap, fp
-        vm.run_context.ap = 0;
+        add_segments!(vm, 2);
+        //Initialize fp
         vm.run_context.fp = 5;
         //Dont insert ids into memory
         //Create ids_data
         let ids_data = ids_data!["a"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((1, 4))
             ))
@@ -599,20 +547,15 @@ mod tests {
     fn run_is_nn_hint_ids_are_relocatable_values() {
         let hint_code = "memory[ap] = 0 if 0 <= (ids.a % PRIME) < range_check_builtin.bound else 1";
         let mut vm = vm_with_range_check!();
-        //Initialize ap, fp
-        vm.run_context.ap = 0;
+        //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
         vm.memory = memory![((1, 4), (2, 3))];
-        vm.segments.add(&mut vm.memory, None);
         //Create ids_data
         let ids_data = ids_data!["a"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((1, 4))
             ))
@@ -627,17 +570,10 @@ mod tests {
         vm.run_context.fp = 3;
         //Insert ids into memory
         vm.memory = memory![((1, 0), 1), ((1, 1), 2), ((1, 3), 4)];
-        vm.segments.add(&mut vm.memory, None);
         //Create ids_data & hint_data
         let ids_data = ids_data!["a", "b", "small_inputs"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
-            Ok(())
-        );
+        assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
         //Hint would return an error if the assertion fails
     }
 
@@ -646,40 +582,29 @@ mod tests {
         let hint_code = "memory[ap] = 0 if (ids.a % PRIME) <= (ids.b % PRIME) else 1";
         let mut vm = vm_with_range_check!();
         //Initialize fp
-        vm.run_context.ap = 0;
         vm.run_context.fp = 10;
         //Insert ids into memory
         vm.memory = memory![((1, 8), 1), ((1, 9), 2)];
-        vm.segments.add(&mut vm.memory, None);
+        add_segments!(vm, 1);
         let ids_data = ids_data!["a", "b"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
-            Ok(())
-        );
+        assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
         //Check result
-        assert_eq!(vm.memory.get_integer(&relocatable!(1, 0)), Ok(&bigint!(0)));
+        check_memory![vm.memory, ((1, 0), 0)];
     }
 
     #[test]
     fn run_is_le_felt_hint_inconsistent_memory() {
         let hint_code = "memory[ap] = 0 if (ids.a % PRIME) <= (ids.b % PRIME) else 1";
         let mut vm = vm_with_range_check!();
-        //Initialize ap, fp
-        vm.run_context.ap = 0;
+        //Initialize fp
         vm.run_context.fp = 2;
         vm.memory = memory![((1, 0), 1), ((1, 1), 2)];
         //Create ids_data & hint_data
         let ids_data = ids_data!["a", "b"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((1, 0)),
@@ -694,16 +619,12 @@ mod tests {
     fn run_is_le_felt_hint_incorrect_ids() {
         let hint_code = "memory[ap] = 0 if (ids.a % PRIME) <= (ids.b % PRIME) else 1";
         let mut vm = vm!();
-        vm.run_context.ap = 0;
         vm.run_context.fp = 10;
         vm.memory = memory![((1, 8), 1), ((1, 9), 2)];
         //Create ids_data & hint_data
         let ids_data = ids_data!["a", "c"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::FailedToGetIds)
         );
     }
@@ -718,14 +639,8 @@ mod tests {
         vm.memory = memory![((1, 0), 1)];
         //Create ids_data & hint_data
         let ids_data = ids_data!["a"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
-            Ok(())
-        );
+        assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
         //Hint would return an error if the assertion fails
     }
 
@@ -739,12 +654,9 @@ mod tests {
         vm.memory = memory![((1, 0), (-1))];
         //Create ids_data & hint_data
         let ids_data = ids_data!["a"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::ValueOutOfRange(bigint!(-1)))
         );
     }
@@ -758,12 +670,9 @@ mod tests {
         //Insert ids into memory
         vm.memory = memory![((1, 0), (-1))];
         let ids_data = ids_data!["incorrect_id"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::FailedToGetIds),
         );
     }
@@ -777,12 +686,9 @@ mod tests {
         //Insert ids into memory
         vm.memory = memory![((1, 0), (10, 10))];
         let ids_data = ids_data!["a"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((1, 3))
             ))
@@ -798,12 +704,9 @@ mod tests {
         //Insert ids into memory
         vm.memory = memory![((1, 0), 1)];
         let ids_data = ids_data!["a"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::NoRangeCheckBuiltin)
         );
     }
@@ -812,16 +715,13 @@ mod tests {
     fn run_assert_nn_reference_is_not_in_memory() {
         let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert 0 <= ids.a % PRIME < range_check_builtin.bound, f'a = {ids.a} is out of range.'";
         let mut vm = vm_with_range_check!();
-        vm.segments.add(&mut vm.memory, None);
+        add_segments!(vm, 1);
         //Initialize fp
         vm.run_context.fp = 4;
         let ids_data = ids_data!["a"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((1, 3))
             ))
@@ -837,12 +737,9 @@ mod tests {
         //Insert ids into memory
         vm.memory = memory![((1, 0), 2), ((1, 1), 1), ((1, 3), 4)];
         let ids_data = ids_data!["a", "b", "small_inputs"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::NonLeFelt(bigint!(2), bigint!(1)))
         );
     }
@@ -856,12 +753,9 @@ mod tests {
         //Insert ids into memory
         vm.memory = memory![((1, 0), 1), ((1, 1), 2), ((1, 2), 4)];
         let ids_data = ids_data!["a", "b", "small_inputs"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((1, 2)),
@@ -881,12 +775,9 @@ mod tests {
         //Insert ids into memory
         vm.memory = memory![((1, 0), (1, 0)), ((1, 1), 1), ((1, 3), 4)];
         let ids_data = ids_data!["a", "b", "small_inputs"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((1, 0))
             ))
@@ -902,12 +793,9 @@ mod tests {
         //Insert ids into memory
         vm.memory = memory![((1, 0), 1), ((1, 1), (1, 0)), ((1, 3), 4)];
         let ids_data = ids_data!["a", "b", "small_inputs"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((1, 1))
             ))
@@ -919,25 +807,16 @@ mod tests {
         let hint_code =
             "memory[ap] = 0 if 0 <= ((-ids.a - 1) % PRIME) < range_check_builtin.bound else 1";
         let mut vm = vm_with_range_check!();
-        //Initialize ap, fp
-        vm.run_context.ap = 0;
+        //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
         vm.memory = memory![((1, 4), 2)];
-        vm.segments.add(&mut vm.memory, None);
+        add_segments!(vm, 1);
         //Create ids_data
         let ids_data = ids_data!["a"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        hint_processor
-            .execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data))
-            .expect("Error while executing hint");
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 0))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(1))))
-        );
+        run_hint!(vm, ids_data, hint_code).expect("Error while executing hint");
+        check_memory![vm.memory, ((1, 0), 1)];
     }
 
     #[test]
@@ -945,42 +824,29 @@ mod tests {
         let hint_code =
             "memory[ap] = 0 if 0 <= ((-ids.a - 1) % PRIME) < range_check_builtin.bound else 1";
         let mut vm = vm_with_range_check!();
-        //Initialize ap, fp
-        vm.run_context.ap = 0;
+        //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
         vm.memory = memory![((1, 4), (-1))];
-        vm.segments.add(&mut vm.memory, None);
+        add_segments!(vm, 1);
         //Create ids_data
         let ids_data = ids_data!["a"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        hint_processor
-            .execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data))
-            .expect("Error while executing hint");
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 0))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
+        run_hint!(vm, ids_data, hint_code).expect("Error while executing hint");
+        check_memory![vm.memory, ((1, 0), 0)];
     }
     #[test]
     fn run_assert_not_equal_int_false() {
         let hint_code = "from starkware.cairo.lang.vm.relocatable import RelocatableValue\nboth_ints = isinstance(ids.a, int) and isinstance(ids.b, int)\nboth_relocatable = (\n    isinstance(ids.a, RelocatableValue) and isinstance(ids.b, RelocatableValue) and\n    ids.a.segment_index == ids.b.segment_index)\nassert both_ints or both_relocatable, \\\n    f'assert_not_equal failed: non-comparable values: {ids.a}, {ids.b}.'\nassert (ids.a - ids.b) % PRIME != 0, f'assert_not_equal failed: {ids.a} = {ids.b}.'";
         let mut vm = vm!();
-        //Initialize ap, fp
-        vm.run_context.ap = 0;
+        //Initialize fp
         vm.run_context.fp = 10;
         //Insert ids into memory
         vm.memory = memory![((1, 8), 1), ((1, 9), 1)];
         let ids_data = ids_data!["a", "b"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::AssertNotEqualFail(
                 MaybeRelocatable::from(bigint!(1)),
                 MaybeRelocatable::from(bigint!(1))
@@ -992,56 +858,37 @@ mod tests {
     fn run_assert_not_equal_int_true() {
         let hint_code = "from starkware.cairo.lang.vm.relocatable import RelocatableValue\nboth_ints = isinstance(ids.a, int) and isinstance(ids.b, int)\nboth_relocatable = (\n    isinstance(ids.a, RelocatableValue) and isinstance(ids.b, RelocatableValue) and\n    ids.a.segment_index == ids.b.segment_index)\nassert both_ints or both_relocatable, \\\n    f'assert_not_equal failed: non-comparable values: {ids.a}, {ids.b}.'\nassert (ids.a - ids.b) % PRIME != 0, f'assert_not_equal failed: {ids.a} = {ids.b}.'";
         let mut vm = vm!();
-        //Initialize ap, fp
-        vm.run_context.ap = 0;
+        //Initialize fp
         vm.run_context.fp = 10;
         //Insert ids into memory
         vm.memory = memory![((1, 8), 1), ((1, 9), 3)];
         let ids_data = ids_data!["a", "b"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
-            Ok(())
-        );
+        assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
     }
 
     #[test]
     fn run_assert_not_equal_int_false_mod() {
         let hint_code = "from starkware.cairo.lang.vm.relocatable import RelocatableValue\nboth_ints = isinstance(ids.a, int) and isinstance(ids.b, int)\nboth_relocatable = (\n    isinstance(ids.a, RelocatableValue) and isinstance(ids.b, RelocatableValue) and\n    ids.a.segment_index == ids.b.segment_index)\nassert both_ints or both_relocatable, \\\n    f'assert_not_equal failed: non-comparable values: {ids.a}, {ids.b}.'\nassert (ids.a - ids.b) % PRIME != 0, f'assert_not_equal failed: {ids.a} = {ids.b}.'";
         let mut vm = vm!();
-        for _ in 0..2 {
-            vm.segments.add(&mut vm.memory, None);
-        }
-        //Initialize ap, fp
-        vm.run_context.ap = 0;
+        add_segments!(vm, 2);
+        //Initialize fp
         vm.run_context.fp = 10;
         //Insert ids into memory
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 8)),
-                //-1 % prime = prime -1
-                &MaybeRelocatable::from(bigint!(-1)),
+        vm.memory = memory![
+            ((1, 8), (-1)),
+            (
+                (1, 9),
+                (
+                    b"3618502788666131213697322783095070105623107215331596699973092056135872020480",
+                    10
+                )
             )
-            .unwrap();
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 9)),
-                //prime -1
-                &MaybeRelocatable::from(bigint_str!(
-                    b"3618502788666131213697322783095070105623107215331596699973092056135872020480"
-                )),
-            )
-            .unwrap();
+        ];
         let ids_data = ids_data!["a", "b"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::AssertNotEqualFail(
                 MaybeRelocatable::from(bigint!(-1)),
                 MaybeRelocatable::from(bigint_str!(
@@ -1055,18 +902,14 @@ mod tests {
     fn run_assert_not_equal_relocatable_false() {
         let hint_code = "from starkware.cairo.lang.vm.relocatable import RelocatableValue\nboth_ints = isinstance(ids.a, int) and isinstance(ids.b, int)\nboth_relocatable = (\n    isinstance(ids.a, RelocatableValue) and isinstance(ids.b, RelocatableValue) and\n    ids.a.segment_index == ids.b.segment_index)\nassert both_ints or both_relocatable, \\\n    f'assert_not_equal failed: non-comparable values: {ids.a}, {ids.b}.'\nassert (ids.a - ids.b) % PRIME != 0, f'assert_not_equal failed: {ids.a} = {ids.b}.'";
         let mut vm = vm!();
-        //Initialize ap, fp
-        vm.run_context.ap = 0;
+        //Initialize fp
         vm.run_context.fp = 10;
         //Insert ids into memory
         vm.memory = memory![((1, 8), (1, 0)), ((1, 9), (1, 0))];
         let ids_data = ids_data!["a", "b"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::AssertNotEqualFail(
                 MaybeRelocatable::from((1, 0)),
                 MaybeRelocatable::from((1, 0))
@@ -1078,38 +921,27 @@ mod tests {
     fn run_assert_not_equal_relocatable_true() {
         let hint_code = "from starkware.cairo.lang.vm.relocatable import RelocatableValue\nboth_ints = isinstance(ids.a, int) and isinstance(ids.b, int)\nboth_relocatable = (\n    isinstance(ids.a, RelocatableValue) and isinstance(ids.b, RelocatableValue) and\n    ids.a.segment_index == ids.b.segment_index)\nassert both_ints or both_relocatable, \\\n    f'assert_not_equal failed: non-comparable values: {ids.a}, {ids.b}.'\nassert (ids.a - ids.b) % PRIME != 0, f'assert_not_equal failed: {ids.a} = {ids.b}.'";
         let mut vm = vm!();
-        //Initialize ap, fp
-        vm.run_context.ap = 0;
+        //Initialize fp
         vm.run_context.fp = 10;
         //Insert ids into memory
         vm.memory = memory![((1, 8), (0, 1)), ((1, 9), (0, 0))];
         let ids_data = ids_data!["a", "b"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
-            Ok(())
-        );
+        assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
     }
 
     #[test]
     fn run_assert_non_equal_relocatable_diff_index() {
         let hint_code = "from starkware.cairo.lang.vm.relocatable import RelocatableValue\nboth_ints = isinstance(ids.a, int) and isinstance(ids.b, int)\nboth_relocatable = (\n    isinstance(ids.a, RelocatableValue) and isinstance(ids.b, RelocatableValue) and\n    ids.a.segment_index == ids.b.segment_index)\nassert both_ints or both_relocatable, \\\n    f'assert_not_equal failed: non-comparable values: {ids.a}, {ids.b}.'\nassert (ids.a - ids.b) % PRIME != 0, f'assert_not_equal failed: {ids.a} = {ids.b}.'";
         let mut vm = vm!();
-        //Initialize ap, fp
-        vm.run_context.ap = 0;
+        //Initialize fp
         vm.run_context.fp = 10;
         //Insert ids into memory
         vm.memory = memory![((1, 8), (2, 0)), ((1, 9), (1, 0))];
         let ids_data = ids_data!["a", "b"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::DiffIndexComp(
                 relocatable!(2, 0),
                 relocatable!(1, 0)
@@ -1121,18 +953,14 @@ mod tests {
     fn run_assert_not_equal_relocatable_and_integer() {
         let hint_code = "from starkware.cairo.lang.vm.relocatable import RelocatableValue\nboth_ints = isinstance(ids.a, int) and isinstance(ids.b, int)\nboth_relocatable = (\n    isinstance(ids.a, RelocatableValue) and isinstance(ids.b, RelocatableValue) and\n    ids.a.segment_index == ids.b.segment_index)\nassert both_ints or both_relocatable, \\\n    f'assert_not_equal failed: non-comparable values: {ids.a}, {ids.b}.'\nassert (ids.a - ids.b) % PRIME != 0, f'assert_not_equal failed: {ids.a} = {ids.b}.'";
         let mut vm = vm!();
-        //Initialize ap, fp
-        vm.run_context.ap = 0;
+        //Initialize fp
         vm.run_context.fp = 10;
         //Insert ids into memory
         vm.memory = memory![((1, 8), (1, 0)), ((1, 9), 1)];
         let ids_data = ids_data!["a", "b"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::DiffTypeComparison(
                 MaybeRelocatable::from((1, 0)),
                 MaybeRelocatable::from(bigint!(1))
@@ -1145,21 +973,14 @@ mod tests {
         let hint_code =
     "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.value)\nassert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'";
         let mut vm = vm!();
-        // //Initialize ap, fp
-        vm.run_context.ap = 0;
+        // //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
         vm.memory = memory![((1, 4), 5)];
         //Create ids
         let ids_data = ids_data!["value"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
 
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
-            Ok(())
-        );
+        assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
     }
 
     #[test]
@@ -1167,19 +988,14 @@ mod tests {
         let hint_code =
     "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.value)\nassert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'";
         let mut vm = vm!();
-        // //Initialize ap, fp
-        vm.run_context.ap = 0;
+        // //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
         vm.memory = memory![((1, 4), 0)];
         //Create ids
         let ids_data = ids_data!["value"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
-
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::AssertNotZero(bigint!(0), vm.prime))
         );
     }
@@ -1189,27 +1005,21 @@ mod tests {
         let hint_code =
     "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.value)\nassert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'";
         let mut vm = vm!();
-        for _ in 0..2 {
-            vm.segments.add(&mut vm.memory, None);
-        }
-        //Initialize ap, fp
-        vm.run_context.ap = 0;
+        add_segments!(vm, 2);
+        //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 4)),
-                &MaybeRelocatable::from(vm.prime.clone()),
+        vm.memory = memory![(
+            (1, 4),
+            (
+                b"3618502788666131213697322783095070105623107215331596699973092056135872020481",
+                10
             )
-            .unwrap();
+        )];
         //Create ids_data & hint_data
         let ids_data = ids_data!["value"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
-
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::AssertNotZero(
                 vm.prime.clone(),
                 vm.prime
@@ -1222,19 +1032,14 @@ mod tests {
         let hint_code =
     "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.value)\nassert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'";
         let mut vm = vm!();
-        // //Initialize ap, fp
-        vm.run_context.ap = 0;
+        // //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
         vm.memory = memory![((1, 4), 0)];
         //Create invalid id key
         let ids_data = ids_data!["incorrect_id"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
-
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::FailedToGetIds)
         );
     }
@@ -1244,18 +1049,14 @@ mod tests {
         let hint_code =
     "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.value)\nassert ids.value % PRIME != 0, f'assert_not_zero failed: {ids.value} = 0.'";
         let mut vm = vm!();
-        // //Initialize ap, fp
-        vm.run_context.ap = 0;
+        // //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
         vm.memory = memory![((1, 4), (1, 0))];
         //Create ids_data & hint_data
         let ids_data = ids_data!["value"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((1, 4))
             ))
@@ -1266,18 +1067,14 @@ mod tests {
     fn run_split_int_assertion_invalid() {
         let hint_code = "assert ids.value == 0, 'split_int(): value is out of range.'";
         let mut vm = vm!();
-        //Initialize ap, fp
-        vm.run_context.ap = 0;
+        //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
         vm.memory = memory![((1, 4), 1)];
         let ids_data = ids_data!["value"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::SplitIntNotZero)
         );
     }
@@ -1286,55 +1083,35 @@ mod tests {
     fn run_split_int_assertion_valid() {
         let hint_code = "assert ids.value == 0, 'split_int(): value is out of range.'";
         let mut vm = vm!();
-        //Initialize ap, fp
-        vm.run_context.ap = 0;
+        //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
         vm.memory = memory![((1, 4), 0)];
         let ids_data = ids_data!["value"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
-            Ok(())
-        );
+        assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
     }
 
     #[test]
     fn run_split_int_valid() {
         let hint_code = "memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base\nassert res < ids.bound, f'split_int(): Limb {res} is out of range.'";
         let mut vm = vm!();
-        //Initialize ap, fp
-        vm.run_context.ap = 0;
+        //Initialize fp
         vm.run_context.fp = 4;
         //Insert ids into memory
         vm.memory = memory![((1, 0), (2, 0)), ((1, 1), 2), ((1, 2), 10), ((1, 3), 100)];
-        for _ in 0..2 {
-            vm.segments.add(&mut vm.memory, None);
-        }
+        add_segments!(vm, 2);
         let ids_data = ids_data!["output", "value", "base", "bound"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
-            Ok(())
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 0))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(2))))
-        );
+        assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
+        check_memory![vm.memory, ((2, 0), 2)];
     }
 
     #[test]
     fn run_split_int_invalid() {
         let hint_code = "memory[ids.output] = res = (int(ids.value) % PRIME) % ids.base\nassert res < ids.bound, f'split_int(): Limb {res} is out of range.'";
         let mut vm = vm!();
-        //Initialize ap, fp
-        vm.run_context.ap = 0;
+        //Initialize fp
         vm.run_context.fp = 4;
         //Insert ids into memory
         vm.memory = memory![
@@ -1343,16 +1120,11 @@ mod tests {
             ((1, 2), 10000),
             ((1, 3), 10)
         ];
-        for _ in 0..2 {
-            vm.segments.add(&mut vm.memory, None);
-        }
+        add_segments!(vm, 2);
         let ids_data = ids_data!["output", "value", "base", "bound"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::SplitIntLimbOutOfRange(bigint!(100)))
         );
     }
@@ -1369,18 +1141,10 @@ mod tests {
         //Dont insert ids.is_positive as we need to modify it inside the hint
         //Create ids
         let ids_data = ids_data!["value", "is_positive"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        hint_processor
-            .execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data))
-            .expect("Error while executing hint");
+        run_hint!(vm, ids_data, hint_code).expect("Error while executing hint");
         //Check that is_positive now contains 1 (true)
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 1))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(1))))
-        );
+        check_memory![vm.memory, ((1, 1), 1)];
     }
 
     #[test]
@@ -1394,18 +1158,10 @@ mod tests {
         vm.memory = memory![((1, 0), (-250))];
         //Dont insert ids.is_positive as we need to modify it inside the hint
         let ids_data = ids_data!["value", "is_positive"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        hint_processor
-            .execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data))
-            .expect("Error while executing hint");
+        run_hint!(vm, ids_data, hint_code).expect("Error while executing hint");
         //Check that is_positive now contains 0 (false)
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 1))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
+        check_memory![vm.memory, ((1, 1), 0)];
     }
 
     #[test]
@@ -1413,29 +1169,21 @@ mod tests {
         let hint_code =
         "from starkware.cairo.common.math_utils import is_positive\nids.is_positive = 1 if is_positive(\n    value=ids.value, prime=PRIME, rc_bound=range_check_builtin.bound) else 0";
         let mut vm = vm_with_range_check!();
-        for _ in 0..2 {
-            vm.segments.add(&mut vm.memory, None);
-        }
         //Initialize fp
         vm.run_context.fp = 2;
         //Insert ids.value into memory
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 0)),
-                &MaybeRelocatable::from(BigInt::new(
-                    Sign::Plus,
-                    vec![1, 0, 0, 0, 0, 0, 17, 134217727],
-                )),
+        vm.memory = memory![(
+            (1, 0),
+            (
+                b"3618502761706184546546682988428055018603476541694452277432519575032261771265",
+                10
             )
-            .unwrap();
+        )];
         //Dont insert ids.is_positive as we need to modify it inside the hint
         let ids_data = ids_data!["value", "is_positive"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::ValueOutsideValidRange(as_int(
                 &BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217727]),
                 &vm.prime
@@ -1445,35 +1193,17 @@ mod tests {
 
     #[test]
     fn run_is_positive_hint_is_positive_not_empty() {
-        let hint_code ="from starkware.cairo.common.math_utils import is_positive\nids.is_positive = 1 if is_positive(\n    value=ids.value, prime=PRIME, rc_bound=range_check_builtin.bound) else 0"
-        ;
+        let hint_code ="from starkware.cairo.common.math_utils import is_positive\nids.is_positive = 1 if is_positive(\n    value=ids.value, prime=PRIME, rc_bound=range_check_builtin.bound) else 0";
         let mut vm = vm_with_range_check!();
-        for _ in 0..2 {
-            vm.segments.add(&mut vm.memory, None);
-        }
+        add_segments!(vm, 2);
         //Initialize fp
         vm.run_context.fp = 2;
-        //Insert ids.value into memory
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 0)),
-                &MaybeRelocatable::from(bigint!(2)),
-            )
-            .unwrap();
-        //Insert ids.is_positive into memory
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 1)),
-                &MaybeRelocatable::from(bigint!(4)),
-            )
-            .unwrap();
+        //Insert ids into memory
+        vm.memory = memory![((1, 0), 2), ((1, 1), 4)];
         let ids_data = ids_data!["value", "is_positive"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((1, 1)),
@@ -1494,19 +1224,10 @@ mod tests {
         vm.memory = memory![((1, 0), 81)];
         //Create ids
         let ids_data = ids_data!["value", "root"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
-            Ok(())
-        );
+        assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
         //Check that root (0,1) has the square root of 81
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 1))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(9))))
-        );
+        check_memory![vm.memory, ((1, 1), 9)];
     }
 
     #[test]
@@ -1519,12 +1240,9 @@ mod tests {
         vm.memory = memory![((1, 0), (-81))];
         //Create ids
         let ids_data = ids_data!["value", "root"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::ValueOutside250BitRange(bigint_str!(
                 b"3618502788666131213697322783095070105623107215331596699973092056135872020400"
             )))
@@ -1541,12 +1259,9 @@ mod tests {
         vm.memory = memory![((1, 0), 81), ((1, 1), 7)];
         //Create ids
         let ids_data = ids_data!["value", "root"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((1, 1)),
@@ -1562,27 +1277,14 @@ mod tests {
         let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\nids.q, ids.r = divmod(ids.value, ids.div)";
         let mut vm = vm_with_range_check!();
         //Initialize fp
-        vm.run_context.ap = 0;
         vm.run_context.fp = 4;
         //Insert ids into memory
         vm.memory = memory![((1, 2), 5), ((1, 3), 7)];
         //Create ids
         let ids_data = ids_data!["r", "q", "div", "value"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        assert!(hint_processor
-            .execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data))
-            .is_ok());
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 0))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(2))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 1))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(1))))
-        );
+        assert!(run_hint!(vm, ids_data, hint_code).is_ok());
+        check_memory![vm.memory, ((1, 0), 2), ((1, 1), 1)];
     }
 
     #[test]
@@ -1590,18 +1292,14 @@ mod tests {
         let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\nids.q, ids.r = divmod(ids.value, ids.div)";
         let mut vm = vm_with_range_check!();
         //Initialize fp
-        vm.run_context.ap = 0;
         vm.run_context.fp = 4;
         //Insert ids into memory
         vm.memory = memory![((1, 2), (-5)), ((1, 3), 7)];
         //Create ids
         let ids_data = ids_data!["r", "q", "div", "value"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::OutOfValidRange(
                 bigint!(-5),
                 bigint_str!(b"10633823966279327296825105735305134080")
@@ -1614,17 +1312,13 @@ mod tests {
         let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\nids.q, ids.r = divmod(ids.value, ids.div)";
         let mut vm = vm!();
         //Initialize fp
-        vm.run_context.ap = 0;
         vm.run_context.fp = 4;
         //Insert ids into memory
         vm.memory = memory![((1, 2), 5), ((1, 3), 7)];
         //Create ids_data
         let ids_data = ids_data!["r", "q", "div", "value"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::NoRangeCheckBuiltin)
         );
     }
@@ -1634,18 +1328,14 @@ mod tests {
         let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\nids.q, ids.r = divmod(ids.value, ids.div)";
         let mut vm = vm_with_range_check!();
         //Initialize fp
-        vm.run_context.ap = 0;
         vm.run_context.fp = 4;
         //Insert ids into memory
         vm.memory = memory![((1, 0), 5), ((1, 2), 5), ((1, 3), 7)];
         //Create ids_data
         let ids_data = ids_data!["r", "q", "div", "value"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((1, 0)),
@@ -1660,22 +1350,15 @@ mod tests {
     fn unsigned_div_rem_incorrect_ids() {
         let hint_code = "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\nids.q, ids.r = divmod(ids.value, ids.div)";
         let mut vm = vm_with_range_check!();
-        for _ in 0..3 {
-            vm.segments.add(&mut vm.memory, None);
-        }
         //Initialize fp
-        vm.run_context.ap = 0;
         vm.run_context.fp = 4;
         //Insert ids into memory
         vm.memory = memory![((1, 2), 5), ((1, 3), 7)];
         //Create ids
         let ids_data = ids_data!["a", "b", "iv", "vlue"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::FailedToGetIds)
         )
     }
@@ -1684,31 +1367,15 @@ mod tests {
     fn signed_div_rem_success() {
         let hint_code = "from starkware.cairo.common.math_utils import as_int, assert_integer\n\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\n\nassert_integer(ids.bound)\nassert ids.bound <= range_check_builtin.bound // 2, \\\n    f'bound={hex(ids.bound)} is out of the valid range.'\n\nint_value = as_int(ids.value, PRIME)\nq, ids.r = divmod(int_value, ids.div)\n\nassert -ids.bound <= q < ids.bound, \\\n    f'{int_value} / {ids.div} = {q} is out of the range [{-ids.bound}, {ids.bound}).'\n\nids.biased_q = q + ids.bound";
         let mut vm = vm_with_range_check!();
-        for _ in 0..5 {
-            vm.segments.add(&mut vm.memory, None);
-        }
         //Initialize fp
-        vm.run_context.ap = 0;
         vm.run_context.fp = 6;
         //Insert ids into memory
         vm.memory = memory![((1, 3), 5), ((1, 4), 10), ((1, 5), 29)];
         //Create ids
         let ids_data = ids_data!["r", "biased_q", "range_check_ptr", "div", "value", "bound"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        assert!(hint_processor
-            .execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data))
-            .is_ok());
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 0))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 1))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(31))))
-        );
+        assert!(run_hint!(vm, ids_data, hint_code).is_ok());
+        check_memory![vm.memory, ((1, 0), 0), ((1, 1), 31)];
     }
 
     #[test]
@@ -1716,27 +1383,14 @@ mod tests {
         let hint_code = "from starkware.cairo.common.math_utils import as_int, assert_integer\n\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\n\nassert_integer(ids.bound)\nassert ids.bound <= range_check_builtin.bound // 2, \\\n    f'bound={hex(ids.bound)} is out of the valid range.'\n\nint_value = as_int(ids.value, PRIME)\nq, ids.r = divmod(int_value, ids.div)\n\nassert -ids.bound <= q < ids.bound, \\\n    f'{int_value} / {ids.div} = {q} is out of the range [{-ids.bound}, {ids.bound}).'\n\nids.biased_q = q + ids.bound";
         let mut vm = vm_with_range_check!();
         //Initialize fp
-        vm.run_context.ap = 0;
         vm.run_context.fp = 6;
         //Insert ids into memory
         vm.memory = memory![((1, 3), 7), ((1, 4), (-10)), ((1, 5), 29)];
         //Create ids
         let ids_data = ids_data!["r", "biased_q", "range_check_ptr", "div", "value", "bound"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        assert!(hint_processor
-            .execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data))
-            .is_ok());
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 0))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(4))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 1))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(27))))
-        );
+        assert!(run_hint!(vm, ids_data, hint_code).is_ok());
+        check_memory![vm.memory, ((1, 0), 4), ((1, 1), 27)];
     }
 
     #[test]
@@ -1744,18 +1398,14 @@ mod tests {
         let hint_code = "from starkware.cairo.common.math_utils import as_int, assert_integer\n\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\n\nassert_integer(ids.bound)\nassert ids.bound <= range_check_builtin.bound // 2, \\\n    f'bound={hex(ids.bound)} is out of the valid range.'\n\nint_value = as_int(ids.value, PRIME)\nq, ids.r = divmod(int_value, ids.div)\n\nassert -ids.bound <= q < ids.bound, \\\n    f'{int_value} / {ids.div} = {q} is out of the range [{-ids.bound}, {ids.bound}).'\n\nids.biased_q = q + ids.bound";
         let mut vm = vm_with_range_check!();
         //Initialize fp
-        vm.run_context.ap = 0;
         vm.run_context.fp = 6;
         //Insert ids into memory
         vm.memory = memory![((1, 3), (-5)), ((1, 4), 10), ((1, 5), 29)];
         //Create ids
         let ids_data = ids_data!["r", "biased_q", "range_check_ptr", "div", "value", "bound"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::OutOfValidRange(
                 bigint!(-5),
                 bigint_str!(b"10633823966279327296825105735305134080")
@@ -1768,17 +1418,13 @@ mod tests {
         let hint_code = "from starkware.cairo.common.math_utils import as_int, assert_integer\n\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\n\nassert_integer(ids.bound)\nassert ids.bound <= range_check_builtin.bound // 2, \\\n    f'bound={hex(ids.bound)} is out of the valid range.'\n\nint_value = as_int(ids.value, PRIME)\nq, ids.r = divmod(int_value, ids.div)\n\nassert -ids.bound <= q < ids.bound, \\\n    f'{int_value} / {ids.div} = {q} is out of the range [{-ids.bound}, {ids.bound}).'\n\nids.biased_q = q + ids.bound";
         let mut vm = vm!();
         //Initialize fp
-        vm.run_context.ap = 0;
         vm.run_context.fp = 6;
         //Insert ids into memory
         vm.memory = memory![((1, 3), 5), ((1, 4), 10), ((1, 5), 29)];
         //Create ids
         let ids_data = ids_data!["r", "biased_q", "range_check_ptr", "div", "value", "bound"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::NoRangeCheckBuiltin)
         );
     }
@@ -1788,18 +1434,14 @@ mod tests {
         let hint_code = "from starkware.cairo.common.math_utils import as_int, assert_integer\n\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\n\nassert_integer(ids.bound)\nassert ids.bound <= range_check_builtin.bound // 2, \\\n    f'bound={hex(ids.bound)} is out of the valid range.'\n\nint_value = as_int(ids.value, PRIME)\nq, ids.r = divmod(int_value, ids.div)\n\nassert -ids.bound <= q < ids.bound, \\\n    f'{int_value} / {ids.div} = {q} is out of the range [{-ids.bound}, {ids.bound}).'\n\nids.biased_q = q + ids.bound";
         let mut vm = vm_with_range_check!();
         //Initialize fp
-        vm.run_context.ap = 0;
         vm.run_context.fp = 6;
         //Insert ids into memory
         vm.memory = memory![((1, 1), 10), ((1, 3), 5), ((1, 4), 10), ((1, 5), 29)];
         //Create ids
         let ids_data = ids_data!["r", "biased_q", "range_check_ptr", "div", "value", "bound"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((1, 1)),
@@ -1815,18 +1457,14 @@ mod tests {
         let hint_code = "from starkware.cairo.common.math_utils import as_int, assert_integer\n\nassert_integer(ids.div)\nassert 0 < ids.div <= PRIME // range_check_builtin.bound, \\\n    f'div={hex(ids.div)} is out of the valid range.'\n\nassert_integer(ids.bound)\nassert ids.bound <= range_check_builtin.bound // 2, \\\n    f'bound={hex(ids.bound)} is out of the valid range.'\n\nint_value = as_int(ids.value, PRIME)\nq, ids.r = divmod(int_value, ids.div)\n\nassert -ids.bound <= q < ids.bound, \\\n    f'{int_value} / {ids.div} = {q} is out of the range [{-ids.bound}, {ids.bound}).'\n\nids.biased_q = q + ids.bound";
         let mut vm = vm_with_range_check!();
         //Initialize fp
-        vm.run_context.ap = 0;
         vm.run_context.fp = 6;
         //Insert ids into memory
         vm.memory = memory![((1, 3), 5), ((1, 4), 10), ((1, 5), 29)];
         //Create ids
         let ids_data = ids_data!["r", "b", "r", "d", "v", "b"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::FailedToGetIds)
         )
     }
@@ -1841,52 +1479,33 @@ mod tests {
         vm.memory = memory![((1, 0), 1)];
         //Create ids
         let ids_data = ids_data!["value", "high", "low"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
-            Ok(())
-        );
+        assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
         //Hint would return an error if the assertion fails
         //Check ids.high and ids.low values
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 1))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 2))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(1))))
-        );
+        check_memory![vm.memory, ((1, 1), 0), ((1, 2), 1)];
     }
 
     #[test]
     fn run_assert_250_bit_invalid() {
-        let hint_code = "from starkware.cairo.common.math_utils import as_int\n\n# Correctness check.\nvalue = as_int(ids.value, PRIME) % PRIME\nassert value < ids.UPPER_BOUND, f'{value} is outside of the range [0, 2**250).'\n\n# Calculation for the assertion.\nids.high, ids.low = divmod(ids.value, ids.SHIFT)"
-             ;
+        let hint_code = "from starkware.cairo.common.math_utils import as_int\n\n# Correctness check.\nvalue = as_int(ids.value, PRIME) % PRIME\nassert value < ids.UPPER_BOUND, f'{value} is outside of the range [0, 2**250).'\n\n# Calculation for the assertion.\nids.high, ids.low = divmod(ids.value, ids.SHIFT)";
         let mut vm = vm!();
-        for _ in 0..2 {
-            vm.segments.add(&mut vm.memory, None);
-        }
         //Initialize fp
         vm.run_context.fp = 3;
         //Insert ids into memory
         //ids.value
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 0)),
-                &MaybeRelocatable::from(bigint!(1).shl(251i32)),
+        vm.memory = memory![(
+            (1, 0),
+            (
+                b"3618502788666131106986593281521497120414687020801267626233049500247285301248",
+                10
             )
-            .unwrap();
+        )];
         //Create ids
         let ids_data = ids_data!["value", "high", "low"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::ValueOutside250BitRange(
                 bigint!(1).shl(251i32)
             ))
@@ -1898,55 +1517,27 @@ mod tests {
         let hint_code =
         "from starkware.cairo.common.math_utils import assert_integer\nassert ids.MAX_HIGH < 2**128 and ids.MAX_LOW < 2**128\nassert PRIME - 1 == ids.MAX_HIGH * 2**128 + ids.MAX_LOW\nassert_integer(ids.value)\nids.low = ids.value & ((1 << 128) - 1)\nids.high = ids.value >> 128";
         let mut vm = vm_with_range_check!();
-        for _ in 0..3 {
-            vm.segments.add(&mut vm.memory, None);
-        }
-
+        vm.memory = memory![
+            ((1, 3), (b"7335438970432432812899076431678123043273", 10)),
+            ((1, 4), (2, 0))
+        ];
+        add_segments!(vm, 1);
         //Initialize fp
         vm.run_context.fp = 7;
-
-        //Insert ids.value into memory
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 3)),
-                &MaybeRelocatable::from(bigint_str!(b"7335438970432432812899076431678123043273")),
-            )
-            .unwrap();
-
-        //Insert ids.low pointer into memory
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 4)),
-                &MaybeRelocatable::from((2, 0)),
-            )
-            .unwrap();
-
         //Create ids
         let ids_data = HashMap::from([
             ("value".to_string(), HintReference::new_simple(-4)),
             ("low".to_string(), HintReference::new(-3, 0, true, true)),
             ("high".to_string(), HintReference::new(-3, 1, true, true)),
         ]);
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
-            Ok(())
-        );
-
+        assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
         //Check hint memory inserts
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 0))),
-            Ok(Some(&MaybeRelocatable::from(bigint_str!(
-                b"189509265092725080168209675610990602697"
-            ))))
-        );
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 1))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(21))))
-        );
+        check_memory![
+            vm.memory,
+            ((2, 0), (b"189509265092725080168209675610990602697", 10)),
+            ((2, 1), 21)
+        ];
     }
 
     #[test]
@@ -1954,38 +1545,18 @@ mod tests {
         let hint_code =
         "from starkware.cairo.common.math_utils import assert_integer\nassert ids.MAX_HIGH < 2**128 and ids.MAX_LOW < 2**128\nassert PRIME - 1 == ids.MAX_HIGH * 2**128 + ids.MAX_LOW\nassert_integer(ids.value)\nids.low = ids.value & ((1 << 128) - 1)\nids.high = ids.value >> 128";
         let mut vm = vm_with_range_check!();
-        for _ in 0..3 {
-            vm.segments.add(&mut vm.memory, None);
-        }
-
+        vm.memory = memory![
+            ((1, 3), (b"7335438970432432812899076431678123043273", 10)),
+            ((1, 4), (2, 0))
+        ];
         //Initialize fp
         vm.run_context.fp = 7;
-
-        //Insert ids.value into memory
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 3)),
-                &MaybeRelocatable::from(bigint_str!(b"7335438970432432812899076431678123043273")),
-            )
-            .unwrap();
-
-        //Insert ids.low pointer into memory
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 4)),
-                &MaybeRelocatable::from((2, 0)),
-            )
-            .unwrap();
-
         //Create incomplete ids
         //Create ids_data & hint_data
         let ids_data = ids_data!["low"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::FailedToGetIds)
         );
     }
@@ -1995,47 +1566,23 @@ mod tests {
         let hint_code =
         "from starkware.cairo.common.math_utils import assert_integer\nassert ids.MAX_HIGH < 2**128 and ids.MAX_LOW < 2**128\nassert PRIME - 1 == ids.MAX_HIGH * 2**128 + ids.MAX_LOW\nassert_integer(ids.value)\nids.low = ids.value & ((1 << 128) - 1)\nids.high = ids.value >> 128";
         let mut vm = vm_with_range_check!();
-        for _ in 0..3 {
-            vm.segments.add(&mut vm.memory, None);
-        }
+        vm.memory = memory![
+            ((1, 3), (b"7335438970432432812899076431678123043273", 10)),
+            ((1, 4), (2, 0)),
+            ((2, 0), 99)
+        ];
         //Initialize fp
         vm.run_context.fp = 7;
-        //Insert ids.value into memory
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 3)),
-                &MaybeRelocatable::from(bigint_str!(b"7335438970432432812899076431678123043273")),
-            )
-            .unwrap();
-
-        //Insert ids.low pointer into memory
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 4)),
-                &MaybeRelocatable::from((2, 0)),
-            )
-            .unwrap();
-
         //Create ids_data & hint_data
         let ids_data = HashMap::from([
             ("value".to_string(), HintReference::new_simple(-4)),
             ("low".to_string(), HintReference::new(-3, 0, true, true)),
             ("high".to_string(), HintReference::new(-3, 1, true, true)),
         ]);
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
-        // Override MaybeRelocatable::from((2, 0)) memory address so, the hint vm.memory.insert fails
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 0)),
-                &MaybeRelocatable::from(bigint!(99)),
-            )
-            .unwrap();
 
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((2, 0)),
@@ -2051,37 +1598,23 @@ mod tests {
         let hint_code =
         "from starkware.cairo.common.math_utils import assert_integer\nassert ids.MAX_HIGH < 2**128 and ids.MAX_LOW < 2**128\nassert PRIME - 1 == ids.MAX_HIGH * 2**128 + ids.MAX_LOW\nassert_integer(ids.value)\nids.low = ids.value & ((1 << 128) - 1)\nids.high = ids.value >> 128";
         let mut vm = vm_with_range_check!();
-        vm.memory = memory![((1, 4), (2, 0))];
-        vm.segments.add(&mut vm.memory, None);
+        vm.memory = memory![
+            ((1, 4), (2, 0)),
+            ((1, 3), (b"7335438970432432812899076431678123043273", 10)),
+            ((2, 1), 99)
+        ];
+        add_segments!(vm, 1);
         //Initialize fp
         vm.run_context.fp = 7;
-        //Insert ids.value into memory
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 3)),
-                &MaybeRelocatable::from(bigint_str!(b"7335438970432432812899076431678123043273")),
-            )
-            .unwrap();
         //Create ids_data & hint_data
         let ids_data = HashMap::from([
             ("value".to_string(), HintReference::new_simple(-4)),
             ("low".to_string(), HintReference::new(-3, 0, true, true)),
             ("high".to_string(), HintReference::new(-3, 1, true, true)),
         ]);
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
-        // Override MaybeRelocatable::from((2, 1)) memory address so, the hint vm.memory.insert fails
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 1)),
-                &MaybeRelocatable::from(bigint!(99)),
-            )
-            .unwrap();
-
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((2, 1)),
@@ -2106,12 +1639,9 @@ mod tests {
             ("low".to_string(), HintReference::new(-3, 0, true, true)),
             ("high".to_string(), HintReference::new(-3, 1, true, true)),
         ]);
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((1, 3))
             ))
@@ -2121,43 +1651,16 @@ mod tests {
     #[test]
     fn run_assert_lt_felt_ok() {
         let hint_code =
-        "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\nassert (ids.a % PRIME) < (ids.b % PRIME), \\\n    f'a = {ids.a % PRIME} is not less than b = {ids.b % PRIME}.'"
-        ;
+        "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert_integer(ids.b)\nassert (ids.a % PRIME) < (ids.b % PRIME), \\\n    f'a = {ids.a % PRIME} is not less than b = {ids.b % PRIME}.'";
         let mut vm = vm_with_range_check!();
-        //Initialize memory segements
-        for _ in 0..3 {
-            vm.segments.add(&mut vm.memory, None);
-        }
-
         //Initialize fp
         vm.run_context.fp = 3;
-
-        //Insert ids.a into memory
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 1)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-
-        //Insert ids.b into memory
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 2)),
-                &MaybeRelocatable::from(bigint!(2)),
-            )
-            .unwrap();
-
+        //Insert ids into memory
+        vm.memory = memory![((1, 1), 1), ((1, 2), 2)];
         //Create ids
         let ids_data = ids_data!["a", "b"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
-            Ok(())
-        );
+        assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
     }
 
     #[test]
@@ -2169,12 +1672,9 @@ mod tests {
         vm.run_context.fp = 3;
         vm.memory = memory![((1, 1), 3), ((1, 2), 2)];
         let ids_data = ids_data!["a", "b"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::AssertLtFelt(bigint!(3), bigint!(2)))
         );
     }
@@ -2189,12 +1689,9 @@ mod tests {
         vm.memory = memory![((1, 1), 1), ((1, 2), 2)];
         //Create Incorrects ids
         let ids_data = ids_data!["a"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::FailedToGetIds)
         );
     }
@@ -2208,12 +1705,9 @@ mod tests {
         vm.run_context.fp = 3;
         vm.memory = memory![((1, 1), (1, 0)), ((1, 2), 2)];
         let ids_data = ids_data!["a", "b"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((1, 1))
             ))
@@ -2229,12 +1723,9 @@ mod tests {
         vm.run_context.fp = 3;
         vm.memory = memory![((1, 1), 1), ((1, 2), (1, 0))];
         let ids_data = ids_data!["a", "b"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((1, 2))
             ))
@@ -2251,12 +1742,9 @@ mod tests {
         //Insert ids.a into memory
         vm.memory = memory![((1, 1), 1)];
         let ids_data = ids_data!["a", "b"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((1, 2))
             ))

--- a/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
@@ -77,17 +77,14 @@ mod tests {
         let mut vm = vm_with_range_check!();
         add_segments!(vm, 3);
         // initialize vm scope with variable `n`
-        let mut exec_scopes = ExecutionScopes::new();
-        exec_scopes.assign_or_update_variable(
+        let mut exec_scopes = scope![(
             "value",
-            any_box!(bigint_str!(
-                b"7737125245533626718119526477371252455336267181195264773712524553362"
-            )),
-        );
+            bigint_str!(b"7737125245533626718119526477371252455336267181195264773712524553362")
+        )];
         //Initialize RubContext
         run_context!(vm, 0, 6, 6);
         //Create hint_data
-        let ids_data = HashMap::from([("res".to_string(), HintReference::new_simple(5))]);
+        let ids_data = non_continuous_ids_data![("res", 5)];
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
         assert_eq!(
             run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
@@ -110,7 +107,7 @@ mod tests {
         //Initialize RubContext
         run_context!(vm, 0, 6, 6);
         //Create hint_data
-        let ids_data = HashMap::from([("res".to_string(), HintReference::new_simple(5))]);
+        let ids_data = non_continuous_ids_data![("res", 5)];
         assert_eq!(
             run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::VariableNotInScopeError(
@@ -125,10 +122,9 @@ mod tests {
         let mut vm = vm_with_range_check!();
 
         // initialize vm scope with variable `n`
-        let mut exec_scopes = ExecutionScopes::new();
-        exec_scopes.assign_or_update_variable("value", any_box!(bigint!(-1)));
+        let mut exec_scopes = scope![("value", bigint!(-1))];
         //Create hint_data
-        let ids_data = HashMap::from([("res".to_string(), HintReference::new_simple(5))]);
+        let ids_data = non_continuous_ids_data![("res", 5)];
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
         assert_eq!(
             run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),

--- a/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
@@ -53,13 +53,13 @@ pub fn bigint_to_uint256(
 
 #[cfg(test)]
 mod tests {
-    use crate::types::relocatable::Relocatable;
-use crate::any_box;
+    use crate::any_box;
     use crate::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::{
         BuiltinHintProcessor, HintProcessorData,
     };
     use crate::hint_processor::hint_processor_definition::HintProcessor;
     use crate::hint_processor::proxies::vm_proxy::get_vm_proxy;
+    use crate::types::relocatable::Relocatable;
     use crate::vm::vm_core::VirtualMachine;
     use num_bigint::Sign;
     use std::any::Any;
@@ -111,13 +111,8 @@ use crate::any_box;
         run_context!(vm, 0, 6, 6);
         //Create hint_data
         let ids_data = HashMap::from([("res".to_string(), HintReference::new_simple(5))]);
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
-
-        //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::VariableNotInScopeError(
                 "value".to_string()
             ))

--- a/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
@@ -53,7 +53,8 @@ pub fn bigint_to_uint256(
 
 #[cfg(test)]
 mod tests {
-    use crate::any_box;
+    use crate::types::relocatable::Relocatable;
+use crate::any_box;
     use crate::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::{
         BuiltinHintProcessor, HintProcessorData,
     };
@@ -83,19 +84,13 @@ mod tests {
                 b"7737125245533626718119526477371252455336267181195264773712524553362"
             )),
         );
-        //Initialize fp
-        vm.run_context.fp = 6;
-        //Initialize ap
-        vm.run_context.ap = 6;
+        //Initialize RubContext
+        run_context!(vm, 0, 6, 6);
         //Create hint_data
         let ids_data = HashMap::from([("res".to_string(), HintReference::new_simple(5))]);
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
-        //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
             Ok(())
         );
         //Check hint memory inserts
@@ -112,10 +107,8 @@ mod tests {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import split\n\nsegments.write_arg(ids.res.address_, split(value))";
         let mut vm = vm_with_range_check!();
         // we don't initialize `value` now:
-        //Initialize fp
-        vm.run_context.fp = 6;
-        //Initialize ap
-        vm.run_context.ap = 6;
+        //Initialize RubContext
+        run_context!(vm, 0, 6, 6);
         //Create hint_data
         let ids_data = HashMap::from([("res".to_string(), HintReference::new_simple(5))]);
         let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
@@ -141,13 +134,9 @@ mod tests {
         exec_scopes.assign_or_update_variable("value", any_box!(bigint!(-1)));
         //Create hint_data
         let ids_data = HashMap::from([("res".to_string(), HintReference::new_simple(5))]);
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
-        //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
             Err(VirtualMachineError::SecpSplitNegative(bigint!(-1)))
         );
     }

--- a/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
@@ -74,9 +74,7 @@ mod tests {
     fn run_nondet_bigint3_ok() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import split\n\nsegments.write_arg(ids.res.address_, split(value))";
         let mut vm = vm_with_range_check!();
-        for _ in 0..3 {
-            vm.segments.add(&mut vm.memory, None);
-        }
+        add_segments!(vm, 3);
         // initialize vm scope with variable `n`
         let mut exec_scopes = ExecutionScopes::new();
         exec_scopes.assign_or_update_variable(

--- a/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
@@ -535,39 +535,28 @@ mod tests {
     fn run_ec_double_assign_new_y_ok() {
         let hint_code = "value = new_y = (slope * (x - new_x) - y) % SECP_P";
         let mut vm = vm_with_range_check!();
-        let mut exec_scopes = ExecutionScopes::new();
-
-        //Insert 'slope' into vm scope
-        exec_scopes.assign_or_update_variable(
-            "slope",
-            any_box!(bigint_str!(
+        let mut exec_scopes = scope![
+            (
+                "slope",
+                bigint_str!(
                 b"48526828616392201132917323266456307435009781900148206102108934970258721901549"
-            )),
-        );
-
-        //Insert 'x' into vm scope
-        exec_scopes.assign_or_update_variable(
-            "x",
-            any_box!(bigint_str!(
-                b"838083498911032969414721426845751663479194726707495046"
-            )),
-        );
-
-        //Insert 'new_x' into vm scope
-        exec_scopes.assign_or_update_variable(
-            "new_x",
-            any_box!(bigint_str!(
+            )
+            ),
+            (
+                "x",
+                bigint_str!(b"838083498911032969414721426845751663479194726707495046")
+            ),
+            (
+                "new_x",
+                bigint_str!(
                 b"59479631769792988345961122678598249997181612138456851058217178025444564264149"
-            )),
-        );
-
-        //Insert 'y' into vm scope
-        exec_scopes.assign_or_update_variable(
-            "y",
-            any_box!(bigint_str!(
-                b"4310143708685312414132851373791311001152018708061750480"
-            )),
-        );
+            )
+            ),
+            (
+                "y",
+                bigint_str!(b"4310143708685312414132851373791311001152018708061750480")
+            )
+        ];
         //Execute the hint
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
         assert_eq!(
@@ -575,20 +564,22 @@ mod tests {
             Ok(())
         );
 
-        //Check 'value' is defined in the vm scope
-        assert_eq!(
-            exec_scopes_proxy.get_int("value"),
-            Ok(bigint_str!(
-                b"7948634220683381957329555864604318996476649323793038777651086572350147290350"
-            ))
-        );
-
-        //Check 'new_y' is defined in the vm scope
-        assert_eq!(
-            exec_scopes_proxy.get_int("new_y"),
-            Ok(bigint_str!(
-                b"7948634220683381957329555864604318996476649323793038777651086572350147290350"
-            ))
+        check_scope!(
+            exec_scopes_proxy,
+            [
+                (
+                    "value",
+                    bigint_str!(
+            b"7948634220683381957329555864604318996476649323793038777651086572350147290350"
+        )
+                ),
+                (
+                    "new_y",
+                    bigint_str!(
+            b"7948634220683381957329555864604318996476649323793038777651086572350147290350"
+        )
+                )
+            ]
         );
     }
 
@@ -633,20 +624,22 @@ mod tests {
             Ok(())
         );
 
-        //Check 'value' is defined in the vm scope
-        assert_eq!(
-            exec_scopes_proxy.get_int("value"),
-            Ok(bigint_str!(
-                b"8891838197222656627233627110766426698842623939023296165598688719819499152657"
-            ))
-        );
-
-        //Check 'new_x' is defined in the vm scope
-        assert_eq!(
-            exec_scopes_proxy.get_int("new_x"),
-            Ok(bigint_str!(
-                b"8891838197222656627233627110766426698842623939023296165598688719819499152657"
-            ))
+        check_scope!(
+            exec_scopes_proxy,
+            [
+                (
+                    "value",
+                    bigint_str!(
+            b"8891838197222656627233627110766426698842623939023296165598688719819499152657"
+        )
+                ),
+                (
+                    "new_x",
+                    bigint_str!(
+            b"8891838197222656627233627110766426698842623939023296165598688719819499152657"
+        )
+                )
+            ]
         );
     }
 
@@ -654,7 +647,7 @@ mod tests {
     fn run_fast_ec_add_assign_new_y_ok() {
         let hint_code = "value = new_y = (slope * (x0 - new_x) - y0) % SECP_P";
         let mut vm = vm_with_range_check!();
-        //Insert 'slope' into vm scope
+
         let mut exec_scopes = scope![
             (
                 "slope",
@@ -685,20 +678,22 @@ mod tests {
             Ok(())
         );
 
-        //Check 'value' is defined in the vm scope
-        assert_eq!(
-            exec_scopes_proxy.get_int("value"),
-            Ok(bigint_str!(
-                b"7948634220683381957329555864604318996476649323793038777651086572350147290350"
-            ))
-        );
-
-        //Check 'new_y' is defined in the vm scope
-        assert_eq!(
-            exec_scopes_proxy.get_int("new_y"),
-            Ok(bigint_str!(
-                b"7948634220683381957329555864604318996476649323793038777651086572350147290350"
-            ))
+        check_scope!(
+            exec_scopes_proxy,
+            [
+                (
+                    "value",
+                    bigint_str!(
+            b"7948634220683381957329555864604318996476649323793038777651086572350147290350"
+        )
+                ),
+                (
+                    "new_y",
+                    bigint_str!(
+            b"7948634220683381957329555864604318996476649323793038777651086572350147290350"
+        )
+                )
+            ]
         );
     }
 

--- a/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
@@ -350,14 +350,11 @@ mod tests {
         vm.run_context.fp = 1;
         //Create hint_data
         let ids_data = ids_data!["point"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         let mut exec_scopes = ExecutionScopes::new();
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
             Ok(())
         );
         //Check 'value' is defined in the vm scope
@@ -386,15 +383,12 @@ mod tests {
         vm.run_context.fp = 1;
 
         let ids_data = ids_data!["point"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         let mut exec_scopes = ExecutionScopes::new();
 
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
             Ok(())
         );
 
@@ -442,15 +436,12 @@ mod tests {
             ("point0".to_string(), HintReference::new_simple(-14)),
             ("point1".to_string(), HintReference::new_simple(-8)),
         ]);
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         let mut exec_scopes = ExecutionScopes::new();
 
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
             Ok(())
         );
 
@@ -495,15 +486,12 @@ mod tests {
             ("point".to_string(), HintReference::new_simple(-10)),
             ("slope".to_string(), HintReference::new_simple(-4)),
         ]);
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         let mut exec_scopes = ExecutionScopes::new();
 
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
             Ok(())
         );
 
@@ -586,12 +574,9 @@ mod tests {
             )),
         );
         //Execute the hint
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), HashMap::new());
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, HashMap::new(), hint_code, exec_scopes_proxy),
             Ok(())
         );
 
@@ -646,15 +631,12 @@ mod tests {
             ("point1".to_string(), HintReference::new_simple(-9)),
             ("slope".to_string(), HintReference::new_simple(-6)),
         ]);
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         let mut exec_scopes = ExecutionScopes::new();
 
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
             Ok(())
         );
 
@@ -711,13 +693,10 @@ mod tests {
                 b"4310143708685312414132851373791311001152018708061750480"
             )),
         );
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), HashMap::new());
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, HashMap::new(), hint_code, exec_scopes_proxy),
             Ok(())
         );
 
@@ -754,15 +733,9 @@ mod tests {
         vm.run_context.ap = 2;
 
         let ids_data = ids_data!["scalar"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
 
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
-            Ok(())
-        );
+        assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
 
         //Check hint memory inserts
         check_memory![&vm.memory, ((1, 2), 0)];

--- a/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
@@ -654,38 +654,30 @@ mod tests {
     fn run_fast_ec_add_assign_new_y_ok() {
         let hint_code = "value = new_y = (slope * (x0 - new_x) - y0) % SECP_P";
         let mut vm = vm_with_range_check!();
-        let mut exec_scopes = ExecutionScopes::new();
         //Insert 'slope' into vm scope
-        exec_scopes.assign_or_update_variable(
-            "slope",
-            any_box!(bigint_str!(
+        let mut exec_scopes = scope![
+            (
+                "slope",
+                bigint_str!(
                 b"48526828616392201132917323266456307435009781900148206102108934970258721901549"
-            )),
-        );
-
-        //Insert 'x0' into vm scope
-        exec_scopes.assign_or_update_variable(
-            "x0",
-            any_box!(bigint_str!(
-                b"838083498911032969414721426845751663479194726707495046"
-            )),
-        );
-
-        //Insert 'new_x' into vm scope
-        exec_scopes.assign_or_update_variable(
-            "new_x",
-            any_box!(bigint_str!(
+            )
+            ),
+            (
+                "x0",
+                bigint_str!(b"838083498911032969414721426845751663479194726707495046")
+            ),
+            (
+                "new_x",
+                bigint_str!(
                 b"59479631769792988345961122678598249997181612138456851058217178025444564264149"
-            )),
-        );
+            )
+            ),
+            (
+                "y0",
+                bigint_str!(b"4310143708685312414132851373791311001152018708061750480")
+            )
+        ];
 
-        //Insert 'y0' into vm scope
-        exec_scopes.assign_or_update_variable(
-            "y0",
-            any_box!(bigint_str!(
-                b"4310143708685312414132851373791311001152018708061750480"
-            )),
-        );
         //Execute the hint
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
         assert_eq!(

--- a/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
@@ -331,6 +331,7 @@ mod tests {
     use crate::hint_processor::proxies::vm_proxy::get_vm_proxy;
     use crate::types::exec_scope::ExecutionScopes;
     use crate::types::relocatable::MaybeRelocatable;
+    use crate::types::relocatable::Relocatable;
     use crate::utils::test_utils::*;
     use crate::vm::errors::memory_errors::MemoryError;
     use crate::vm::runners::builtin_runner::RangeCheckBuiltinRunner;
@@ -391,21 +392,22 @@ mod tests {
             run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
             Ok(())
         );
-
-        //Check 'value' is defined in the vm scope
-        assert_eq!(
-            exec_scopes_proxy.get_int("value"),
-            Ok(bigint_str!(
-                b"40442433062102151071094722250325492738932110061897694430475034100717288403728"
-            ))
-        );
-
-        //Check 'slope' is defined in the vm scope
-        assert_eq!(
-            exec_scopes_proxy.get_int("slope"),
-            Ok(bigint_str!(
-                b"40442433062102151071094722250325492738932110061897694430475034100717288403728"
-            ))
+        check_scope!(
+            exec_scopes_proxy,
+            [
+                (
+                    "value",
+                    bigint_str!(
+            b"40442433062102151071094722250325492738932110061897694430475034100717288403728"
+        )
+                ),
+                (
+                    "slope",
+                    bigint_str!(
+            b"40442433062102151071094722250325492738932110061897694430475034100717288403728"
+        )
+                )
+            ]
         );
     }
 
@@ -444,21 +446,22 @@ mod tests {
             run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
             Ok(())
         );
-
-        //Check 'value' is defined in the vm scope
-        assert_eq!(
-            exec_scopes_proxy.get_int("value"),
-            Ok(bigint_str!(
-                b"41419765295989780131385135514529906223027172305400087935755859001910844026631"
-            ))
-        );
-
-        //Check 'slope' is defined in the vm scope
-        assert_eq!(
-            exec_scopes_proxy.get_int("slope"),
-            Ok(bigint_str!(
-                b"41419765295989780131385135514529906223027172305400087935755859001910844026631"
-            ))
+        check_scope!(
+            exec_scopes_proxy,
+            [
+                (
+                    "value",
+                    bigint_str!(
+            b"41419765295989780131385135514529906223027172305400087935755859001910844026631"
+        )
+                ),
+                (
+                    "slope",
+                    bigint_str!(
+            b"41419765295989780131385135514529906223027172305400087935755859001910844026631"
+        )
+                )
+            ]
         );
     }
 
@@ -495,44 +498,36 @@ mod tests {
             Ok(())
         );
 
-        //Check 'slope' is defined in the vm scope
-        assert_eq!(
-            exec_scopes_proxy.get_int("slope"),
-            Ok(bigint_str!(
-                b"48526828616392201132917323266456307435009781900148206102108934970258721901549"
-            ))
-        );
-
-        //Check 'x' is defined in the vm scope
-        assert_eq!(
-            exec_scopes_proxy.get_int("x"),
-            Ok(bigint_str!(
-                b"838083498911032969414721426845751663479194726707495046"
-            ))
-        );
-
-        //Check 'y' is defined in the vm scope
-        assert_eq!(
-            exec_scopes_proxy.get_int("y"),
-            Ok(bigint_str!(
-                b"4310143708685312414132851373791311001152018708061750480"
-            ))
-        );
-
-        //Check 'value' is defined in the vm scope
-        assert_eq!(
-            exec_scopes_proxy.get_int("value"),
-            Ok(bigint_str!(
-                b"59479631769792988345961122678598249997181612138456851058217178025444564264149"
-            ))
-        );
-
-        //Check 'new_x' is defined in the vm scope
-        assert_eq!(
-            exec_scopes_proxy.get_int("new_x"),
-            Ok(bigint_str!(
-                b"59479631769792988345961122678598249997181612138456851058217178025444564264149"
-            ))
+        check_scope!(
+            exec_scopes_proxy,
+            [
+                (
+                    "slope",
+                    bigint_str!(
+            b"48526828616392201132917323266456307435009781900148206102108934970258721901549"
+        )
+                ),
+                (
+                    "x",
+                    bigint_str!(b"838083498911032969414721426845751663479194726707495046")
+                ),
+                (
+                    "y",
+                    bigint_str!(b"4310143708685312414132851373791311001152018708061750480")
+                ),
+                (
+                    "value",
+                    bigint_str!(
+            b"59479631769792988345961122678598249997181612138456851058217178025444564264149"
+        )
+                ),
+                (
+                    "new_x",
+                    bigint_str!(
+            b"59479631769792988345961122678598249997181612138456851058217178025444564264149"
+        )
+                )
+            ]
         );
     }
 
@@ -621,11 +616,9 @@ mod tests {
             ((1, 11), 16032182557092050689870202_i128)
         ];
 
-        //Initialize fp
-        vm.run_context.fp = 15;
+        //Initialize run_context
+        run_context!(vm, 0, 20, 15);
 
-        //Initialize ap
-        vm.run_context.ap = 20;
         let ids_data = HashMap::from([
             ("point0".to_string(), HintReference::new_simple(-15)),
             ("point1".to_string(), HintReference::new_simple(-9)),
@@ -726,11 +719,8 @@ mod tests {
         //Insert ids.scalar into memory
         vm.memory = memory![((1, 0), scalar)];
 
-        //Initialize fp
-        vm.run_context.fp = 1;
-
-        //Initialize ap
-        vm.run_context.ap = 2;
+        //Initialize RunContext
+        run_context!(vm, 0, 2, 1);
 
         let ids_data = ids_data!["scalar"];
 

--- a/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
@@ -157,10 +157,7 @@ mod tests {
         //Initialize run_context
         run_context!(vm, 0, 9, 9);
         //Create hint data
-        let ids_data = HashMap::from([
-            ("val".to_string(), HintReference::new_simple(-5)),
-            ("q".to_string(), HintReference::new_simple(0)),
-        ]);
+        let ids_data = non_continuous_ids_data![("val", -5), ("q", 0)];
         vm.memory = memory![((1, 4), 0), ((1, 5), 0), ((1, 6), 0)];
         //Execute the hint
         assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
@@ -198,10 +195,7 @@ mod tests {
         run_context!(vm, 0, 9, 9);
 
         //Create hint data
-        let ids_data = HashMap::from([
-            ("val".to_string(), HintReference::new_simple(-5)),
-            ("q".to_string(), HintReference::new_simple(0)),
-        ]);
+        let ids_data = non_continuous_ids_data![("val", -5), ("q", 0)];
         vm.memory = memory![((1, 4), 0), ((1, 5), 0), ((1, 6), 0), ((1, 9), 55)];
         //Execute the hint
         assert_eq!(
@@ -226,7 +220,7 @@ mod tests {
         vm.run_context.fp = 25;
 
         //Create hint data
-        let ids_data = HashMap::from([("x".to_string(), HintReference::new_simple(-5))]);
+        let ids_data = non_continuous_ids_data![("x", -5)];
 
         vm.memory = memory![
             ((1, 20), (b"132181232131231239112312312313213083892150", 10)),
@@ -299,11 +293,14 @@ mod tests {
         );
 
         //Check 'x' is defined in the vm scope
-        assert_eq!(
-            exec_scopes_proxy.get_int("x"),
-            Ok(bigint_str!(
-                b"1389505070847794345082847096905107459917719328738389700703952672838091425185"
-            ))
+        check_scope!(
+            exec_scopes_proxy,
+            [(
+                "x",
+                bigint_str!(
+                    b"1389505070847794345082847096905107459917719328738389700703952672838091425185"
+                )
+            )]
         );
     }
 

--- a/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
@@ -138,8 +138,8 @@ mod tests {
     use crate::hint_processor::proxies::exec_scopes_proxy::get_exec_scopes_proxy;
     use crate::hint_processor::proxies::vm_proxy::get_vm_proxy;
     use crate::types::exec_scope::ExecutionScopes;
-    use crate::types::instruction::Register;
     use crate::types::relocatable::MaybeRelocatable;
+    use crate::types::relocatable::Relocatable;
     use crate::utils::test_utils::*;
     use crate::vm::errors::memory_errors::MemoryError;
     use crate::vm::runners::builtin_runner::RangeCheckBuiltinRunner;
@@ -148,155 +148,43 @@ mod tests {
     use num_bigint::Sign;
     use std::any::Any;
 
+    from_bigint_str![42];
+
     #[test]
     fn run_verify_zero_ok() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nq, r = divmod(pack(ids.val, PRIME), SECP_P)\nassert r == 0, f\"verify_zero: Invalid input {ids.val.d0, ids.val.d1, ids.val.d2}.\"\nids.q = q % PRIME";
         let mut vm = vm_with_range_check!();
-        //Initialize fp
-        vm.run_context.fp = 9;
-
-        //Initialize ap
-        vm.run_context.ap = 9;
+        //Initialize run_context
+        run_context!(vm, 0, 9, 9);
         //Create hint data
         let ids_data = HashMap::from([
-            (
-                "val".to_string(),
-                HintReference {
-                    dereference: true,
-                    register: Some(Register::FP),
-                    offset1: -5,
-                    offset2: 0,
-                    inner_dereference: false,
-                    immediate: None,
-                    ap_tracking_data: Some(ApTracking {
-                        group: 1,
-                        offset: 0,
-                    }),
-                },
-            ),
-            (
-                "q".to_string(),
-                HintReference {
-                    dereference: true,
-                    register: Some(Register::AP),
-                    offset1: 0,
-                    offset2: 0,
-                    inner_dereference: false,
-                    immediate: None,
-                    ap_tracking_data: Some(ApTracking {
-                        group: 1,
-                        offset: 0,
-                    }),
-                },
-            ),
+            ("val".to_string(), HintReference::new_simple(-5)),
+            ("q".to_string(), HintReference::new_simple(0)),
         ]);
-        let hint_data = HintProcessorData {
-            code: hint_code.to_string(),
-            ap_tracking: ApTracking {
-                group: 1,
-                offset: 0,
-            },
-            ids_data,
-        };
         vm.memory = memory![((1, 4), 0), ((1, 5), 0), ((1, 6), 0)];
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
-            Ok(())
-        );
-
+        assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
         //Check hint memory inserts
         //ids.q
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 9))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
+        check_memory![&vm.memory, ((1, 9), 0)];
     }
 
     #[test]
     fn run_verify_zero_error() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nq, r = divmod(pack(ids.val, PRIME), SECP_P)\nassert r == 0, f\"verify_zero: Invalid input {ids.val.d0, ids.val.d1, ids.val.d2}.\"\nids.q = q % PRIME";
         let mut vm = vm_with_range_check!();
-        for _ in 0..3 {
-            vm.segments.add(&mut vm.memory, None);
-        }
-
-        //Initialize fp
-        vm.run_context.fp = 9;
-
-        //Initialize ap
-        vm.run_context.ap = 9;
+        add_segments!(vm, 3);
+        //Initialize run_context
+        run_context!(vm, 0, 9, 9);
         //Create hint data
         let ids_data = HashMap::from([
-            (
-                "val".to_string(),
-                HintReference {
-                    dereference: true,
-                    register: Some(Register::FP),
-                    offset1: -5,
-                    offset2: 0,
-                    inner_dereference: false,
-                    immediate: None,
-                    ap_tracking_data: Some(ApTracking {
-                        group: 1,
-                        offset: 0,
-                    }),
-                },
-            ),
-            (
-                "q".to_string(),
-                HintReference {
-                    dereference: true,
-                    register: Some(Register::AP),
-                    offset1: 0,
-                    offset2: 0,
-                    inner_dereference: false,
-                    immediate: None,
-                    ap_tracking_data: Some(ApTracking {
-                        group: 1,
-                        offset: 0,
-                    }),
-                },
-            ),
+            ("val".to_string(), HintReference::new_simple(-5)),
+            ("q".to_string(), HintReference::new_simple(0)),
         ]);
-        let hint_data = HintProcessorData {
-            code: hint_code.to_string(),
-            ap_tracking: ApTracking {
-                group: 1,
-                offset: 0,
-            },
-            ids_data,
-        };
-        //Insert ids.val.d0 into memory
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 4)),
-                &MaybeRelocatable::from(bigint!(0)),
-            )
-            .unwrap();
-
-        //Insert ids.val.d1 into memory
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 5)),
-                &MaybeRelocatable::from(bigint!(0)),
-            )
-            .unwrap();
-
-        //Insert ids.val.d2 into memory
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 6)),
-                &MaybeRelocatable::from(bigint!(150)),
-            )
-            .unwrap();
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
+        vm.memory = memory![((1, 4), 0), ((1, 5), 0), ((1, 6), 150)];
         //Execute the hint
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data),),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::SecpVerifyZero(bigint_str!(
                 b"897946605976106752944343961220884287276604954404454400"
             ),))
@@ -307,94 +195,20 @@ mod tests {
     fn run_verify_zero_invalid_memory_insert() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nq, r = divmod(pack(ids.val, PRIME), SECP_P)\nassert r == 0, f\"verify_zero: Invalid input {ids.val.d0, ids.val.d1, ids.val.d2}.\"\nids.q = q % PRIME";
         let mut vm = vm_with_range_check!();
-        for _ in 0..3 {
-            vm.segments.add(&mut vm.memory, None);
-        }
+        add_segments!(vm, 3);
 
-        //Initialize fp
-        vm.run_context.fp = 9;
-
-        //Initialize ap
-        vm.run_context.ap = 9;
+        //Initialize run_context
+        run_context!(vm, 0, 9, 9);
 
         //Create hint data
         let ids_data = HashMap::from([
-            (
-                "val".to_string(),
-                HintReference {
-                    dereference: true,
-                    register: Some(Register::FP),
-                    offset1: -5,
-                    offset2: 0,
-                    inner_dereference: false,
-                    immediate: None,
-                    ap_tracking_data: Some(ApTracking {
-                        group: 1,
-                        offset: 0,
-                    }),
-                },
-            ),
-            (
-                "q".to_string(),
-                HintReference {
-                    dereference: true,
-                    register: Some(Register::AP),
-                    offset1: 0,
-                    offset2: 0,
-                    inner_dereference: false,
-                    immediate: None,
-                    ap_tracking_data: Some(ApTracking {
-                        group: 1,
-                        offset: 0,
-                    }),
-                },
-            ),
+            ("val".to_string(), HintReference::new_simple(-5)),
+            ("q".to_string(), HintReference::new_simple(0)),
         ]);
-        let hint_data = HintProcessorData {
-            code: hint_code.to_string(),
-            ap_tracking: ApTracking {
-                group: 1,
-                offset: 0,
-            },
-            ids_data,
-        };
-
-        //Insert ids.val.d0 into memory
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 4)),
-                &MaybeRelocatable::from(bigint!(0)),
-            )
-            .unwrap();
-
-        //Insert ids.val.d1 into memory
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 5)),
-                &MaybeRelocatable::from(bigint!(0)),
-            )
-            .unwrap();
-
-        //Insert ids.val.d2 into memory
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 6)),
-                &MaybeRelocatable::from(bigint!(0)),
-            )
-            .unwrap();
-
-        // Insert ids.val.d2  before the hint execution, so the hint memory insert fails
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 9)),
-                &MaybeRelocatable::from(bigint!(55)),
-            )
-            .unwrap();
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
+        vm.memory = memory![((1, 4), 0), ((1, 5), 0), ((1, 6), 0), ((1, 9), 55)];
         //Execute the hint
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((1, 9)),
@@ -409,61 +223,25 @@ mod tests {
     fn run_reduce_ok() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nvalue = pack(ids.x, PRIME) % SECP_P";
         let mut vm = vm_with_range_check!();
-        for _ in 0..3 {
-            vm.segments.add(&mut vm.memory, None);
-        }
+        add_segments!(vm, 3);
 
         //Initialize fp
         vm.run_context.fp = 25;
 
         //Create hint data
-        let ids_data = HashMap::from([(
-            "x".to_string(),
-            HintReference {
-                dereference: true,
-                register: Some(Register::FP),
-                offset1: -5,
-                offset2: 0,
-                inner_dereference: false,
-                immediate: None,
-                ap_tracking_data: Some(ApTracking {
-                    group: 2,
-                    offset: 0,
-                }),
-            },
-        )]);
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
-        //Insert ids.x.d0 into memory
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 20)),
-                &MaybeRelocatable::from(bigint_str!(b"132181232131231239112312312313213083892150")),
-            )
-            .unwrap();
+        let ids_data = HashMap::from([("x".to_string(), HintReference::new_simple(-5))]);
 
-        //Insert ids.x.d1 into memory
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 21)),
-                &MaybeRelocatable::from(bigint!(10)),
-            )
-            .unwrap();
-
-        //Insert ids.x.d2 into memory
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 22)),
-                &MaybeRelocatable::from(bigint!(10)),
-            )
-            .unwrap();
+        vm.memory = memory![
+            ((1, 20), (b"132181232131231239112312312313213083892150", 10)),
+            ((1, 21), 10),
+            ((1, 22), 10)
+        ];
 
         let mut exec_scopes = ExecutionScopes::new();
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
         //Execute the hint
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
             Ok(())
         );
 
@@ -480,44 +258,17 @@ mod tests {
     fn run_reduce_error() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\nvalue = pack(ids.x, PRIME) % SECP_P";
         let mut vm = vm_with_range_check!();
-        for _ in 0..3 {
-            vm.segments.add(&mut vm.memory, None);
-        }
+        add_segments!(vm, 3);
 
         //Initialize fp
         vm.run_context.fp = 25;
 
         //Create hint data
-        let ids_data = HashMap::from([(
-            "x".to_string(),
-            HintReference {
-                dereference: true,
-                register: Some(Register::FP),
-                offset1: -5,
-                offset2: 0,
-                inner_dereference: false,
-                immediate: None,
-                ap_tracking_data: Some(ApTracking {
-                    group: 2,
-                    offset: 0,
-                }),
-            },
-        )]);
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
-
+        let ids_data = HashMap::from([("x".to_string(), HintReference::new_simple(-5))]);
         //Skip ids.x values insert so the hint fails.
-        // vm.memory
-        //     .insert(
-        //         &MaybeRelocatable::from((1, 20)),
-        //         &MaybeRelocatable::from(bigint_str!(b"132181232131231239112312312313213083892150")),
-        //     )
-        //     .unwrap();
-
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         //Execute the hint
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((1, 20))
             ))
@@ -533,23 +284,7 @@ mod tests {
         vm.run_context.fp = 15;
 
         //Create hint data
-        let ids_data = HashMap::from([(
-            "x".to_string(),
-            HintReference {
-                dereference: true,
-                register: Some(Register::FP),
-                offset1: -5,
-                offset2: 0,
-                inner_dereference: false,
-                immediate: None,
-                ap_tracking_data: Some(ApTracking {
-                    group: 2,
-                    offset: 0,
-                }),
-            },
-        )]);
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
-
+        let ids_data = HashMap::from([("x".to_string(), HintReference::new_simple(-5))]);
         //Insert ids.x.d0, ids.x.d1, ids.x.d2 into memory
         vm.memory = memory![
             ((1, 10), 232113757366008801543585_i128),
@@ -560,11 +295,9 @@ mod tests {
         let mut exec_scopes = ExecutionScopes::new();
 
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
             Ok(())
         );
 
@@ -586,35 +319,13 @@ mod tests {
         vm.run_context.fp = 15;
 
         //Create hint data
-        let ids_data = HashMap::from([(
-            "x".to_string(),
-            HintReference {
-                dereference: true,
-                register: Some(Register::FP),
-                offset1: -5,
-                offset2: 0,
-                inner_dereference: false,
-                immediate: None,
-                ap_tracking_data: Some(ApTracking {
-                    group: 2,
-                    offset: 0,
-                }),
-            },
-        )]);
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
+        let ids_data = HashMap::from([("x".to_string(), HintReference::new_simple(-5))]);
 
         //Skip ids.x.d0, ids.x.d1, ids.x.d2 inserts so the hints fails
-        // vm.memory = memory![
-        //     ((1, 10), 232113757366008801543585_i128),
-        //     ((1, 11), 232113757366008801543585_i128),
-        //     ((1, 12), 232113757366008801543585_i128)
-        // ];
 
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((1, 10))
             ))
@@ -627,9 +338,7 @@ mod tests {
         let mut vm = vm_with_range_check!();
 
         //Initialize memory
-        for _ in 0..2 {
-            vm.segments.add(&mut vm.memory, None);
-        }
+        add_segments!(vm, 2);
 
         //Initialize ap
         vm.run_context.ap = 15;
@@ -638,22 +347,16 @@ mod tests {
         //Initialize vm scope with variable `x`
         exec_scopes.assign_or_update_variable("x", any_box!(bigint!(0i32)));
         //Create hint data
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), HashMap::new());
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, HashMap::new(), hint_code, exec_scopes_proxy),
             Ok(())
         );
 
         //Check hint memory insert
         //memory[ap] = to_felt_or_relocatable(x == 0)
-        assert_eq!(
-            vm.memory.get(&vm.run_context.get_ap()),
-            Ok(Some(&MaybeRelocatable::from(bigint!(1i32))))
-        );
+        check_memory!(&vm.memory, ((1, 15), 1));
     }
 
     #[test]
@@ -662,9 +365,7 @@ mod tests {
         let mut vm = vm_with_range_check!();
 
         //Initialize memory
-        for _ in 0..2 {
-            vm.segments.add(&mut vm.memory, None);
-        }
+        add_segments!(vm, 2);
 
         //Initialize ap
         vm.run_context.ap = 15;
@@ -672,23 +373,17 @@ mod tests {
         //Initialize vm scope with variable `x`
         let mut exec_scopes = ExecutionScopes::new();
         exec_scopes.assign_or_update_variable("x", any_box!(bigint!(123890i32)));
-        //Create hint data
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), HashMap::new());
+
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, HashMap::new(), hint_code, exec_scopes_proxy),
             Ok(())
         );
 
         //Check hint memory insert
         //memory[ap] = to_felt_or_relocatable(x == 0)
-        assert_eq!(
-            vm.memory.get(&vm.run_context.get_ap()),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0i32))))
-        );
+        check_memory!(&vm.memory, ((1, 15), 0));
     }
 
     #[test]
@@ -697,23 +392,16 @@ mod tests {
         let mut vm = vm_with_range_check!();
 
         //Initialize memory
-        for _ in 0..2 {
-            vm.segments.add(&mut vm.memory, None);
-        }
+        add_segments!(vm, 2);
 
         //Initialize ap
         vm.run_context.ap = 15;
 
         //Skip `x` assignment
-        // exec_scopes
-        //     .assign_or_update_variable("x", bigint!(123890)));
-        //Create hint data
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), HashMap::new());
+
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, HashMap::new(), hint_code),
             Err(VirtualMachineError::VariableNotInScopeError(
                 "x".to_string()
             ))
@@ -734,14 +422,10 @@ mod tests {
         //Initialize vm scope with variable `x`
         let mut exec_scopes = ExecutionScopes::new();
         exec_scopes.assign_or_update_variable("x", any_box!(bigint!(0)));
-        //Create hint data
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), HashMap::new());
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, HashMap::new(), hint_code, exec_scopes_proxy),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     vm.run_context.get_ap(),
@@ -765,14 +449,10 @@ mod tests {
                 b"52621538839140286024584685587354966255185961783273479086367"
             )),
         );
-        //Create hint data
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), HashMap::new());
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, HashMap::new(), hint_code, exec_scopes_proxy),
             Ok(())
         );
 
@@ -797,17 +477,10 @@ mod tests {
     fn is_zero_assign_scope_variables_scope_error() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P\nfrom starkware.python.math_utils import div_mod\n\nvalue = x_inv = div_mod(1, x, SECP_P)";
         let mut vm = vm_with_range_check!();
-
         //Skip `x` assignment
-        // exec_scopes
-        //     .assign_or_update_variable("x", bigint_str!(b"52621538839140286024584685587354966255185961783273479086367")));
-        //Create hint data
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), HashMap::new());
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, HashMap::new(), hint_code),
             Err(VirtualMachineError::VariableNotInScopeError(
                 "x".to_string()
             ))

--- a/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
@@ -177,10 +177,7 @@ mod tests {
         //Initialize run_context
         run_context!(vm, 0, 9, 9);
         //Create hint data
-        let ids_data = HashMap::from([
-            ("val".to_string(), HintReference::new_simple(-5)),
-            ("q".to_string(), HintReference::new_simple(0)),
-        ]);
+        let ids_data = non_continuous_ids_data![("val", -5), ("q", 0)];
         vm.memory = memory![((1, 4), 0), ((1, 5), 0), ((1, 6), 150)];
         //Execute the hint
         assert_eq!(

--- a/src/hint_processor/builtin_hint_processor/secp/signature.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/signature.rs
@@ -77,6 +77,7 @@ pub fn get_point_from_x(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::any_box;
     use crate::hint_processor::proxies::exec_scopes_proxy::get_exec_scopes_proxy;
     use crate::{
         bigint, bigint_str,
@@ -89,6 +90,7 @@ mod tests {
     };
     use num_bigint::BigInt;
     use num_bigint::Sign;
+    use std::any::Any;
 
     #[test]
     fn safe_div_ok() {
@@ -103,10 +105,7 @@ mod tests {
             ((1, 5), 1)
         ];
         vm.run_context.fp = 3;
-        let ids_data = HashMap::from([
-            ("a".to_string(), HintReference::new_simple(-3)),
-            ("b".to_string(), HintReference::new_simple(0)),
-        ]);
+        let ids_data = non_continuous_ids_data![("a", -3), ("b", 0)];
         let mut exec_scopes = ExecutionScopes::new();
         let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
@@ -124,11 +123,8 @@ mod tests {
 
     #[test]
     fn safe_div_fail() {
-        let mut exec_scopes = ExecutionScopes::new();
+        let mut exec_scopes = scope![("a", bigint!(0)), ("b", bigint!(1)), ("res", bigint!(1))];
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        exec_scopes_proxy.insert_value("a", bigint!(0_usize));
-        exec_scopes_proxy.insert_value("b", bigint!(1_usize));
-        exec_scopes_proxy.insert_value("res", bigint!(1_usize));
         assert_eq!(Err(VirtualMachineError::SafeDivFail(bigint!(1_usize), bigint_str!(b"115792089237316195423570985008687907852837564279074904382605163141518161494337"))), div_mod_n_safe_div(exec_scopes_proxy));
     }
 
@@ -142,10 +138,7 @@ mod tests {
             ((1, 3), 2147483647)
         ];
         vm.run_context.fp = 1;
-        let ids_data = HashMap::from([
-            ("v".to_string(), HintReference::new_simple(-1)),
-            ("x_cube".to_string(), HintReference::new_simple(0)),
-        ]);
+        let ids_data = non_continuous_ids_data![("v", -1), ("x_cube", 0)];
         let vm_proxy = &mut get_vm_proxy(&mut vm);
         assert!(get_point_from_x(
             vm_proxy,
@@ -180,11 +173,14 @@ mod tests {
             ),
             Ok(())
         );
-        assert_eq!(
-            exec_scopes_proxy.get_int_ref("value"),
-            Ok(&bigint_str!(
-                b"94274691440067846579164151740284923997007081248613730142069408045642476712539"
-            ))
+        check_scope!(
+            exec_scopes_proxy,
+            [(
+                "value",
+                bigint_str!(
+            b"94274691440067846579164151740284923997007081248613730142069408045642476712539"
+        )
+            )]
         );
     }
 }

--- a/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
@@ -312,6 +312,8 @@ pub fn squash_dict(
 mod tests {
     use crate::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::HintProcessorData;
     use crate::hint_processor::proxies::vm_proxy::get_vm_proxy;
+    use crate::vm::errors::memory_errors::MemoryError;
+    use crate::vm::vm_memory::memory::Memory;
     use std::any::Any;
 
     use super::*;
@@ -322,7 +324,7 @@ mod tests {
     use crate::utils::test_utils::*;
     use crate::vm::runners::builtin_runner::RangeCheckBuiltinRunner;
     use crate::vm::vm_core::VirtualMachine;
-    use crate::{any_box, bigint};
+    use crate::{any_box, bigint, bigint_str};
     use num_bigint::Sign;
 
     //Hint code as consts
@@ -347,49 +349,34 @@ mod tests {
         access_indices.insert(bigint!(5), current_accessed_indices);
         //Create vm
         let mut vm = vm!();
-        for _ in 0..3 {
-            vm.segments.add(&mut vm.memory, None);
-        }
         //Store scope variables
-        let mut exec_scopes = ExecutionScopes::new();
-        exec_scopes.assign_or_update_variable("access_indices", any_box!(access_indices));
-        exec_scopes.assign_or_update_variable("key", any_box!(bigint!(5)));
+        let mut exec_scopes = scope![("access_indices", access_indices), ("key", bigint!(5))];
         //Initialize fp
         vm.run_context.fp = 1;
         //Insert ids into memory (range_check_ptr)
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 0)),
-                &MaybeRelocatable::from((2, 0)),
-            )
-            .unwrap();
+        vm.memory = memory![((1, 0), (2, 0))];
+        add_segments!(vm, 1);
         //Create ids_data
         let ids_data = ids_data!["range_check_ptr"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
             Ok(())
         );
         //Check scope variables
-        //Prepare expected data
-        let current_access_indices_scope = exec_scopes_proxy
-            .get_list("current_access_indices")
-            .unwrap();
-        assert_eq!(
-            current_access_indices_scope,
-            vec![bigint!(10), bigint!(9), bigint!(7)]
+        check_scope!(
+            exec_scopes_proxy,
+            [
+                (
+                    "current_access_indices",
+                    vec![bigint!(10), bigint!(9), bigint!(7)]
+                ),
+                ("current_access_index", bigint!(3))
+            ]
         );
-        let current_access_index = exec_scopes_proxy.get_int("current_access_index").unwrap();
-        assert_eq!(current_access_index, bigint!(3));
         //Check that current_access_index is now at range_check_ptr
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 0))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(3))))
-        );
+        check_memory![vm.memory, ((2, 0), 3)];
     }
 
     #[test]
@@ -402,31 +389,18 @@ mod tests {
         access_indices.insert(bigint!(5), current_accessed_indices);
         //Create vm
         let mut vm = vm!();
-        for _ in 0..3 {
-            vm.segments.add(&mut vm.memory, None);
-        }
         //Store scope variables
-        let mut exec_scopes = ExecutionScopes::new();
-        exec_scopes.assign_or_update_variable("access_indices", any_box!(access_indices));
-        exec_scopes.assign_or_update_variable("key", any_box!(bigint!(5)));
+        let mut exec_scopes = scope![("access_indices", access_indices), ("key", bigint!(5))];
         //Initialize fp
         vm.run_context.fp = 1;
         //Insert ids into memory (range_check_ptr)
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 0)),
-                &MaybeRelocatable::from((2, 0)),
-            )
-            .unwrap();
+        vm.memory = memory![((1, 0), (2, 0))];
         //Create ids_data
         let ids_data = ids_data!["range_check_ptr"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
             Err(VirtualMachineError::EmptyCurrentAccessIndices)
         );
     }
@@ -437,27 +411,15 @@ mod tests {
         //No scope variables
         //Create vm
         let mut vm = vm!();
-        for _ in 0..3 {
-            vm.segments.add(&mut vm.memory, None);
-        }
         //Initialize fp
         vm.run_context.fp = 1;
         //Insert ids into memory (range_check_ptr)
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 0)),
-                &MaybeRelocatable::from((2, 0)),
-            )
-            .unwrap();
-        //Create ids
+        vm.memory = memory![((1, 0), (2, 0))];
         //Create ids_data
         let ids_data = ids_data!["range_check_ptr"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::VariableNotInScopeError(String::from(
                 "key"
             )))
@@ -467,152 +429,109 @@ mod tests {
     #[test]
     fn should_skip_loop_valid_empty_current_access_indices() {
         let hint_code = SQUASH_DICT_INNER_SKIP_LOOP;
-        //Prepare scope variables
-        let current_access_indices: Box<dyn Any> = Box::new(Vec::<BigInt>::new());
         //Create vm
         let mut vm = vm!();
-        for _ in 0..2 {
-            vm.segments.add(&mut vm.memory, None);
-        }
+        add_segments!(vm, 2);
         //Store scope variables
-        let mut exec_scopes = ExecutionScopes::new();
-        exec_scopes.assign_or_update_variable("current_access_indices", current_access_indices);
+        let mut exec_scopes = scope![("current_access_indices", Vec::<BigInt>::new())];
         //Initialize fp
         vm.run_context.fp = 1;
         //Create ids_data
         let ids_data = ids_data!["should_skip_loop"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
             Ok(())
         );
         //Check the value of ids.should_skip_loop
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 0))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(1))))
-        );
+        check_memory![vm.memory, ((1, 0), 1)];
     }
 
     #[test]
     fn should_skip_loop_valid_non_empty_current_access_indices() {
         let hint_code = SQUASH_DICT_INNER_SKIP_LOOP;
-        //Prepare scope variables
-        let current_access_indices: Box<dyn Any> = Box::new(vec![bigint!(4), bigint!(7)]);
         //Create vm
         let mut vm = vm!();
-        for _ in 0..2 {
-            vm.segments.add(&mut vm.memory, None);
-        }
+        add_segments!(vm, 2);
         //Store scope variables
-        let mut exec_scopes = ExecutionScopes::new();
-        exec_scopes.assign_or_update_variable("current_access_indices", current_access_indices);
+        let mut exec_scopes = scope![("current_access_indices", vec![bigint!(4), bigint!(7)])];
         //Initialize fp
         vm.run_context.fp = 1;
         //Create ids_data
         let ids_data = ids_data!["should_skip_loop"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
             Ok(())
         );
         //Check the value of ids.should_skip_loop
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 0))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
+        check_memory![vm.memory, ((1, 0), 0)];
     }
 
     #[test]
     fn squash_dict_inner_check_access_index_valid() {
         let hint_code = SQUASH_DICT_INNER_CHECK_ACCESS_INDEX;
-        //Prepare scope variables
-        let current_access_indices: Box<dyn Any> =
-            Box::new(vec![bigint!(10), bigint!(9), bigint!(7), bigint!(5)]);
-        let current_access_index: Box<dyn Any> = Box::new(bigint!(1));
         //Create vm
         let mut vm = vm!();
-        for _ in 0..3 {
-            vm.segments.add(&mut vm.memory, None);
-        }
+        add_segments!(vm, 2);
         //Store scope variables
-        let mut exec_scopes = ExecutionScopes::new();
-        exec_scopes.assign_or_update_variable("current_access_indices", current_access_indices);
-        exec_scopes.assign_or_update_variable("current_access_index", current_access_index);
+        let mut exec_scopes = scope![
+            (
+                "current_access_indices",
+                vec![bigint!(10), bigint!(9), bigint!(7), bigint!(5)]
+            ),
+            ("current_access_index", bigint!(1))
+        ];
         //Initialize fp
         vm.run_context.fp = 1;
         //Create ids_data
         let ids_data = ids_data!["loop_temps"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
             Ok(())
         );
         //Check scope variables
-        let current_access_indices_scope = exec_scopes_proxy
-            .get_list("current_access_indices")
-            .unwrap();
-        let new_access_index = exec_scopes_proxy.get_int("new_access_index").unwrap();
-        let current_access_index = exec_scopes_proxy.get_int("current_access_index").unwrap();
-        assert_eq!(
-            current_access_indices_scope,
-            vec![bigint!(10), bigint!(9), bigint!(7)]
+        check_scope!(
+            exec_scopes_proxy,
+            [
+                (
+                    "current_access_indices",
+                    vec![bigint!(10), bigint!(9), bigint!(7)]
+                ),
+                ("new_access_index", bigint!(5)),
+                ("current_access_index", bigint!(5))
+            ]
         );
-        assert_eq!(current_access_index, bigint!(5));
-        assert_eq!(new_access_index, bigint!(5));
         //Check the value of loop_temps.index_delta_minus_1
         //new_index - current_index -1
         //5 - 1 - 1 = 3
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 0))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(3))))
-        );
+        check_memory![vm.memory, ((1, 0), 3)];
     }
 
     #[test]
     fn squash_dict_inner_check_access_current_access_addr_empty() {
         let hint_code = SQUASH_DICT_INNER_CHECK_ACCESS_INDEX;
-        //Prepare scope variables
-        let current_access_indices: Box<dyn Any> = Box::new(Vec::<BigInt>::new());
-        let current_access_index: Box<dyn Any> = Box::new(bigint!(1));
         //Create vm
         let mut vm = vm!();
-        for _ in 0..3 {
-            vm.segments.add(&mut vm.memory, None);
-        }
         //Store scope variables
-        let mut exec_scopes = ExecutionScopes::new();
-        exec_scopes.assign_or_update_variable("current_access_indices", current_access_indices);
-        exec_scopes.assign_or_update_variable("current_access_index", current_access_index);
+        let mut exec_scopes = scope![
+            ("current_access_indices", Vec::<BigInt>::new()),
+            ("current_access_index", bigint!(1))
+        ];
         //Initialize fp
         vm.run_context.fp = 1;
         //Insert ids into memory (loop_temps)
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 0)),
-                &MaybeRelocatable::from((2, 0)),
-            )
-            .unwrap();
+        vm.memory = memory![((1, 0), (2, 0))];
         //Create ids_data
         let ids_data = ids_data!["loop_temps"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
             Err(VirtualMachineError::EmptyCurrentAccessIndices)
         );
     }
@@ -620,88 +539,59 @@ mod tests {
     #[test]
     fn should_continue_loop_valid_non_empty_current_access_indices() {
         let hint_code = SQUASH_DICT_INNER_CONTINUE_LOOP;
-        //Prepare scope variables
-        let current_access_indices: Box<dyn Any> = Box::new(vec![bigint!(4), bigint!(7)]);
         //Create vm
         let mut vm = vm!();
-        for _ in 0..3 {
-            vm.segments.add(&mut vm.memory, None);
-        }
+        add_segments!(vm, 2);
         //Store scope variables
-        let mut exec_scopes = ExecutionScopes::new();
-        exec_scopes.assign_or_update_variable("current_access_indices", current_access_indices);
+        let mut exec_scopes = scope![("current_access_indices", vec![bigint!(4), bigint!(7)])];
         //Initialize fp
         vm.run_context.fp = 1;
         //Create ids_data
         let ids_data = ids_data!["loop_temps"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
             Ok(())
         );
         //Check the value of ids.loop_temps.should_continue (loop_temps + 3)
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 3))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(1))))
-        );
+        check_memory![vm.memory, ((1, 3), 1)];
     }
 
     #[test]
     fn should_continue_loop_valid_empty_current_access_indices() {
         let hint_code = SQUASH_DICT_INNER_CONTINUE_LOOP;
-        //Prepare scope variables
-        let current_access_indices: Box<dyn Any> = Box::new(Vec::<BigInt>::new());
         //Create vm
         let mut vm = vm!();
-        for _ in 0..3 {
-            vm.segments.add(&mut vm.memory, None);
-        }
+        add_segments!(vm, 2);
         //Store scope variables
-        let mut exec_scopes = ExecutionScopes::new();
-        exec_scopes.assign_or_update_variable("current_access_indices", current_access_indices);
+        let mut exec_scopes = scope![("current_access_indices", Vec::<BigInt>::new())];
         //Initialize fp
         vm.run_context.fp = 1;
         //Create ids_data
         let ids_data = ids_data!["loop_temps"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
             Ok(())
         );
         //Check the value of ids.loop_temps.should_continue (loop_temps + 3)
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 3))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
-        );
+        check_memory![vm.memory, ((1, 3), 0)];
     }
 
     #[test]
     fn assert_current_indices_len_is_empty() {
         let hint_code = SQUASH_DICT_INNER_ASSERT_LEN;
-        //Prepare scope variables
-        let current_access_indices: Box<dyn Any> = Box::new(Vec::<BigInt>::new());
         //Create vm
         let mut vm = vm!();
         //Store scope variables
-        let mut exec_scopes = ExecutionScopes::new();
-        exec_scopes.assign_or_update_variable("current_access_indices", current_access_indices);
-        //Create hint_data
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), HashMap::new());
+        let mut exec_scopes = scope![("current_access_indices", Vec::<BigInt>::new())];
         //Execute the hint
         //Hint should produce an error if assertion fails
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, HashMap::new(), hint_code, exec_scopes_proxy),
             Ok(())
         );
     }
@@ -709,22 +599,15 @@ mod tests {
     #[test]
     fn assert_current_indices_len_is_empty_not() {
         let hint_code = SQUASH_DICT_INNER_ASSERT_LEN;
-        //Prepare scope variables
-        let current_access_indices: Box<dyn Any> = Box::new(vec![bigint!(29)]);
         //Create vm
         let mut vm = vm!();
         //Store scope variables
-        let mut exec_scopes = ExecutionScopes::new();
-        exec_scopes.assign_or_update_variable("current_access_indices", current_access_indices);
-        //Create hint_data
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), HashMap::new());
+        let mut exec_scopes = scope![("current_access_indices", vec![bigint!(29)])];
         //Execute the hint
         //Hint should produce an error if assertion fails
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, HashMap::new(), hint_code, exec_scopes_proxy),
             Err(VirtualMachineError::CurrentAccessIndicesNotEmpty)
         );
     }
@@ -738,32 +621,19 @@ mod tests {
         access_indices.insert(bigint!(5), current_accessed_indices);
         //Create vm
         let mut vm = vm!();
-        for _ in 0..3 {
-            vm.segments.add(&mut vm.memory, None);
-        }
         //Store scope variables
-        let mut exec_scopes = ExecutionScopes::new();
-        exec_scopes.assign_or_update_variable("access_indices", any_box!(access_indices));
-        exec_scopes.assign_or_update_variable("key", any_box!(bigint!(5)));
+        let mut exec_scopes = scope![("access_indices", access_indices), ("key", bigint!(5))];
         //Initialize fp
         vm.run_context.fp = 1;
         //Insert ids into memory (n_used_accesses)
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 0)),
-                &MaybeRelocatable::from(bigint!(4)),
-            )
-            .unwrap();
+        vm.memory = memory![((1, 0), 4)];
         //Create hint_data
         let ids_data = ids_data!["n_used_accesses"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
         //Hint would fail is assertion fails
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
             Ok(())
         );
     }
@@ -777,31 +647,18 @@ mod tests {
         access_indices.insert(bigint!(5), current_accessed_indices);
         //Create vm
         let mut vm = vm!();
-        for _ in 0..3 {
-            vm.segments.add(&mut vm.memory, None);
-        }
         //Store scope variables
-        let mut exec_scopes = ExecutionScopes::new();
-        exec_scopes.assign_or_update_variable("access_indices", any_box!(access_indices));
-        exec_scopes.assign_or_update_variable("key", any_box!(bigint!(5)));
+        let mut exec_scopes = scope![("access_indices", access_indices), ("key", bigint!(5))];
         //Initialize fp
         vm.run_context.fp = 1;
         //Insert ids into memory (n_used_accesses)
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 0)),
-                &MaybeRelocatable::from(bigint!(5)),
-            )
-            .unwrap();
+        vm.memory = memory![((1, 0), 5)];
         //Create hint_data
         let ids_data = ids_data!["n_used_accesses"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
             Err(VirtualMachineError::NumUsedAccessesAssertFail(
                 bigint!(5),
                 4,
@@ -819,31 +676,18 @@ mod tests {
         access_indices.insert(bigint!(5), current_accessed_indices);
         //Create vm
         let mut vm = vm!();
-        for _ in 0..3 {
-            vm.segments.add(&mut vm.memory, None);
-        }
         //Store scope variables
-        let mut exec_scopes = ExecutionScopes::new();
-        exec_scopes.assign_or_update_variable("access_indices", any_box!(access_indices));
-        exec_scopes.assign_or_update_variable("key", any_box!(bigint!(5)));
+        let mut exec_scopes = scope![("access_indices", access_indices), ("key", bigint!(5))];
         //Initialize fp
         vm.run_context.fp = 1;
         //Insert ids into memory (n_used_accesses)
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 0)),
-                &MaybeRelocatable::from((1, 2)),
-            )
-            .unwrap();
+        vm.memory = memory![((1, 0), (1, 2))];
         //Create hint_data
         let ids_data = ids_data!["n_used_accesses"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from((1, 0))
             ))
@@ -853,21 +697,14 @@ mod tests {
     #[test]
     fn squash_dict_assert_len_keys_empty() {
         let hint_code = SQUASH_DICT_INNER_LEN_KEYS;
-        //Prepare scope variables
-        let keys: Box<dyn Any> = Box::new(Vec::<BigInt>::new());
         //Create vm
         let mut vm = vm!();
         //Store scope variables
-        let mut exec_scopes = ExecutionScopes::new();
-        exec_scopes.assign_or_update_variable("keys", keys);
-        //Create hint_data
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), HashMap::new());
+        let mut exec_scopes = scope![("keys", Vec::<BigInt>::new())];
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, HashMap::new(), hint_code, exec_scopes_proxy),
             Ok(())
         );
     }
@@ -875,21 +712,14 @@ mod tests {
     #[test]
     fn squash_dict_assert_len_keys_not_empty() {
         let hint_code = SQUASH_DICT_INNER_LEN_KEYS;
-        //Prepare scope variables
-        let keys: Box<dyn Any> = Box::new(vec![bigint!(3)]);
         //Create vm
         let mut vm = vm!();
         //Store scope variables
-        let mut exec_scopes = ExecutionScopes::new();
-        exec_scopes.assign_or_update_variable("keys", keys);
-        //Create hint_data
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), HashMap::new());
+        let mut exec_scopes = scope![("keys", vec![bigint!(3)])];
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, HashMap::new(), hint_code, exec_scopes_proxy),
             Err(VirtualMachineError::KeysNotEmpty)
         );
     }
@@ -899,13 +729,9 @@ mod tests {
         let hint_code = SQUASH_DICT_INNER_LEN_KEYS;
         //Create vm
         let mut vm = vm!();
-        //Create hint_data
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), HashMap::new());
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, HashMap::new(), hint_code),
             Err(VirtualMachineError::VariableNotInScopeError(String::from(
                 "keys"
             )))
@@ -915,65 +741,45 @@ mod tests {
     #[test]
     fn squash_dict_inner_next_key_keys_non_empty() {
         let hint_code = SQUASH_DICT_INNER_NEXT_KEY;
-        //Prepare scope variables
-        let keys: Box<dyn Any> = Box::new(vec![bigint!(1), bigint!(3)]);
         //Create vm
         let mut vm = vm!();
-        for _ in 0..2 {
-            vm.segments.add(&mut vm.memory, None);
-        }
+        add_segments!(vm, 2);
         //Store scope variables
-        let mut exec_scopes = ExecutionScopes::new();
-        exec_scopes.assign_or_update_variable("keys", keys);
+        let mut exec_scopes = scope![("keys", vec![bigint!(1), bigint!(3)])];
         //Initialize fp
         vm.run_context.fp = 1;
         //Create hint_data
         let ids_data = ids_data!["next_key"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
             Ok(())
         );
         //Check the value of ids.next_key
-        assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((1, 0))),
-            Ok(Some(&MaybeRelocatable::from(bigint!(3))))
-        );
+        check_memory![vm.memory, ((1, 0), 3)];
         //Check local variables
-        let keys = exec_scopes_proxy.get_list_ref("keys").unwrap();
-        let key = exec_scopes_proxy.get_int_ref("key").unwrap();
-        assert_eq!(key, &bigint!(3));
-        assert_eq!(keys, &vec![bigint!(1)]);
+        check_scope!(
+            exec_scopes_proxy,
+            [("keys", vec![bigint!(1)]), ("key", bigint!(3))]
+        );
     }
 
     #[test]
     fn squash_dict_inner_next_key_keys_empty() {
         let hint_code = SQUASH_DICT_INNER_NEXT_KEY;
-        //Prepare scope variables
-        let keys: Box<dyn Any> = Box::new(Vec::<BigInt>::new());
         //Create vm
         let mut vm = vm!();
-        for _ in 0..2 {
-            vm.segments.add(&mut vm.memory, None);
-        }
         //Store scope variables
-        let mut exec_scopes = ExecutionScopes::new();
-        exec_scopes.assign_or_update_variable("keys", keys);
+        let mut exec_scopes = scope![("keys", Vec::<BigInt>::new())];
         //Initialize fp
         vm.run_context.fp = 1;
         //Create hint_data
         let ids_data = ids_data!["next_key"];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
             Err(VirtualMachineError::EmptyKeys)
         );
     }
@@ -984,77 +790,20 @@ mod tests {
         let hint_code = SQUASH_DICT;
         //Create vm
         let mut vm = vm_with_range_check!();
-        for _ in 0..3 {
-            vm.segments.add(&mut vm.memory, None);
-        }
         //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
-        //ids.n_accesses
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 4)),
-                &MaybeRelocatable::from(bigint!(2)),
-            )
-            .unwrap();
-        //ids.n_ptr_diff
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 3)),
-                &MaybeRelocatable::from(bigint!(6)),
-            )
-            .unwrap();
-        //Leave gaps for ids.big_keys (0,1) and ids.first_key (0,2)
-        //ids.dict_accesses
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 0)),
-                &MaybeRelocatable::from((2, 0)),
-            )
-            .unwrap();
-        //Points to the first dict_access
-        //dict_accesses[0].key
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 0)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-        //dict_accesses[0].prev_value
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 1)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-        //dict_accesses[0].next_value
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 2)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-        //dict_accesses[1].key
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 3)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-        //dict_accesses[1].prev_value
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 4)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-        //dict_accesses[1].next_value
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 5)),
-                &MaybeRelocatable::from(bigint!(2)),
-            )
-            .unwrap();
+        vm.memory = memory![
+            ((1, 0), (2, 0)),
+            ((1, 3), 6),
+            ((1, 4), 2),
+            ((2, 0), 1),
+            ((2, 1), 1),
+            ((2, 2), 1),
+            ((2, 3), 1),
+            ((2, 4), 1),
+            ((2, 5), 2)
+        ];
         //Create hint_data
         let ids_data = ids_data![
             "dict_accesses",
@@ -1063,39 +812,27 @@ mod tests {
             "ptr_diff",
             "n_accesses"
         ];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         let mut exec_scopes = ExecutionScopes::new();
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
             Ok(())
         );
         //Check scope variables
-        let access_indices = get_access_indices(exec_scopes_proxy).unwrap();
-        assert_eq!(
-            access_indices,
-            &HashMap::from([(bigint!(1), vec![bigint!(0), bigint!(1)])])
+        check_scope!(
+            exec_scopes_proxy,
+            [
+                (
+                    "access_indices",
+                    HashMap::from([(bigint!(1), vec![bigint!(0), bigint!(1)])])
+                ),
+                ("keys", Vec::<BigInt>::new()),
+                ("key", bigint!(1))
+            ]
         );
-        let keys = exec_scopes_proxy.get_list("keys").unwrap();
-        assert_eq!(keys, Vec::<BigInt>::new());
-        let key = exec_scopes_proxy.get_int("key").unwrap();
-        assert_eq!(key, bigint!(1));
         //Check ids variables
-        let big_keys = vm
-            .memory
-            .get(&MaybeRelocatable::from((1, 1)))
-            .unwrap()
-            .unwrap();
-        assert_eq!(big_keys, &MaybeRelocatable::from(bigint!(0)));
-        let first_key = vm
-            .memory
-            .get(&MaybeRelocatable::from((1, 2)))
-            .unwrap()
-            .unwrap();
-        assert_eq!(first_key, &MaybeRelocatable::from(bigint!(1)));
+        check_memory![vm.memory, ((1, 1), 0), ((1, 2), 1)];
     }
 
     #[test]
@@ -1104,120 +841,26 @@ mod tests {
         let hint_code = SQUASH_DICT;
         //Create vm
         let mut vm = vm_with_range_check!();
-        for _ in 0..3 {
-            vm.segments.add(&mut vm.memory, None);
-        }
         //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
-        //ids.n_accesses
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 4)),
-                &MaybeRelocatable::from(bigint!(4)),
-            )
-            .unwrap();
-        //ids.n_ptr_diff
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 3)),
-                &MaybeRelocatable::from(bigint!(6)),
-            )
-            .unwrap();
-        //Leave gaps for ids.big_keys (0,1) and ids.first_key (0,2)
-        //ids.dict_accesses
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 0)),
-                &MaybeRelocatable::from((2, 0)),
-            )
-            .unwrap();
-        //Points to the first dict_access
-        //dict_accesses[0].key
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 0)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-        //dict_accesses[0].prev_value
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 1)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-        //dict_accesses[0].next_value
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 2)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-        //dict_accesses[1].key
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 3)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-        //dict_accesses[1].prev_value
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 4)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-        //dict_accesses[1].next_value
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 5)),
-                &MaybeRelocatable::from(bigint!(2)),
-            )
-            .unwrap();
-        //dict_accesses[2].key
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 6)),
-                &MaybeRelocatable::from(bigint!(2)),
-            )
-            .unwrap();
-        //dict_accesses[2].prev_value
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 7)),
-                &MaybeRelocatable::from(bigint!(10)),
-            )
-            .unwrap();
-        //dict_accesses[2].next_value
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 8)),
-                &MaybeRelocatable::from(bigint!(10)),
-            )
-            .unwrap();
-        //dict_accesses[3].key
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 9)),
-                &MaybeRelocatable::from(bigint!(2)),
-            )
-            .unwrap();
-        //dict_accesses[3].prev_value
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 10)),
-                &MaybeRelocatable::from(bigint!(10)),
-            )
-            .unwrap();
-        //dict_accesses[3].next_value
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 11)),
-                &MaybeRelocatable::from(bigint!(20)),
-            )
-            .unwrap();
-
+        vm.memory = memory![
+            ((1, 0), (2, 0)),
+            ((1, 3), 6),
+            ((1, 4), 4),
+            ((2, 0), 1),
+            ((2, 1), 1),
+            ((2, 2), 1),
+            ((2, 3), 1),
+            ((2, 4), 1),
+            ((2, 5), 2),
+            ((2, 6), 2),
+            ((2, 7), 10),
+            ((2, 8), 10),
+            ((2, 9), 2),
+            ((2, 10), 10),
+            ((2, 11), 20)
+        ];
         //Create hint_data
         let ids_data = ids_data![
             "dict_accesses",
@@ -1226,42 +869,32 @@ mod tests {
             "ptr_diff",
             "n_accesses"
         ];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         let mut exec_scopes = ExecutionScopes::new();
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
             Ok(())
         );
         //Check scope variables
-        let access_indices = get_access_indices(exec_scopes_proxy).unwrap();
-        assert_eq!(
-            access_indices,
-            &HashMap::from([
-                (bigint!(1), vec![bigint!(0), bigint!(1)]),
-                (bigint!(2), vec![bigint!(2), bigint!(3)])
-            ])
+        check_scope!(
+            exec_scopes_proxy,
+            [
+                (
+                    "access_indices",
+                    HashMap::from([
+                        (bigint!(1), vec![bigint!(0), bigint!(1)]),
+                        (bigint!(2), vec![bigint!(2), bigint!(3)])
+                    ])
+                ),
+                ("keys", vec![bigint!(2)]),
+                ("key", bigint!(1))
+            ]
         );
         let keys = exec_scopes_proxy.get_list("keys").unwrap();
         assert_eq!(keys, vec![bigint!(2)]);
-        let key = exec_scopes_proxy.get_int("key").unwrap();
-        assert_eq!(key, bigint!(1));
         //Check ids variables
-        let big_keys = vm
-            .memory
-            .get(&MaybeRelocatable::from((1, 1)))
-            .unwrap()
-            .unwrap();
-        assert_eq!(big_keys, &MaybeRelocatable::from(bigint!(0)));
-        let first_key = vm
-            .memory
-            .get(&MaybeRelocatable::from((1, 2)))
-            .unwrap()
-            .unwrap();
-        assert_eq!(first_key, &MaybeRelocatable::from(bigint!(1)));
+        check_memory![vm.memory, ((1, 1), 0), ((1, 2), 1)];
     }
 
     #[test]
@@ -1270,83 +903,23 @@ mod tests {
         let hint_code = SQUASH_DICT;
         //Create vm
         let mut vm = vm_with_range_check!();
-        for _ in 0..3 {
-            vm.segments.add(&mut vm.memory, None);
-        }
         //Create scope variables
-        let mut exec_scopes = ExecutionScopes::new();
-        let max_size: Box<dyn Any> = Box::new(bigint!(12));
-        exec_scopes.assign_or_update_variable("__squash_dict_max_size", max_size);
+        let mut exec_scopes = scope![("__squash_dict_max_size", bigint!(12))];
         //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
-        //ids.n_accesses
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 4)),
-                &MaybeRelocatable::from(bigint!(2)),
-            )
-            .unwrap();
-        //ids.n_ptr_diff
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 3)),
-                &MaybeRelocatable::from(bigint!(6)),
-            )
-            .unwrap();
-        //Leave gaps for ids.big_keys (0,1) and ids.first_key (0,2)
-        //ids.dict_accesses
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 0)),
-                &MaybeRelocatable::from((2, 0)),
-            )
-            .unwrap();
-        //Points to the first dict_access
-        //dict_accesses[0].key
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 0)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-        //dict_accesses[0].prev_value
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 1)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-        //dict_accesses[0].next_value
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 2)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-        //dict_accesses[1].key
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 3)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-        //dict_accesses[1].prev_value
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 4)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-        //dict_accesses[1].next_value
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 5)),
-                &MaybeRelocatable::from(bigint!(2)),
-            )
-            .unwrap();
-
-        //Create hint_data
+        vm.memory = memory![
+            ((1, 0), (2, 0)),
+            ((1, 3), 6),
+            ((1, 4), 2),
+            ((2, 0), 1),
+            ((2, 1), 1),
+            ((2, 2), 1),
+            ((2, 3), 1),
+            ((2, 4), 1),
+            ((2, 5), 2)
+        ];
+        //Create ids_data
         let ids_data = ids_data![
             "dict_accesses",
             "big_keys",
@@ -1354,38 +927,26 @@ mod tests {
             "ptr_diff",
             "n_accesses"
         ];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
             Ok(())
         );
         //Check scope variables
-        let access_indices = get_access_indices(exec_scopes_proxy).unwrap();
-        assert_eq!(
-            access_indices,
-            &HashMap::from([(bigint!(1), vec![bigint!(0), bigint!(1)])])
+        check_scope!(
+            exec_scopes_proxy,
+            [
+                (
+                    "access_indices",
+                    HashMap::from([(bigint!(1), vec![bigint!(0), bigint!(1)])])
+                ),
+                ("keys", Vec::<BigInt>::new()),
+                ("key", bigint!(1))
+            ]
         );
-        let keys = exec_scopes_proxy.get_list("keys").unwrap();
-        assert_eq!(keys, Vec::<BigInt>::new());
-        let key = exec_scopes_proxy.get_int("key").unwrap();
-        assert_eq!(key, bigint!(1));
         //Check ids variables
-        let big_keys = vm
-            .memory
-            .get(&MaybeRelocatable::from((1, 1)))
-            .unwrap()
-            .unwrap();
-        assert_eq!(big_keys, &MaybeRelocatable::from(bigint!(0)));
-        let first_key = vm
-            .memory
-            .get(&MaybeRelocatable::from((1, 2)))
-            .unwrap()
-            .unwrap();
-        assert_eq!(first_key, &MaybeRelocatable::from(bigint!(1)));
+        check_memory![vm.memory, ((1, 1), 0), ((1, 2), 1)];
     }
 
     #[test]
@@ -1394,83 +955,23 @@ mod tests {
         let hint_code = SQUASH_DICT;
         //Create vm
         let mut vm = vm_with_range_check!();
-        for _ in 0..3 {
-            vm.segments.add(&mut vm.memory, None);
-        }
         //Create scope variables
-        let mut exec_scopes = ExecutionScopes::new();
-        let max_size: Box<dyn Any> = Box::new(bigint!(1));
-        exec_scopes.assign_or_update_variable("__squash_dict_max_size", max_size);
+        let mut exec_scopes = scope![("__squash_dict_max_size", bigint!(1))];
         //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
-        //ids.n_accesses
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 4)),
-                &MaybeRelocatable::from(bigint!(2)),
-            )
-            .unwrap();
-        //ids.n_ptr_diff
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 3)),
-                &MaybeRelocatable::from(bigint!(6)),
-            )
-            .unwrap();
-        //Leave gaps for ids.big_keys (0,1) and ids.first_key (0,2)
-        //ids.dict_accesses
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 0)),
-                &MaybeRelocatable::from((2, 0)),
-            )
-            .unwrap();
-        //Points to the first dict_access
-        //dict_accesses[0].key
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 0)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-        //dict_accesses[0].prev_value
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 1)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-        //dict_accesses[0].next_value
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 2)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-        //dict_accesses[1].key
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 3)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-        //dict_accesses[1].prev_value
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 4)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-        //dict_accesses[1].next_value
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 5)),
-                &MaybeRelocatable::from(bigint!(2)),
-            )
-            .unwrap();
-
-        //Create hint_data
+        vm.memory = memory![
+            ((1, 0), (2, 0)),
+            ((1, 3), 6),
+            ((1, 4), 2),
+            ((2, 0), 1),
+            ((2, 1), 1),
+            ((2, 2), 1),
+            ((2, 3), 1),
+            ((2, 4), 1),
+            ((2, 5), 2)
+        ];
+        //Create ids_data
         let ids_data = ids_data![
             "dict_accesses",
             "big_keys",
@@ -1478,13 +979,10 @@ mod tests {
             "ptr_diff",
             "n_accesses"
         ];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
             Err(VirtualMachineError::SquashDictMaxSizeExceeded(
                 bigint!(1),
                 bigint!(2)
@@ -1498,78 +996,20 @@ mod tests {
         let hint_code = SQUASH_DICT;
         //Create vm
         let mut vm = vm_with_range_check!();
-        for _ in 0..3 {
-            vm.segments.add(&mut vm.memory, None);
-        }
         //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
-        //ids.n_accesses
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 4)),
-                &MaybeRelocatable::from(bigint!(2)),
-            )
-            .unwrap();
-        //ids.n_ptr_diff
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 3)),
-                &MaybeRelocatable::from(bigint!(7)),
-            )
-            .unwrap();
-        //Leave gaps for ids.big_keys (0,1) and ids.first_key (0,2)
-        //ids.dict_accesses
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 0)),
-                &MaybeRelocatable::from((2, 0)),
-            )
-            .unwrap();
-        //Points to the first dict_access
-        //dict_accesses[0].key
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 0)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-        //dict_accesses[0].prev_value
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 1)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-        //dict_accesses[0].next_value
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 2)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-        //dict_accesses[1].key
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 3)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-        //dict_accesses[1].prev_value
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 4)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-        //dict_accesses[1].next_value
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 5)),
-                &MaybeRelocatable::from(bigint!(2)),
-            )
-            .unwrap();
-
+        vm.memory = memory![
+            ((1, 0), (2, 0)),
+            ((1, 3), 7),
+            ((1, 4), 2),
+            ((2, 0), 1),
+            ((2, 1), 1),
+            ((2, 2), 1),
+            ((2, 3), 1),
+            ((2, 4), 1),
+            ((2, 5), 2)
+        ];
         //Create hint_data
         let ids_data = ids_data![
             "dict_accesses",
@@ -1578,12 +1018,9 @@ mod tests {
             "ptr_diff",
             "n_accesses"
         ];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code),
             Err(VirtualMachineError::PtrDiffNotDivisibleByDictAccessSize)
         );
     }
@@ -1593,81 +1030,26 @@ mod tests {
         let hint_code = SQUASH_DICT;
         //Create vm
         let mut vm = vm_with_range_check!();
-        for _ in 0..3 {
-            vm.segments.add(&mut vm.memory, None);
-        }
         //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
-        //ids.n_accesses
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 4)),
-                &MaybeRelocatable::from(BigInt::new(
-                    Sign::Plus,
-                    vec![1, 0, 0, 0, 0, 0, 17, 134217728],
-                )),
-            )
-            .unwrap();
-        //ids.n_ptr_diff
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 3)),
-                &MaybeRelocatable::from(bigint!(6)),
-            )
-            .unwrap();
-        //Leave gaps for ids.big_keys (0,1) and ids.first_key (0,2)
-        //ids.dict_accesses
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 0)),
-                &MaybeRelocatable::from((2, 0)),
-            )
-            .unwrap();
-        //Points to the first dict_access
-        //dict_accesses[0].key
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 0)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-        //dict_accesses[0].prev_value
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 1)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-        //dict_accesses[0].next_value
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 2)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-        //dict_accesses[1].key
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 3)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-        //dict_accesses[1].prev_value
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 4)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-        //dict_accesses[1].next_value
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 5)),
-                &MaybeRelocatable::from(bigint!(2)),
-            )
-            .unwrap();
-
+        vm.memory = memory![
+            ((1, 0), (2, 0)),
+            ((1, 3), 6),
+            (
+                (1, 4),
+                (
+                    b"3618502761706184546546682988428055018603476541694452277432519575032261771265",
+                    10
+                )
+            ),
+            ((2, 0), 1),
+            ((2, 1), 1),
+            ((2, 2), 1),
+            ((2, 3), 1),
+            ((2, 4), 1),
+            ((2, 5), 2)
+        ];
         //Create hint_data
         let ids_data = ids_data![
             "dict_accesses",
@@ -1676,16 +1058,12 @@ mod tests {
             "ptr_diff",
             "n_accesses"
         ];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data)),
-            Err(VirtualMachineError::NAccessesTooBig(BigInt::new(
-                Sign::Plus,
-                vec![1, 0, 0, 0, 0, 0, 17, 134217728]
-            ),))
+            run_hint!(vm, ids_data, hint_code),
+            Err(VirtualMachineError::NAccessesTooBig(bigint_str!(
+                b"3618502761706184546546682988428055018603476541694452277432519575032261771265"
+            )))
         );
     }
 
@@ -1695,84 +1073,32 @@ mod tests {
         let hint_code = SQUASH_DICT;
         //Create vm
         let mut vm = vm_with_range_check!();
-        for _ in 0..3 {
-            vm.segments.add(&mut vm.memory, None);
-        }
         //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
-        //ids.n_accesses
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 4)),
-                &MaybeRelocatable::from(bigint!(2)),
-            )
-            .unwrap();
-        //ids.n_ptr_diff
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 3)),
-                &MaybeRelocatable::from(bigint!(6)),
-            )
-            .unwrap();
-        //Leave gaps for ids.big_keys (0,1) and ids.first_key (0,2)
-        //ids.dict_accesses
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((1, 0)),
-                &MaybeRelocatable::from((2, 0)),
-            )
-            .unwrap();
-        //Points to the first dict_access
-        //dict_accesses[0].key
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 0)),
-                &MaybeRelocatable::from(BigInt::new(
-                    Sign::Plus,
-                    vec![1, 0, 0, 0, 0, 0, 17, 134217727],
-                )),
-            )
-            .unwrap();
-        //dict_accesses[0].prev_value
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 1)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-        //dict_accesses[0].next_value
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 2)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-        //dict_accesses[1].key
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 3)),
-                &MaybeRelocatable::from(BigInt::new(
-                    Sign::Plus,
-                    vec![1, 0, 0, 0, 0, 0, 17, 134217727],
-                )),
-            )
-            .unwrap();
-        //dict_accesses[1].prev_value
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 4)),
-                &MaybeRelocatable::from(bigint!(1)),
-            )
-            .unwrap();
-        //dict_accesses[1].next_value
-        vm.memory
-            .insert(
-                &MaybeRelocatable::from((2, 5)),
-                &MaybeRelocatable::from(bigint!(2)),
-            )
-            .unwrap();
-
+        vm.memory = memory![
+            ((1, 0), (2, 0)),
+            ((1, 3), 6),
+            ((1, 4), 2),
+            (
+                (2, 0),
+                (
+                    b"3618502761706184546546682988428055018603476541694452277432519575032261771265",
+                    10
+                )
+            ),
+            ((2, 1), 1),
+            ((2, 2), 1),
+            (
+                (2, 3),
+                (
+                    b"3618502761706184546546682988428055018603476541694452277432519575032261771265",
+                    10
+                )
+            ),
+            ((2, 4), 1),
+            ((2, 5), 2)
+        ];
         //Create hint_data
         let ids_data = ids_data![
             "dict_accesses",
@@ -1781,50 +1107,29 @@ mod tests {
             "ptr_diff",
             "n_accesses"
         ];
-        let hint_data = HintProcessorData::new_default(hint_code.to_string(), ids_data);
         let mut exec_scopes = ExecutionScopes::new();
         //Execute the hint
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
             Ok(())
         );
         //Check scope variables
-        let access_indices = get_access_indices(exec_scopes_proxy).unwrap();
-        assert_eq!(
-            access_indices,
-            &HashMap::from([(
-                BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217727]),
-                vec![bigint!(0), bigint!(1)]
-            )])
-        );
-        let keys = exec_scopes_proxy.get_list("keys").unwrap();
-        assert_eq!(keys, Vec::<BigInt>::new());
-        let key = exec_scopes_proxy.get_int("key").unwrap();
-        assert_eq!(
-            key,
-            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217727])
-        );
+        check_scope!(exec_scopes_proxy, [("access_indices", HashMap::from([(
+           bigint_str!(b"3618502761706184546546682988428055018603476541694452277432519575032261771265"),
+            vec![bigint!(0), bigint!(1)]
+        )])), ("keys", Vec::<BigInt>::new()), ("key", bigint_str!(b"3618502761706184546546682988428055018603476541694452277432519575032261771265"))]);
         //Check ids variables
-        let big_keys = vm
-            .memory
-            .get(&MaybeRelocatable::from((1, 1)))
-            .unwrap()
-            .unwrap();
-        assert_eq!(big_keys, &MaybeRelocatable::from(bigint!(1)));
-        let first_key = vm
-            .memory
-            .get(&MaybeRelocatable::from((1, 2)))
-            .unwrap()
-            .unwrap();
-        assert_eq!(
-            first_key,
-            &MaybeRelocatable::from(BigInt::new(
-                Sign::Plus,
-                vec![1, 0, 0, 0, 0, 0, 17, 134217727]
-            ))
-        );
+        check_memory![
+            vm.memory,
+            ((1, 1), 1),
+            (
+                (1, 2),
+                (
+                    b"3618502761706184546546682988428055018603476541694452277432519575032261771265",
+                    10
+                )
+            )
+        ];
     }
 }

--- a/src/hint_processor/builtin_hint_processor/usort.rs
+++ b/src/hint_processor/builtin_hint_processor/usort.rs
@@ -165,23 +165,17 @@ mod tests {
 
     #[test]
     fn usort_out_of_range() {
-        let hint = "from collections import defaultdict\n\ninput_ptr = ids.input\ninput_len = int(ids.input_len)\nif __usort_max_size is not None:\n    assert input_len <= __usort_max_size, (\n        f\"usort() can only be used with input_len<={__usort_max_size}. \"\n        f\"Got: input_len={input_len}.\"\n    )\n\npositions_dict = defaultdict(list)\nfor i in range(input_len):\n    val = memory[input_ptr + i]\n    positions_dict[val].append(i)\n\noutput = sorted(positions_dict.keys())\nids.output_len = len(output)\nids.output = segments.gen_arg(output)\nids.multiplicities = segments.gen_arg([len(positions_dict[k]) for k in output])";
+        let hint_code = "from collections import defaultdict\n\ninput_ptr = ids.input\ninput_len = int(ids.input_len)\nif __usort_max_size is not None:\n    assert input_len <= __usort_max_size, (\n        f\"usort() can only be used with input_len<={__usort_max_size}. \"\n        f\"Got: input_len={input_len}.\"\n    )\n\npositions_dict = defaultdict(list)\nfor i in range(input_len):\n    val = memory[input_ptr + i]\n    positions_dict[val].append(i)\n\noutput = sorted(positions_dict.keys())\nids.output_len = len(output)\nids.output = segments.gen_arg(output)\nids.multiplicities = segments.gen_arg([len(positions_dict[k]) for k in output])";
         let mut vm = vm_with_range_check!();
-
         vm.run_context.fp = 2;
-
-        vm.segments.add(&mut vm.memory, None);
+        add_segments!(vm, 1);
         vm.memory = memory![((1, 0), (2, 1)), ((1, 1), 5)];
         //Create hint_data
         let ids_data = ids_data!["input", "input_len"];
-        let hint_data = HintProcessorData::new_default(hint.to_string(), ids_data);
-        let mut exec_scopes = ExecutionScopes::new();
-        exec_scopes.assign_or_update_variable("usort_max_size", any_box!(1_u64));
-        let vm_proxy = &mut get_vm_proxy(&mut vm);
+        let mut exec_scopes = scope![("usort_max_size", 1_u64)];
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
-        let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
+            run_hint!(vm, ids_data, hint_code, exec_scopes_proxy),
             Err(VirtualMachineError::UsortOutOfRange(1, bigint!(5)))
         );
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -279,6 +279,22 @@ pub mod test_utils {
         };
     }
     pub(crate) use add_dict_manager;
+
+    macro_rules! run_hint {
+        ($vm:expr, $ids_data:expr, $hint_code:expr, $exec_proxy:expr) => {{
+            let hint_data = HintProcessorData::new_default($hint_code.to_string(), $ids_data);
+            let vm_proxy = &mut get_vm_proxy(&mut $vm);
+            let hint_processor = BuiltinHintProcessor::new_empty();
+            hint_processor.execute_hint(vm_proxy, $exec_proxy, &any_box!(hint_data))
+        }};
+        ($vm:expr, $ids_data:expr, $hint_code:expr) => {{
+            let hint_data = HintProcessorData::new_default($hint_code.to_string(), $ids_data);
+            let vm_proxy = &mut get_vm_proxy(&mut $vm);
+            let hint_processor = BuiltinHintProcessor::new_empty();
+            hint_processor.execute_hint(vm_proxy, exec_scopes_proxy_ref!(), &any_box!(hint_data))
+        }};
+    }
+    pub(crate) use run_hint;
 }
 
 #[cfg(test)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -232,6 +232,19 @@ pub mod test_utils {
     }
     pub(crate) use ids_data;
 
+    macro_rules! non_continuous_ids_data {
+        ( $( ($name: expr, $offset:expr) ),* ) => {
+            {
+                let mut ids_data = HashMap::<String, HintReference>::new();
+                $(
+                    ids_data.insert(String::from($name), HintReference::new_simple($offset));
+                )*
+                ids_data
+            }
+        };
+    }
+    pub(crate) use non_continuous_ids_data;
+
     macro_rules! trace_check {
         ( $trace: expr, [ $( (($si_pc:expr, $off_pc:expr), ($si_ap:expr, $off_ap:expr), ($si_fp:expr, $off_fp:expr)) ),+ ] ) => {
             let mut index = -1;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -286,13 +286,6 @@ pub mod test_utils {
     }
     pub(crate) use exec_scopes_proxy_ref;
 
-    macro_rules! add_dict_manager {
-        ($es_proxy:expr, $dict:expr) => {
-            $es_proxy.insert_value("dict_manager", Rc::new(RefCell::new($dict)))
-        };
-    }
-    pub(crate) use add_dict_manager;
-
     macro_rules! run_hint {
         ($vm:expr, $ids_data:expr, $hint_code:expr, $exec_proxy:expr) => {{
             let hint_data = HintProcessorData::new_default($hint_code.to_string(), $ids_data);
@@ -378,6 +371,45 @@ pub mod test_utils {
         };
     }
     pub(crate) use check_dict_ptr;
+
+    macro_rules! dict_manager {
+        ($exec_scopes_proxy:expr, $tracker_num:expr, $( ($key:expr, $val:expr )),* ) => {
+            let mut tracker = DictTracker::new_empty(&relocatable!($tracker_num, 0));
+            $(
+            tracker.insert_value(&bigint!($key), &bigint!($val));
+            )*
+            let mut dict_manager = DictManager::new();
+            dict_manager.trackers.insert(2, tracker);
+            $exec_scopes_proxy.insert_value("dict_manager", Rc::new(RefCell::new(dict_manager)))
+        };
+        ($exec_scopes_proxy:expr, $tracker_num:expr) => {
+            let  tracker = DictTracker::new_empty(&relocatable!($tracker_num, 0));
+            let mut dict_manager = DictManager::new();
+            dict_manager.trackers.insert(2, tracker);
+            $exec_scopes_proxy.insert_value("dict_manager", Rc::new(RefCell::new(dict_manager)))
+        };
+
+    }
+    pub(crate) use dict_manager;
+
+    macro_rules! dict_manager_default {
+        ($exec_scopes_proxy:expr, $tracker_num:expr,$default:expr, $( ($key:expr, $val:expr )),* ) => {
+            let mut tracker = DictTracker::new_default_dict(&relocatable!($tracker_num, 0), &bigint!($default), None);
+            $(
+            tracker.insert_value(&bigint!($key), &bigint!($val));
+            )*
+            let mut dict_manager = DictManager::new();
+            dict_manager.trackers.insert(2, tracker);
+            $exec_scopes_proxy.insert_value("dict_manager", Rc::new(RefCell::new(dict_manager)))
+        };
+        ($exec_scopes_proxy:expr, $tracker_num:expr,$default:expr) => {
+            let tracker = DictTracker::new_default_dict(&relocatable!($tracker_num, 0), &bigint!($default), None);
+            let mut dict_manager = DictManager::new();
+            dict_manager.trackers.insert(2, tracker);
+            $exec_scopes_proxy.insert_value("dict_manager", Rc::new(RefCell::new(dict_manager)))
+        };
+    }
+    pub(crate) use dict_manager_default;
 
     use crate::hint_processor::proxies::exec_scopes_proxy::ExecutionScopesProxy;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -428,7 +428,10 @@ pub mod test_utils {
 #[cfg(test)]
 mod test {
 
+    use std::collections::HashMap;
+
     use super::*;
+    use crate::hint_processor::hint_processor_definition::HintReference;
     use crate::types::relocatable::MaybeRelocatable;
     use crate::vm::errors::memory_errors::MemoryError;
     use crate::vm::trace::trace_entry::TraceEntry;
@@ -640,5 +643,15 @@ mod test {
                 ((4, 9), (5, 5), (3, 7))
             ]
         );
+    }
+
+    #[test]
+    fn test_non_continuous_ids_data() {
+        let ids_data_macro = non_continuous_ids_data![("a", -2), ("b", -6)];
+        let ids_data_verbose = HashMap::from([
+            ("a".to_string(), HintReference::new_simple(-2)),
+            ("b".to_string(), HintReference::new_simple(-6)),
+        ]);
+        assert_eq!(ids_data_macro, ids_data_verbose);
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -314,6 +314,22 @@ pub mod test_utils {
     }
     pub(crate) use check_scope;
 
+    macro_rules! scope {
+        (  $( ($name: expr, $val: expr)),*  ) => {
+            {
+                let mut exec_scopes = ExecutionScopes::new();
+                $(
+                    exec_scopes.assign_or_update_variable(
+                        $name,
+                        any_box!($val),
+                    );
+                )*
+                exec_scopes
+            }
+        };
+    }
+    pub(crate) use scope;
+
     use crate::hint_processor::proxies::exec_scopes_proxy::ExecutionScopesProxy;
 
     pub fn check_scope_value<T: std::fmt::Debug + std::cmp::PartialEq + 'static>(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -295,6 +295,15 @@ pub mod test_utils {
         }};
     }
     pub(crate) use run_hint;
+
+    macro_rules! add_segments {
+        ($vm:expr, $n:expr) => {
+            for _ in 0..$n {
+                $vm.segments.add(&mut $vm.memory, None);
+            }
+        };
+    }
+    pub(crate) use add_segments;
 }
 
 #[cfg(test)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -343,6 +343,42 @@ pub mod test_utils {
     }
     pub(crate) use scope;
 
+    macro_rules! check_dictionary {
+        ( $exec_scopes_proxy: expr, $tracker_num:expr, $( ($key:expr, $val:expr )),* ) => {
+            $(
+                assert_eq!(
+                    $exec_scopes_proxy
+                        .get_dict_manager()
+                        .unwrap()
+                        .borrow_mut()
+                        .trackers
+                        .get_mut(&$tracker_num)
+                        .unwrap()
+                        .get_value(&bigint!($key)),
+                    Ok(&bigint!($val))
+                );
+            )*
+        };
+    }
+    pub(crate) use check_dictionary;
+
+    macro_rules! check_dict_ptr {
+        ($exec_scopes_proxy: expr, $tracker_num: expr, ($i:expr, $off:expr)) => {
+            assert_eq!(
+                $exec_scopes_proxy
+                    .get_dict_manager()
+                    .unwrap()
+                    .borrow()
+                    .trackers
+                    .get(&$tracker_num)
+                    .unwrap()
+                    .current_ptr,
+                relocatable!($i, $off)
+            );
+        };
+    }
+    pub(crate) use check_dict_ptr;
+
     use crate::hint_processor::proxies::exec_scopes_proxy::ExecutionScopesProxy;
 
     pub fn check_scope_value<T: std::fmt::Debug + std::cmp::PartialEq + 'static>(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -304,6 +304,26 @@ pub mod test_utils {
         };
     }
     pub(crate) use add_segments;
+
+    macro_rules! check_scope {
+        ( $exec_proxy: expr, [ $( ($name: expr, $val: expr)),* ] ) => {
+            $(
+                check_scope_value($exec_proxy, $name, $val);
+            )*
+        };
+    }
+    pub(crate) use check_scope;
+
+    use crate::hint_processor::proxies::exec_scopes_proxy::ExecutionScopesProxy;
+
+    pub fn check_scope_value<T: std::fmt::Debug + std::cmp::PartialEq + 'static>(
+        proxy: &ExecutionScopesProxy,
+        name: &str,
+        value: T,
+    ) {
+        let scope_value = proxy.get_any_boxed_ref(name).unwrap();
+        assert_eq!(scope_value.downcast_ref(), Some(&value));
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Add macros: `run_hint`, `add_segments`, `check_scope`, `scope`, `non_continuous_ids_data`, `check_dictionary`, `check_dict_ptr`, `dict_manager`, `default_dict_manager`
