### PR TITLE
Specify cairo-lang version = 0.9.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,10 @@ deps:
 	cargo install --version 1.14.0 hyperfine
 	pyenv install pypy3.7-7.3.9
 	pyenv global pypy3.7-7.3.9
-	pip install cairo_lang
+	pip install cairo_lang==0.9.0
 	pyenv install 3.7.12
 	pyenv global 3.7.12
-	pip install cairo_lang
+	pip install cairo_lang==0.9.0
 
 build:
 	cargo build --release


### PR DESCRIPTION
# Specify cairo-lang version = 0.9.0

## Description

Specify cairo-lang version = 0.9.0, so the Cairo programs run OK

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
