### PR TITLE
Refactor functions to use Relocatable instead of MaybeRelocatable

### DIFF
--- a/src/hint_processor/builtin_hint_processor/hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/hint_utils.rs
@@ -29,13 +29,7 @@ pub fn insert_value_into_ap(
     run_context: &RunContext,
     value: impl Into<MaybeRelocatable>,
 ) -> Result<(), VirtualMachineError> {
-    memory.insert_value(
-        &(run_context
-            .get_ap()
-            .try_into()
-            .map_err(VirtualMachineError::MemoryError)?),
-        value,
-    )
+    memory.insert_value(&(run_context.get_ap()), value)
 }
 
 //Returns the Relocatable value stored in the given ids variable

--- a/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
@@ -744,7 +744,7 @@ mod tests {
             hint_processor.execute_hint(vm_proxy, exec_scopes_proxy, &any_box!(hint_data)),
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
-                    vm.run_context.get_ap(),
+                    MaybeRelocatable::from(vm.run_context.get_ap()),
                     MaybeRelocatable::from(bigint!(55i32)),
                     MaybeRelocatable::from(bigint!(1i32))
                 )

--- a/src/hint_processor/hint_processor_utils.rs
+++ b/src/hint_processor/hint_processor_utils.rs
@@ -94,16 +94,14 @@ pub fn compute_addr_from_reference(
 ) -> Result<Relocatable, VirtualMachineError> {
     let base_addr = match hint_reference.register {
         //This should never fail
-        Some(Register::FP) => run_context.get_fp().get_relocatable()?.clone(),
+        Some(Register::FP) => run_context.get_fp(),
         Some(Register::AP) => {
             let var_ap_trackig = hint_reference
                 .ap_tracking_data
                 .as_ref()
                 .ok_or(VirtualMachineError::NoneApTrackingData)?;
 
-            let ap = run_context.get_ap().get_relocatable()?.clone();
-
-            apply_ap_tracking_correction(&ap, var_ap_trackig, hint_ap_tracking)?
+            apply_ap_tracking_correction(&run_context.get_ap(), var_ap_trackig, hint_ap_tracking)?
         }
         None => return Err(VirtualMachineError::NoRegisterInReference),
     };

--- a/src/types/relocatable.rs
+++ b/src/types/relocatable.rs
@@ -482,56 +482,6 @@ mod tests {
     }
 
     #[test]
-    fn add_maybe_mod_ok() {
-        assert_eq!(
-            Ok(relocatable!(1, 2)),
-            relocatable!(1, 0).add_maybe_mod(&mayberelocatable!(2), &bigint!(71))
-        );
-        assert_eq!(
-            Ok(relocatable!(0, 58)),
-            relocatable!(0, 29).add_maybe_mod(&mayberelocatable!(100), &bigint!(71))
-        );
-        assert_eq!(
-            Ok(relocatable!(2, 45)),
-            relocatable!(2, 12).add_maybe_mod(&mayberelocatable!(104), &bigint!(71))
-        );
-
-        assert_eq!(
-            Ok(relocatable!(1, 0)),
-            relocatable!(1, 0).add_maybe_mod(&mayberelocatable!(0), &bigint!(71))
-        );
-        assert_eq!(
-            Ok(relocatable!(1, 2)),
-            relocatable!(1, 2).add_maybe_mod(&mayberelocatable!(71), &bigint!(71))
-        );
-
-        assert_eq!(
-            Ok(relocatable!(14, 0)),
-            relocatable!(14, (71 * 12))
-                .add_maybe_mod(&mayberelocatable!((pow(71, 3))), &bigint!(71))
-        );
-    }
-
-    #[test]
-    fn add_maybe_mod_add_two_relocatable_error() {
-        assert_eq!(
-            Err(VirtualMachineError::RelocatableAdd),
-            relocatable!(1, 0).add_maybe_mod(&mayberelocatable!(1, 2), &bigint!(71))
-        );
-    }
-
-    #[test]
-    fn add_maybe_mod_offset_exceeded_error() {
-        assert_eq!(
-            Err(VirtualMachineError::OffsetExceeded(bigint!(usize::MAX) + 1)),
-            relocatable!(1, 0).add_maybe_mod(
-                &mayberelocatable!(bigint!(usize::MAX) + 1),
-                &(bigint!(usize::MAX) + 8)
-            )
-        );
-    }
-
-    #[test]
     fn add_int_to_int_prime() {
         let addr_a = &MaybeRelocatable::Int(BigInt::new(
             Sign::Plus,
@@ -742,6 +692,56 @@ mod tests {
         assert_eq!(
             Err(VirtualMachineError::OffsetExceeded(bigint!(usize::MAX) + 1)),
             relocatable!(0, 0).add_int_mod(&(bigint!(usize::MAX) + 1), &(bigint!(usize::MAX) + 2))
+        );
+    }
+
+    #[test]
+    fn add_maybe_mod_ok() {
+        assert_eq!(
+            Ok(relocatable!(1, 2)),
+            relocatable!(1, 0).add_maybe_mod(&mayberelocatable!(2), &bigint!(71))
+        );
+        assert_eq!(
+            Ok(relocatable!(0, 58)),
+            relocatable!(0, 29).add_maybe_mod(&mayberelocatable!(100), &bigint!(71))
+        );
+        assert_eq!(
+            Ok(relocatable!(2, 45)),
+            relocatable!(2, 12).add_maybe_mod(&mayberelocatable!(104), &bigint!(71))
+        );
+
+        assert_eq!(
+            Ok(relocatable!(1, 0)),
+            relocatable!(1, 0).add_maybe_mod(&mayberelocatable!(0), &bigint!(71))
+        );
+        assert_eq!(
+            Ok(relocatable!(1, 2)),
+            relocatable!(1, 2).add_maybe_mod(&mayberelocatable!(71), &bigint!(71))
+        );
+
+        assert_eq!(
+            Ok(relocatable!(14, 0)),
+            relocatable!(14, (71 * 12))
+                .add_maybe_mod(&mayberelocatable!((pow(71, 3))), &bigint!(71))
+        );
+    }
+
+    #[test]
+    fn add_maybe_mod_add_two_relocatable_error() {
+        assert_eq!(
+            Err(VirtualMachineError::RelocatableAdd),
+            relocatable!(1, 0).add_maybe_mod(&mayberelocatable!(1, 2), &bigint!(71))
+        );
+    }
+
+    #[test]
+    fn add_maybe_mod_offset_exceeded_error() {
+        assert_eq!(
+            Err(VirtualMachineError::OffsetExceeded(bigint!(usize::MAX) + 1)),
+            relocatable!(1, 0).add_maybe_mod(
+                &mayberelocatable!(bigint!(usize::MAX) + 1),
+                &(bigint!(usize::MAX) + 8)
+            )
         );
     }
 }

--- a/src/types/relocatable.rs
+++ b/src/types/relocatable.rs
@@ -720,4 +720,28 @@ mod tests {
             Err(MemoryError::Relocation)
         );
     }
+
+    #[test]
+    fn relocatable_add_int_mod_ok() {
+        assert_eq!(
+            Ok(relocatable!(1, 6)),
+            relocatable!(1, 2).add_int_mod(&bigint!(4), &bigint!(71))
+        );
+        assert_eq!(
+            Ok(relocatable!(3, 2)),
+            relocatable!(3, 2).add_int_mod(&bigint!(0), &bigint!(71))
+        );
+        assert_eq!(
+            Ok(relocatable!(9, 12)),
+            relocatable!(9, 48).add_int_mod(&bigint!(35), &bigint!(71))
+        );
+    }
+
+    #[test]
+    fn relocatable_add_int_mod_offset_exceeded_error() {
+        assert_eq!(
+            Err(VirtualMachineError::OffsetExceeded(bigint!(usize::MAX) + 1)),
+            relocatable!(0, 0).add_int_mod(&(bigint!(usize::MAX) + 1), &(bigint!(usize::MAX) + 2))
+        );
+    }
 }

--- a/src/types/relocatable.rs
+++ b/src/types/relocatable.rs
@@ -145,10 +145,9 @@ impl Relocatable {
             "Address offsets cant be negative"
         );
         big_offset = big_offset.mod_floor(prime);
-        let new_offset = match big_offset.to_usize() {
-            Some(usize) => usize,
-            None => return Err(VirtualMachineError::OffsetExceeded(big_offset)),
-        };
+        let new_offset = big_offset
+            .to_usize()
+            .ok_or(VirtualMachineError::OffsetExceeded(big_offset))?;
         Ok(Relocatable {
             segment_index: self.segment_index,
             offset: new_offset,
@@ -167,10 +166,9 @@ impl Relocatable {
             .map_err(|_| VirtualMachineError::RelocatableAdd)?;
 
         let big_offset: BigInt = (num_ref + self.offset).mod_floor(prime);
-        let new_offset = match big_offset.to_usize() {
-            Some(usize) => usize,
-            None => return Err(VirtualMachineError::OffsetExceeded(big_offset)),
-        };
+        let new_offset = big_offset
+            .to_usize()
+            .ok_or(VirtualMachineError::OffsetExceeded(big_offset))?;
         Ok(Relocatable {
             segment_index: self.segment_index,
             offset: new_offset,
@@ -210,10 +208,9 @@ impl MaybeRelocatable {
                     "Address offsets cant be negative"
                 );
                 big_offset = big_offset.mod_floor(prime);
-                let new_offset = match big_offset.to_usize() {
-                    Some(usize) => usize,
-                    None => return Err(VirtualMachineError::OffsetExceeded(big_offset)),
-                };
+                let new_offset = big_offset
+                    .to_usize()
+                    .ok_or(VirtualMachineError::OffsetExceeded(big_offset))?;
                 Ok(MaybeRelocatable::RelocatableValue(Relocatable {
                     segment_index: rel.segment_index,
                     offset: new_offset,
@@ -260,10 +257,9 @@ impl MaybeRelocatable {
             | (&MaybeRelocatable::Int(ref num_ref), &MaybeRelocatable::RelocatableValue(ref rel)) =>
             {
                 let big_offset: BigInt = (num_ref + rel.offset).mod_floor(prime);
-                let new_offset = match big_offset.to_usize() {
-                    Some(usize) => usize,
-                    None => return Err(VirtualMachineError::OffsetExceeded(big_offset)),
-                };
+                let new_offset = big_offset
+                    .to_usize()
+                    .ok_or(VirtualMachineError::OffsetExceeded(big_offset))?;
                 Ok(MaybeRelocatable::RelocatableValue(Relocatable {
                     segment_index: rel.segment_index,
                     offset: new_offset,

--- a/src/types/relocatable.rs
+++ b/src/types/relocatable.rs
@@ -157,25 +157,24 @@ impl Relocatable {
 
     ///Adds a MaybeRelocatable to self, then performs mod prime
     /// Cant add two relocatable values
-    pub fn add_mod(
+    pub fn add_maybe_mod(
         &self,
         other: &MaybeRelocatable,
         prime: &BigInt,
     ) -> Result<Relocatable, VirtualMachineError> {
-        match *other {
-            MaybeRelocatable::RelocatableValue(_) => Err(VirtualMachineError::RelocatableAdd),
-            MaybeRelocatable::Int(ref num_ref) => {
-                let big_offset: BigInt = (num_ref + self.offset).mod_floor(prime);
-                let new_offset = match big_offset.to_usize() {
-                    Some(usize) => usize,
-                    None => return Err(VirtualMachineError::OffsetExceeded(big_offset)),
-                };
-                Ok(Relocatable {
-                    segment_index: self.segment_index,
-                    offset: new_offset,
-                })
-            }
-        }
+        let num_ref = other
+            .get_int_ref()
+            .map_err(|_| VirtualMachineError::RelocatableAdd)?;
+
+        let big_offset: BigInt = (num_ref + self.offset).mod_floor(prime);
+        let new_offset = match big_offset.to_usize() {
+            Some(usize) => usize,
+            None => return Err(VirtualMachineError::OffsetExceeded(big_offset)),
+        };
+        Ok(Relocatable {
+            segment_index: self.segment_index,
+            offset: new_offset,
+        })
     }
 
     pub fn sub_rel(&self, other: &Self) -> Result<usize, VirtualMachineError> {

--- a/src/types/relocatable.rs
+++ b/src/types/relocatable.rs
@@ -133,6 +133,51 @@ impl Relocatable {
         Ok(relocatable!(self.segment_index, new_offset))
     }
 
+    ///Adds a bigint to self, then performs mod prime
+    pub fn add_int_mod(
+        &self,
+        other: &BigInt,
+        prime: &BigInt,
+    ) -> Result<Relocatable, VirtualMachineError> {
+        let mut big_offset = self.offset + other;
+        assert!(
+            !big_offset.is_negative(),
+            "Address offsets cant be negative"
+        );
+        big_offset = big_offset.mod_floor(prime);
+        let new_offset = match big_offset.to_usize() {
+            Some(usize) => usize,
+            None => return Err(VirtualMachineError::OffsetExceeded(big_offset)),
+        };
+        Ok(Relocatable {
+            segment_index: self.segment_index,
+            offset: new_offset,
+        })
+    }
+
+    ///Adds a MaybeRelocatable to self, then performs mod prime
+    /// Cant add two relocatable values
+    pub fn add_mod(
+        &self,
+        other: &MaybeRelocatable,
+        prime: &BigInt,
+    ) -> Result<Relocatable, VirtualMachineError> {
+        match *other {
+            MaybeRelocatable::RelocatableValue(_) => Err(VirtualMachineError::RelocatableAdd),
+            MaybeRelocatable::Int(ref num_ref) => {
+                let big_offset: BigInt = (num_ref + self.offset).mod_floor(prime);
+                let new_offset = match big_offset.to_usize() {
+                    Some(usize) => usize,
+                    None => return Err(VirtualMachineError::OffsetExceeded(big_offset)),
+                };
+                Ok(Relocatable {
+                    segment_index: self.segment_index,
+                    offset: new_offset,
+                })
+            }
+        }
+    }
+
     pub fn sub_rel(&self, other: &Self) -> Result<usize, VirtualMachineError> {
         if self.segment_index != other.segment_index {
             return Err(VirtualMachineError::DiffIndexSub);

--- a/src/vm/context/run_context.rs
+++ b/src/vm/context/run_context.rs
@@ -13,9 +13,6 @@ pub struct RunContext {
 }
 
 impl RunContext {
-    pub fn get_pc(&self) -> Relocatable {
-        Relocatable::from(&self.pc)
-    }
     pub fn get_ap(&self) -> Relocatable {
         Relocatable::from((1, self.ap))
     }
@@ -53,7 +50,7 @@ impl RunContext {
             Op1Addr::FP => self.get_fp(),
             Op1Addr::AP => self.get_ap(),
             Op1Addr::Imm => match instruction.off2 == bigint!(1) {
-                true => self.get_pc(),
+                true => self.pc.clone(),
                 false => return Err(VirtualMachineError::ImmShouldBe1),
             },
             Op1Addr::Op0 => match op0 {

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -159,7 +159,7 @@ impl<'a> CairoRunner<'a> {
         entrypoint: usize,
         mut stack: Vec<MaybeRelocatable>,
         return_fp: MaybeRelocatable,
-    ) -> Result<MaybeRelocatable, RunnerError> {
+    ) -> Result<Relocatable, RunnerError> {
         let end = self.vm.segments.add(&mut self.vm.memory, None);
         stack.append(&mut vec![
             return_fp,
@@ -176,12 +176,12 @@ impl<'a> CairoRunner<'a> {
         }
         self.initialize_state(entrypoint, stack)?;
         self.final_pc = Some(end.clone());
-        Ok(MaybeRelocatable::RelocatableValue(end))
+        Ok(end)
     }
     ///Initializes state for running a program from the main() entrypoint.
     ///If self.proof_mode == True, the execution starts from the start label rather then the main() function.
     ///Returns the value of the program counter after returning from main.
-    pub fn initialize_main_entrypoint(&mut self) -> Result<MaybeRelocatable, RunnerError> {
+    pub fn initialize_main_entrypoint(&mut self) -> Result<Relocatable, RunnerError> {
         //self.execution_public_memory = Vec::new() -> Not used now
         let mut stack = Vec::new();
         for (_name, builtin_runner) in self.vm.builtin_runners.iter() {
@@ -268,10 +268,10 @@ impl<'a> CairoRunner<'a> {
         Ok(hint_data_dictionary)
     }
 
-    pub fn run_until_pc(&mut self, address: MaybeRelocatable) -> Result<(), VirtualMachineError> {
+    pub fn run_until_pc(&mut self, address: Relocatable) -> Result<(), VirtualMachineError> {
         let references = self.get_reference_list();
         let hint_data_dictionary = self.get_hint_data_dictionary(&references)?;
-        while &self.vm.run_context.get_pc() != address.get_relocatable()? {
+        while self.vm.run_context.get_pc() != address {
             self.vm.step(
                 self.hint_executor,
                 &mut self.exec_scopes,

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -271,7 +271,7 @@ impl<'a> CairoRunner<'a> {
     pub fn run_until_pc(&mut self, address: MaybeRelocatable) -> Result<(), VirtualMachineError> {
         let references = self.get_reference_list();
         let hint_data_dictionary = self.get_hint_data_dictionary(&references)?;
-        while self.vm.run_context.get_pc() != address {
+        while &self.vm.run_context.get_pc() != address.get_relocatable()? {
             self.vm.step(
                 self.hint_executor,
                 &mut self.exec_scopes,

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -876,7 +876,7 @@ mod tests {
         cairo_runner.program_base = Some(relocatable!(0, 0));
         cairo_runner.execution_base = Some(relocatable!(0, 0));
         let return_pc = cairo_runner.initialize_main_entrypoint().unwrap();
-        assert_eq!(return_pc, MaybeRelocatable::from((1, 0)));
+        assert_eq!(return_pc, Relocatable::from((1, 0)));
     }
 
     #[test]
@@ -1631,7 +1631,7 @@ mod tests {
         let mut cairo_runner = CairoRunner::new(&program, true, &hint_processor).unwrap();
         cairo_runner.initialize_segments(None);
         let end = cairo_runner.initialize_main_entrypoint().unwrap();
-        assert_eq!(end, MaybeRelocatable::from((3, 0)));
+        assert_eq!(end, Relocatable::from((3, 0)));
         cairo_runner.initialize_vm().unwrap();
         //Execution Phase
         assert_eq!(cairo_runner.run_until_pc(end), Ok(()));

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -271,7 +271,7 @@ impl<'a> CairoRunner<'a> {
     pub fn run_until_pc(&mut self, address: Relocatable) -> Result<(), VirtualMachineError> {
         let references = self.get_reference_list();
         let hint_data_dictionary = self.get_hint_data_dictionary(&references)?;
-        while self.vm.run_context.get_pc() != address {
+        while self.vm.run_context.pc != address {
             self.vm.step(
                 self.hint_executor,
                 &mut self.exec_scopes,

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -32,7 +32,7 @@ pub struct Operands {
 }
 
 #[derive(PartialEq, Debug)]
-struct OperandsAddresses(MaybeRelocatable, MaybeRelocatable, MaybeRelocatable);
+struct OperandsAddresses(Relocatable, Relocatable, Relocatable);
 
 #[derive(Clone, Debug)]
 pub struct HintData {
@@ -49,7 +49,7 @@ pub struct VirtualMachine {
     pub segments: MemorySegmentManager,
     pub _program_base: Option<MaybeRelocatable>,
     pub memory: Memory,
-    accessed_addresses: Option<Vec<MaybeRelocatable>>,
+    accessed_addresses: Option<Vec<Relocatable>>,
     pub trace: Option<Vec<TraceEntry>>,
     current_step: usize,
     skip_instruction_execution: bool,
@@ -436,7 +436,7 @@ impl VirtualMachine {
                 op_addrs.0,
                 op_addrs.1,
                 op_addrs.2,
-                MaybeRelocatable::from(self.run_context.get_pc()),
+                self.run_context.pc.clone(),
             ];
             accessed_addresses.extend_from_slice(addresses);
         }
@@ -600,11 +600,7 @@ impl VirtualMachine {
         match (dst, op0, op1) {
             (Some(unwrapped_dst), Some(unwrapped_op0), Some(unwrapped_op1)) => {
                 let accessed_addresses = if self.accessed_addresses.is_some() {
-                    Some(OperandsAddresses(
-                        MaybeRelocatable::from(dst_addr),
-                        MaybeRelocatable::from(op0_addr),
-                        MaybeRelocatable::from(op1_addr),
-                    ))
+                    Some(OperandsAddresses(dst_addr, op0_addr, op1_addr))
                 } else {
                     None
                 };

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -674,6 +674,7 @@ mod tests {
         },
     };
 
+    use crate::bigint;
     use num_bigint::Sign;
     use std::collections::HashSet;
 
@@ -1981,9 +1982,9 @@ mod tests {
         };
 
         let expected_addresses = Some(OperandsAddresses(
-            dst_addr.clone(),
-            op0_addr.clone(),
-            op1_addr.clone(),
+            dst_addr.get_relocatable().unwrap().clone(),
+            op0_addr.get_relocatable().unwrap().clone(),
+            op1_addr.get_relocatable().unwrap().clone(),
         ));
 
         let (operands, addresses) = vm.compute_operands(&inst).unwrap();
@@ -2032,9 +2033,9 @@ mod tests {
         };
 
         let expected_addresses = Some(OperandsAddresses(
-            dst_addr.clone(),
-            op0_addr.clone(),
-            op1_addr.clone(),
+            dst_addr.get_relocatable().unwrap().clone(),
+            op0_addr.get_relocatable().unwrap().clone(),
+            op1_addr.get_relocatable().unwrap().clone(),
         ));
 
         let (operands, addresses) = vm.compute_operands(&inst).unwrap();
@@ -2075,9 +2076,9 @@ mod tests {
         };
 
         let expected_addresses = Some(OperandsAddresses(
-            mayberelocatable!(1, 1),
-            mayberelocatable!(1, 1),
-            mayberelocatable!(0, 1),
+            relocatable!(1, 1),
+            relocatable!(1, 1),
+            relocatable!(0, 1),
         ));
 
         let (operands, addresses) = vm.compute_operands(&instruction).unwrap();
@@ -2295,9 +2296,9 @@ mod tests {
         assert_eq!(vm.run_context.fp, 0);
 
         let accessed_addresses = vm.accessed_addresses.as_ref().unwrap();
-        assert!(accessed_addresses.contains(&MaybeRelocatable::from((1, 0))));
-        assert!(accessed_addresses.contains(&MaybeRelocatable::from((1, 1))));
-        assert!(accessed_addresses.contains(&MaybeRelocatable::from((0, 0))));
+        assert!(accessed_addresses.contains(&Relocatable::from((1, 0))));
+        assert!(accessed_addresses.contains(&Relocatable::from((1, 1))));
+        assert!(accessed_addresses.contains(&Relocatable::from((0, 0))));
     }
 
     #[test]
@@ -2355,7 +2356,7 @@ mod tests {
             ((1, 1), (3, 0))
         ];
 
-        let final_pc = MaybeRelocatable::from((3, 0));
+        let final_pc = Relocatable::from((3, 0));
         let hint_processor = BuiltinHintProcessor::new_empty();
         //Run steps
         while vm.run_context.pc != final_pc {
@@ -2391,23 +2392,23 @@ mod tests {
             .accessed_addresses
             .unwrap()
             .into_iter()
-            .collect::<HashSet<MaybeRelocatable>>();
+            .collect::<HashSet<Relocatable>>();
         assert_eq!(accessed_addresses.len(), 14);
         //Check each element individually
-        assert!(accessed_addresses.contains(&MaybeRelocatable::from((0, 1))));
-        assert!(accessed_addresses.contains(&MaybeRelocatable::from((0, 7))));
-        assert!(accessed_addresses.contains(&MaybeRelocatable::from((1, 2))));
-        assert!(accessed_addresses.contains(&MaybeRelocatable::from((0, 4))));
-        assert!(accessed_addresses.contains(&MaybeRelocatable::from((0, 0))));
-        assert!(accessed_addresses.contains(&MaybeRelocatable::from((1, 5))));
-        assert!(accessed_addresses.contains(&MaybeRelocatable::from((1, 1))));
-        assert!(accessed_addresses.contains(&MaybeRelocatable::from((0, 3))));
-        assert!(accessed_addresses.contains(&MaybeRelocatable::from((1, 4))));
-        assert!(accessed_addresses.contains(&MaybeRelocatable::from((0, 6))));
-        assert!(accessed_addresses.contains(&MaybeRelocatable::from((0, 2))));
-        assert!(accessed_addresses.contains(&MaybeRelocatable::from((0, 5))));
-        assert!(accessed_addresses.contains(&MaybeRelocatable::from((1, 0))));
-        assert!(accessed_addresses.contains(&MaybeRelocatable::from((1, 3))));
+        assert!(accessed_addresses.contains(&Relocatable::from((0, 1))));
+        assert!(accessed_addresses.contains(&Relocatable::from((0, 7))));
+        assert!(accessed_addresses.contains(&Relocatable::from((1, 2))));
+        assert!(accessed_addresses.contains(&Relocatable::from((0, 4))));
+        assert!(accessed_addresses.contains(&Relocatable::from((0, 0))));
+        assert!(accessed_addresses.contains(&Relocatable::from((1, 5))));
+        assert!(accessed_addresses.contains(&Relocatable::from((1, 1))));
+        assert!(accessed_addresses.contains(&Relocatable::from((0, 3))));
+        assert!(accessed_addresses.contains(&Relocatable::from((1, 4))));
+        assert!(accessed_addresses.contains(&Relocatable::from((0, 6))));
+        assert!(accessed_addresses.contains(&Relocatable::from((0, 2))));
+        assert!(accessed_addresses.contains(&Relocatable::from((0, 5))));
+        assert!(accessed_addresses.contains(&Relocatable::from((1, 0))));
+        assert!(accessed_addresses.contains(&Relocatable::from((1, 3))));
     }
 
     #[test]
@@ -2597,9 +2598,9 @@ mod tests {
             )),
         };
         let expected_operands_mem_addresses = Some(OperandsAddresses(
-            MaybeRelocatable::from((1, 13)),
-            MaybeRelocatable::from((1, 7)),
-            MaybeRelocatable::from((3, 2)),
+            Relocatable::from((1, 13)),
+            Relocatable::from((1, 7)),
+            Relocatable::from((3, 2)),
         ));
         assert_eq!(
             Ok((expected_operands, expected_operands_mem_addresses)),
@@ -2678,9 +2679,9 @@ mod tests {
             op1: MaybeRelocatable::from(bigint!(8)),
         };
         let expected_operands_mem_addresses = Some(OperandsAddresses(
-            MaybeRelocatable::from((1, 9)),
-            MaybeRelocatable::from((1, 3)),
-            MaybeRelocatable::from((2, 2)),
+            Relocatable::from((1, 9)),
+            Relocatable::from((1, 3)),
+            Relocatable::from((2, 2)),
         ));
         assert_eq!(
             Ok((expected_operands, expected_operands_mem_addresses)),

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -141,7 +141,7 @@ impl VirtualMachine {
     ) -> Result<(), VirtualMachineError> {
         let new_ap: Relocatable = match instruction.ap_update {
             ApUpdate::Add => match operands.res.clone() {
-                Some(res) => self.run_context.get_ap().add_mod(&res, &self.prime)?,
+                Some(res) => self.run_context.get_ap().add_maybe_mod(&res, &self.prime)?,
                 None => return Err(VirtualMachineError::UnconstrainedResAdd),
             },
             ApUpdate::Add1 => self.run_context.get_ap() + 1,
@@ -175,7 +175,12 @@ impl VirtualMachine {
             },
             PcUpdate::Jnz => match VirtualMachine::is_zero(operands.dst.clone())? {
                 true => &self.run_context.pc + instruction.size(),
-                false => (self.run_context.pc.add_mod(&operands.op1, &self.prime))?,
+                false => {
+                    (self
+                        .run_context
+                        .pc
+                        .add_maybe_mod(&operands.op1, &self.prime))?
+                }
             },
         };
         self.run_context.pc = new_pc;


### PR DESCRIPTION
# Refactor functions to use Relocatable instead of MaybeRelocatable

Resolves #391 

* Add Relocatable.add_int_mod && Relocatable.add_maybe_mod implementations
* Refactor RunContext.{get_ap(), get_fp} to return a Relocatable
* Delete RunContext.{get_pc()} impl
* Refactor Runcontext.{compute_dst_addr, compute_op0_addr, compute_op1_addr} to return a Relocatable
* Refactor CairoRunner.initialize_function_entrypoint && CairoRunner.initialize_main_entrypoint to return a Result<Relocatable..
* Refactor CairoRunner.run_until_pc to receive a Relocatable a an input
* Refactor VirtualMachine.deduce_memory_cell input to be a Relocatable
* Refactor VirtualMachine.accessed_addresses: Option<Vec<MaybeRelocatable>>
* Refactor Struct OperandsAddresses(Relocatable, Relocatable, Relocatable)

## Checklist
- [x] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
