### PR TITLE
[REFACTOR] Abstract the representation of field elements. Phase 1

### DIFF
--- a/src/hint_processor/builtin_hint_processor/cairo_keccak/keccak_hints.rs
+++ b/src/hint_processor/builtin_hint_processor/cairo_keccak/keccak_hints.rs
@@ -2,6 +2,7 @@ use crate::hint_processor::builtin_hint_processor::hint_utils::get_integer_from_
 use crate::hint_processor::builtin_hint_processor::hint_utils::get_ptr_from_var_name;
 use crate::hint_processor::builtin_hint_processor::hint_utils::insert_value_into_ap;
 use crate::hint_processor::proxies::vm_proxy::VMProxy;
+use crate::types::relocatable::FieldElement;
 use crate::{
     bigint, hint_processor::hint_processor_definition::HintReference,
     serde::deserialize_program::ApTracking, types::relocatable::MaybeRelocatable,
@@ -225,7 +226,7 @@ fn maybe_reloc_vec_to_u64_array(
     let array: [u64; KECCAK_STATE_SIZE_FELTS] = vec
         .iter()
         .map(|n| {
-            if let Some(MaybeRelocatable::Int(num)) = n {
+            if let Some(MaybeRelocatable::Int(FieldElement { num })) = n {
                 num.to_u64().ok_or(VirtualMachineError::BigintToU64Fail)
             } else {
                 Err(VirtualMachineError::ExpectedIntAtRange(n.cloned()))

--- a/src/hint_processor/builtin_hint_processor/find_element_hint.rs
+++ b/src/hint_processor/builtin_hint_processor/find_element_hint.rs
@@ -307,7 +307,7 @@ mod tests {
     fn find_elm_zero_elm_size() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::from([(
             "elm_size".to_string(),
-            MaybeRelocatable::Int(bigint!(0)),
+            MaybeRelocatable::from(bigint!(0)),
         )]));
         assert_eq!(
             run_hint!(vm, ids_data, hint_code::FIND_ELEMENT),
@@ -319,7 +319,7 @@ mod tests {
     fn find_elm_negative_elm_size() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::from([(
             "elm_size".to_string(),
-            MaybeRelocatable::Int(bigint!(-1)),
+            MaybeRelocatable::from(bigint!(-1)),
         )]));
         assert_eq!(
             run_hint!(vm, ids_data, hint_code::FIND_ELEMENT),
@@ -342,7 +342,7 @@ mod tests {
     fn find_elm_negative_n_elms() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::from([(
             "n_elms".to_string(),
-            MaybeRelocatable::Int(bigint!(-1)),
+            MaybeRelocatable::from(bigint!(-1)),
         )]));
         assert_eq!(
             run_hint!(vm, ids_data, hint_code::FIND_ELEMENT),
@@ -393,7 +393,7 @@ mod tests {
     fn search_sorted_lower_no_matches() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::from([(
             "key".to_string(),
-            MaybeRelocatable::Int(bigint!(7)),
+            MaybeRelocatable::from(bigint!(7)),
         )]));
         assert_eq!(
             run_hint!(vm, ids_data, hint_code::SEARCH_SORTED_LOWER),
@@ -420,7 +420,7 @@ mod tests {
     fn search_sorted_lower_zero_elm_size() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::from([(
             "elm_size".to_string(),
-            MaybeRelocatable::Int(bigint!(0)),
+            MaybeRelocatable::from(bigint!(0)),
         )]));
         assert_eq!(
             run_hint!(vm, ids_data, hint_code::SEARCH_SORTED_LOWER),
@@ -432,7 +432,7 @@ mod tests {
     fn search_sorted_lower_negative_elm_size() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::from([(
             "elm_size".to_string(),
-            MaybeRelocatable::Int(bigint!(-1)),
+            MaybeRelocatable::from(bigint!(-1)),
         )]));
         assert_eq!(
             run_hint!(vm, ids_data, hint_code::SEARCH_SORTED_LOWER),
@@ -458,7 +458,7 @@ mod tests {
     fn search_sorted_lower_negative_n_elms() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::from([(
             "n_elms".to_string(),
-            MaybeRelocatable::Int(bigint!(-1)),
+            MaybeRelocatable::from(bigint!(-1)),
         )]));
         assert_eq!(
             run_hint!(vm, ids_data, hint_code::SEARCH_SORTED_LOWER),

--- a/src/hint_processor/builtin_hint_processor/hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/hint_utils.rs
@@ -92,7 +92,7 @@ pub fn get_relocatable_from_var_name(
 }
 
 //Gets the value of a variable name.
-//If the value is an MaybeRelocatable::Int(Bigint) return &Bigint
+//If the value is an MaybeRelocatable::Int(FieldElement{Bigint}) return &Bigint
 //else raises Err
 pub fn get_integer_from_var_name<'a>(
     var_name: &str,

--- a/src/hint_processor/builtin_hint_processor/math_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/math_utils.rs
@@ -123,7 +123,7 @@ pub fn assert_not_equal(
     match (vm_proxy.memory.get(&a_addr), vm_proxy.memory.get(&b_addr)) {
         (Ok(Some(maybe_rel_a)), Ok(Some(maybe_rel_b))) => match (maybe_rel_a, maybe_rel_b) {
             (MaybeRelocatable::Int(ref a), MaybeRelocatable::Int(ref b)) => {
-                if (a - b).is_multiple_of(vm_proxy.prime) {
+                if (&a.num - &b.num).is_multiple_of(vm_proxy.prime) {
                     return Err(VirtualMachineError::AssertNotEqualFail(
                         maybe_rel_a.clone(),
                         maybe_rel_b.clone(),

--- a/src/hint_processor/builtin_hint_processor/math_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/math_utils.rs
@@ -608,8 +608,8 @@ mod tests {
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((1, 0)),
-                    MaybeRelocatable::Int(bigint!(1)),
-                    MaybeRelocatable::Int(bigint!(0))
+                    MaybeRelocatable::from(bigint!(1)),
+                    MaybeRelocatable::from(bigint!(0))
                 )
             ))
         );
@@ -1339,8 +1339,8 @@ mod tests {
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((1, 0)),
-                    MaybeRelocatable::Int(bigint!(5)),
-                    MaybeRelocatable::Int(bigint!(2))
+                    MaybeRelocatable::from(bigint!(5)),
+                    MaybeRelocatable::from(bigint!(2))
                 )
             ))
         );
@@ -1445,8 +1445,8 @@ mod tests {
             Err(VirtualMachineError::MemoryError(
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((1, 1)),
-                    MaybeRelocatable::Int(bigint!(10)),
-                    MaybeRelocatable::Int(bigint!(31))
+                    MaybeRelocatable::from(bigint!(10)),
+                    MaybeRelocatable::from(bigint!(31))
                 )
             ))
         );

--- a/src/hint_processor/builtin_hint_processor/set.rs
+++ b/src/hint_processor/builtin_hint_processor/set.rs
@@ -135,7 +135,7 @@ mod tests {
         assert_eq!(run_hint!(vm, ids_data, HINT_CODE), Ok(()));
         assert_eq!(
             vm.memory.get(&MaybeRelocatable::from((1, 0))),
-            Ok(Some(&MaybeRelocatable::Int(bigint!(0))))
+            Ok(Some(&MaybeRelocatable::from(bigint!(0))))
         )
     }
 

--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -412,12 +412,12 @@ mod tests {
         let builtins: Vec<String> = Vec::new();
 
         let data: Vec<MaybeRelocatable> = vec![
-            MaybeRelocatable::Int(BigInt::from_i64(5189976364521848832).unwrap()),
-            MaybeRelocatable::Int(BigInt::from_i64(1000).unwrap()),
-            MaybeRelocatable::Int(BigInt::from_i64(5189976364521848832).unwrap()),
-            MaybeRelocatable::Int(BigInt::from_i64(2000).unwrap()),
-            MaybeRelocatable::Int(BigInt::from_i64(5201798304953696256).unwrap()),
-            MaybeRelocatable::Int(BigInt::from_i64(2345108766317314046).unwrap()),
+            MaybeRelocatable::from(BigInt::from_i64(5189976364521848832).unwrap()),
+            MaybeRelocatable::from(BigInt::from_i64(1000).unwrap()),
+            MaybeRelocatable::from(BigInt::from_i64(5189976364521848832).unwrap()),
+            MaybeRelocatable::from(BigInt::from_i64(2000).unwrap()),
+            MaybeRelocatable::from(BigInt::from_i64(5201798304953696256).unwrap()),
+            MaybeRelocatable::from(BigInt::from_i64(2345108766317314046).unwrap()),
         ];
 
         let mut hints: HashMap<usize, Vec<HintParams>> = HashMap::new();
@@ -617,12 +617,12 @@ mod tests {
 
         let builtins: Vec<String> = Vec::new();
         let data: Vec<MaybeRelocatable> = vec![
-            MaybeRelocatable::Int(BigInt::from_i64(5189976364521848832).unwrap()),
-            MaybeRelocatable::Int(BigInt::from_i64(1000).unwrap()),
-            MaybeRelocatable::Int(BigInt::from_i64(5189976364521848832).unwrap()),
-            MaybeRelocatable::Int(BigInt::from_i64(2000).unwrap()),
-            MaybeRelocatable::Int(BigInt::from_i64(5201798304953696256).unwrap()),
-            MaybeRelocatable::Int(BigInt::from_i64(2345108766317314046).unwrap()),
+            MaybeRelocatable::from(BigInt::from_i64(5189976364521848832).unwrap()),
+            MaybeRelocatable::from(BigInt::from_i64(1000).unwrap()),
+            MaybeRelocatable::from(BigInt::from_i64(5189976364521848832).unwrap()),
+            MaybeRelocatable::from(BigInt::from_i64(2000).unwrap()),
+            MaybeRelocatable::from(BigInt::from_i64(5201798304953696256).unwrap()),
+            MaybeRelocatable::from(BigInt::from_i64(2345108766317314046).unwrap()),
         ];
 
         let mut hints: HashMap<usize, Vec<HintParams>> = HashMap::new();

--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -170,7 +170,7 @@ impl<'de> de::Visitor<'de> for MaybeRelocatableVisitor {
                     hex::decode(&no_prefix_hex);
 
                 match decoded_result {
-                    Ok(decoded_hex) => data.push(MaybeRelocatable::Int(BigInt::from_bytes_be(
+                    Ok(decoded_hex) => data.push(MaybeRelocatable::from(BigInt::from_bytes_be(
                         Sign::Plus,
                         &decoded_hex,
                     ))),

--- a/src/types/program.rs
+++ b/src/types/program.rs
@@ -39,12 +39,12 @@ mod tests {
 
         let builtins: Vec<String> = Vec::new();
         let data: Vec<MaybeRelocatable> = vec![
-            MaybeRelocatable::Int(BigInt::from_i64(5189976364521848832).unwrap()),
-            MaybeRelocatable::Int(BigInt::from_i64(1000).unwrap()),
-            MaybeRelocatable::Int(BigInt::from_i64(5189976364521848832).unwrap()),
-            MaybeRelocatable::Int(BigInt::from_i64(2000).unwrap()),
-            MaybeRelocatable::Int(BigInt::from_i64(5201798304953696256).unwrap()),
-            MaybeRelocatable::Int(BigInt::from_i64(2345108766317314046).unwrap()),
+            MaybeRelocatable::from(BigInt::from_i64(5189976364521848832).unwrap()),
+            MaybeRelocatable::from(BigInt::from_i64(1000).unwrap()),
+            MaybeRelocatable::from(BigInt::from_i64(5189976364521848832).unwrap()),
+            MaybeRelocatable::from(BigInt::from_i64(2000).unwrap()),
+            MaybeRelocatable::from(BigInt::from_i64(5201798304953696256).unwrap()),
+            MaybeRelocatable::from(BigInt::from_i64(2345108766317314046).unwrap()),
         ];
 
         let mut identifiers: HashMap<String, Identifier> = HashMap::new();

--- a/src/types/relocatable.rs
+++ b/src/types/relocatable.rs
@@ -540,14 +540,14 @@ mod tests {
     fn add_bigint_to_int() {
         let addr = MaybeRelocatable::from(bigint!(7));
         let added_addr = addr.add_int_mod(&bigint!(2), &bigint!(17));
-        assert_eq!(Ok(MaybeRelocatable::Int(bigint!(9))), added_addr);
+        assert_eq!(Ok(MaybeRelocatable::from(bigint!(9))), added_addr);
     }
 
     #[test]
     fn add_usize_to_int() {
         let addr = MaybeRelocatable::from(bigint!(7));
         let added_addr = addr.add_usize_mod(2, Some(bigint!(17)));
-        assert_eq!(MaybeRelocatable::Int(bigint!(9)), added_addr);
+        assert_eq!(MaybeRelocatable::from(bigint!(9)), added_addr);
     }
 
     #[test]
@@ -602,7 +602,7 @@ mod tests {
                 ],
             ),
         );
-        assert_eq!(Ok(MaybeRelocatable::Int(bigint!(4))), added_addr);
+        assert_eq!(Ok(MaybeRelocatable::from(bigint!(4))), added_addr);
     }
 
     #[test]
@@ -628,7 +628,7 @@ mod tests {
 
     #[test]
     fn add_int_to_int_prime() {
-        let addr_a = &MaybeRelocatable::Int(BigInt::new(
+        let addr_a = &MaybeRelocatable::from(BigInt::new(
             Sign::Plus,
             vec![1, 0, 0, 0, 0, 0, 17, 134217728],
         ));
@@ -677,7 +677,7 @@ mod tests {
     #[test]
     fn add_int_to_relocatable_prime() {
         let addr_a = &MaybeRelocatable::from((7, 14));
-        let addr_b = &MaybeRelocatable::Int(BigInt::new(
+        let addr_b = &MaybeRelocatable::from(BigInt::new(
             Sign::Plus,
             vec![1, 0, 0, 0, 0, 0, 17, 134217728],
         ));
@@ -708,7 +708,7 @@ mod tests {
 
     #[test]
     fn add_int_int_rel_offset_exceeded() {
-        let addr = MaybeRelocatable::Int(bigint_str!(b"18446744073709551616"));
+        let addr = MaybeRelocatable::from(bigint_str!(b"18446744073709551616"));
         let relocatable = Relocatable {
             offset: 0,
             segment_index: 0,
@@ -779,16 +779,16 @@ mod tests {
 
     #[test]
     fn mod_floor_int() {
-        let num = MaybeRelocatable::Int(bigint!(7));
+        let num = MaybeRelocatable::from(bigint!(7));
         let div = bigint!(5);
-        let expected_rem = MaybeRelocatable::Int(bigint!(2));
+        let expected_rem = MaybeRelocatable::from(bigint!(2));
         assert_eq!(num.mod_floor(&div), Ok(expected_rem));
     }
 
     #[test]
     fn mod_floor_bad_type() {
         let value = &MaybeRelocatable::from((2, 7));
-        let div = MaybeRelocatable::Int(bigint!(5));
+        let div = MaybeRelocatable::from(bigint!(5));
         assert_eq!(value.divmod(&div), Err(VirtualMachineError::NotImplemented));
     }
 

--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -5,7 +5,7 @@ use num_bigint::BigInt;
 use num_integer::Integer;
 
 use crate::bigint;
-use crate::types::relocatable::{MaybeRelocatable, Relocatable};
+use crate::types::relocatable::{FieldElement, MaybeRelocatable, Relocatable};
 use crate::vm::errors::runner_errors::RunnerError;
 use crate::vm::runners::builtin_runner::BuiltinRunner;
 use crate::vm::vm_memory::memory::Memory;
@@ -58,8 +58,10 @@ impl BuiltinRunner for BitwiseBuiltinRunner {
         }
         let x_addr = MaybeRelocatable::from((address.segment_index, address.offset - index));
         let y_addr = x_addr.add_usize_mod(1, None);
-        if let (Ok(Some(MaybeRelocatable::Int(num_x))), Ok(Some(MaybeRelocatable::Int(num_y)))) =
-            (memory.get(&x_addr), memory.get(&y_addr))
+        if let (
+            Ok(Some(MaybeRelocatable::Int(FieldElement { num: num_x }))),
+            Ok(Some(MaybeRelocatable::Int(FieldElement { num: num_y }))),
+        ) = (memory.get(&x_addr), memory.get(&y_addr))
         {
             let _2_pow_bits = bigint!(1).shl(self.total_n_bits);
             if num_x >= &_2_pow_bits {

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -4,7 +4,7 @@ use num_bigint::BigInt;
 use num_integer::Integer;
 
 use crate::math_utils::{ec_add, ec_double};
-use crate::types::relocatable::{MaybeRelocatable, Relocatable};
+use crate::types::relocatable::{FieldElement, MaybeRelocatable, Relocatable};
 use crate::vm::errors::runner_errors::RunnerError;
 use crate::vm::runners::builtin_runner::BuiltinRunner;
 use crate::vm::vm_memory::memory::Memory;
@@ -128,7 +128,7 @@ impl BuiltinRunner for EcOpBuiltinRunner {
             {
                 None => return Ok(None),
                 Some(addr) => {
-                    if let &MaybeRelocatable::Int(ref num) = addr {
+                    if let &MaybeRelocatable::Int(FieldElement { ref num }) = addr {
                         input_cells.push(num);
                     } else {
                         return Err(RunnerError::ExpectedInteger(
@@ -166,8 +166,8 @@ impl BuiltinRunner for EcOpBuiltinRunner {
             self.scalar_height,
         )?;
         match index - self.n_input_cells {
-            0 => Ok(Some(MaybeRelocatable::Int(result.0))),
-            _ => Ok(Some(MaybeRelocatable::Int(result.1))),
+            0 => Ok(Some(MaybeRelocatable::from(result.0))),
+            _ => Ok(Some(MaybeRelocatable::from(result.1))),
             //Default case corresponds to 1, as there are no other possible cases
         }
     }

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -4,7 +4,7 @@ use num_bigint::BigInt;
 use num_integer::Integer;
 
 use crate::math_utils::{ec_add, ec_double};
-use crate::types::relocatable::{FieldElement, MaybeRelocatable, Relocatable};
+use crate::types::relocatable::{MaybeRelocatable, Relocatable};
 use crate::vm::errors::runner_errors::RunnerError;
 use crate::vm::runners::builtin_runner::BuiltinRunner;
 use crate::vm::vm_memory::memory::Memory;
@@ -128,8 +128,8 @@ impl BuiltinRunner for EcOpBuiltinRunner {
             {
                 None => return Ok(None),
                 Some(addr) => {
-                    if let &MaybeRelocatable::Int(FieldElement { ref num }) = addr {
-                        input_cells.push(num);
+                    if let &MaybeRelocatable::Int(ref felt) = addr {
+                        input_cells.push(&felt.num);
                     } else {
                         return Err(RunnerError::ExpectedInteger(
                             instance.add_usize_mod(i, None),

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -5,7 +5,7 @@ use num_bigint::BigInt;
 use num_traits::{One, Zero};
 
 use crate::bigint;
-use crate::types::relocatable::{MaybeRelocatable, Relocatable};
+use crate::types::relocatable::{FieldElement, MaybeRelocatable, Relocatable};
 use crate::vm::errors::memory_errors::MemoryError;
 use crate::vm::errors::runner_errors::RunnerError;
 use crate::vm::runners::builtin_runner::BuiltinRunner;
@@ -56,7 +56,9 @@ impl BuiltinRunner for RangeCheckBuiltinRunner {
             |memory: &Memory,
              address: &MaybeRelocatable|
              -> Result<MaybeRelocatable, MemoryError> {
-                if let Some(MaybeRelocatable::Int(ref num)) = memory.get(address)? {
+                if let Some(MaybeRelocatable::Int(FieldElement { ref num })) =
+                    memory.get(address)?
+                {
                     if &BigInt::zero() <= num && num < &BigInt::one().shl(128u8) {
                         Ok(address.to_owned())
                     } else {

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -670,7 +670,7 @@ mod tests {
             .get_instruction_encoding()
             .expect("Unexpected error on get_instruction_encoding");
         assert_eq!(num, &bigint!(5));
-        assert_eq!(imm, Some(&MaybeRelocatable::Int(bigint!(6))));
+        assert_eq!(imm, Some(&MaybeRelocatable::from(bigint!(6))));
     }
 
     #[test]
@@ -700,10 +700,10 @@ mod tests {
         };
 
         let operands = Operands {
-            dst: MaybeRelocatable::Int(bigint!(11)),
-            res: Some(MaybeRelocatable::Int(bigint!(8))),
-            op0: MaybeRelocatable::Int(bigint!(9)),
-            op1: MaybeRelocatable::Int(bigint!(10)),
+            dst: MaybeRelocatable::from(bigint!(11)),
+            res: Some(MaybeRelocatable::from(bigint!(8))),
+            op0: MaybeRelocatable::from(bigint!(9)),
+            op1: MaybeRelocatable::from(bigint!(10)),
         };
 
         let mut vm = vm!();
@@ -761,10 +761,10 @@ mod tests {
         };
 
         let operands = Operands {
-            dst: MaybeRelocatable::Int(bigint!(11)),
-            res: Some(MaybeRelocatable::Int(bigint!(8))),
-            op0: MaybeRelocatable::Int(bigint!(9)),
-            op1: MaybeRelocatable::Int(bigint!(10)),
+            dst: MaybeRelocatable::from(bigint!(11)),
+            res: Some(MaybeRelocatable::from(bigint!(8))),
+            op0: MaybeRelocatable::from(bigint!(9)),
+            op1: MaybeRelocatable::from(bigint!(10)),
         };
 
         let mut vm = vm!();
@@ -791,10 +791,10 @@ mod tests {
         };
 
         let operands = Operands {
-            dst: MaybeRelocatable::Int(bigint!(11)),
-            res: Some(MaybeRelocatable::Int(bigint!(8))),
-            op0: MaybeRelocatable::Int(bigint!(9)),
-            op1: MaybeRelocatable::Int(bigint!(10)),
+            dst: MaybeRelocatable::from(bigint!(11)),
+            res: Some(MaybeRelocatable::from(bigint!(8))),
+            op0: MaybeRelocatable::from(bigint!(9)),
+            op1: MaybeRelocatable::from(bigint!(10)),
         };
 
         let mut vm = VirtualMachine::new(bigint!(39), Vec::new(), false);
@@ -824,10 +824,10 @@ mod tests {
         };
 
         let operands = Operands {
-            dst: MaybeRelocatable::Int(bigint!(11)),
+            dst: MaybeRelocatable::from(bigint!(11)),
             res: None,
-            op0: MaybeRelocatable::Int(bigint!(9)),
-            op1: MaybeRelocatable::Int(bigint!(10)),
+            op0: MaybeRelocatable::from(bigint!(9)),
+            op1: MaybeRelocatable::from(bigint!(10)),
         };
 
         let mut vm = VirtualMachine::new(bigint!(39), Vec::new(), false);
@@ -859,10 +859,10 @@ mod tests {
         };
 
         let operands = Operands {
-            dst: MaybeRelocatable::Int(bigint!(11)),
-            res: Some(MaybeRelocatable::Int(bigint!(8))),
-            op0: MaybeRelocatable::Int(bigint!(9)),
-            op1: MaybeRelocatable::Int(bigint!(10)),
+            dst: MaybeRelocatable::from(bigint!(11)),
+            res: Some(MaybeRelocatable::from(bigint!(8))),
+            op0: MaybeRelocatable::from(bigint!(9)),
+            op1: MaybeRelocatable::from(bigint!(10)),
         };
 
         let mut vm = VirtualMachine::new(bigint!(39), Vec::new(), false);
@@ -892,10 +892,10 @@ mod tests {
         };
 
         let operands = Operands {
-            dst: MaybeRelocatable::Int(bigint!(11)),
-            res: Some(MaybeRelocatable::Int(bigint!(8))),
-            op0: MaybeRelocatable::Int(bigint!(9)),
-            op1: MaybeRelocatable::Int(bigint!(10)),
+            dst: MaybeRelocatable::from(bigint!(11)),
+            res: Some(MaybeRelocatable::from(bigint!(8))),
+            op0: MaybeRelocatable::from(bigint!(9)),
+            op1: MaybeRelocatable::from(bigint!(10)),
         };
 
         let mut vm = VirtualMachine::new(bigint!(39), Vec::new(), false);
@@ -925,10 +925,10 @@ mod tests {
         };
 
         let operands = Operands {
-            dst: MaybeRelocatable::Int(bigint!(11)),
-            res: Some(MaybeRelocatable::Int(bigint!(8))),
-            op0: MaybeRelocatable::Int(bigint!(9)),
-            op1: MaybeRelocatable::Int(bigint!(10)),
+            dst: MaybeRelocatable::from(bigint!(11)),
+            res: Some(MaybeRelocatable::from(bigint!(8))),
+            op0: MaybeRelocatable::from(bigint!(9)),
+            op1: MaybeRelocatable::from(bigint!(10)),
         };
 
         let mut vm = VirtualMachine::new(bigint!(39), Vec::new(), false);
@@ -958,10 +958,10 @@ mod tests {
         };
 
         let operands = Operands {
-            dst: MaybeRelocatable::Int(bigint!(11)),
-            res: Some(MaybeRelocatable::Int(bigint!(8))),
-            op0: MaybeRelocatable::Int(bigint!(9)),
-            op1: MaybeRelocatable::Int(bigint!(10)),
+            dst: MaybeRelocatable::from(bigint!(11)),
+            res: Some(MaybeRelocatable::from(bigint!(8))),
+            op0: MaybeRelocatable::from(bigint!(9)),
+            op1: MaybeRelocatable::from(bigint!(10)),
         };
 
         let mut vm = vm!();
@@ -988,10 +988,10 @@ mod tests {
         };
 
         let operands = Operands {
-            dst: MaybeRelocatable::Int(bigint!(11)),
-            res: Some(MaybeRelocatable::Int(bigint!(8))),
-            op0: MaybeRelocatable::Int(bigint!(9)),
-            op1: MaybeRelocatable::Int(bigint!(10)),
+            dst: MaybeRelocatable::from(bigint!(11)),
+            res: Some(MaybeRelocatable::from(bigint!(8))),
+            op0: MaybeRelocatable::from(bigint!(9)),
+            op1: MaybeRelocatable::from(bigint!(10)),
         };
 
         let mut vm = vm!();
@@ -1020,8 +1020,8 @@ mod tests {
         let operands = Operands {
             dst: mayberelocatable!(1, 11),
             res: Some(mayberelocatable!(0, 8)),
-            op0: MaybeRelocatable::Int(bigint!(9)),
-            op1: MaybeRelocatable::Int(bigint!(10)),
+            op0: MaybeRelocatable::from(bigint!(9)),
+            op1: MaybeRelocatable::from(bigint!(10)),
         };
 
         let mut vm = vm!();
@@ -1048,10 +1048,10 @@ mod tests {
         };
 
         let operands = Operands {
-            dst: MaybeRelocatable::Int(bigint!(11)),
+            dst: MaybeRelocatable::from(bigint!(11)),
             res: None,
-            op0: MaybeRelocatable::Int(bigint!(9)),
-            op1: MaybeRelocatable::Int(bigint!(10)),
+            op0: MaybeRelocatable::from(bigint!(9)),
+            op1: MaybeRelocatable::from(bigint!(10)),
         };
 
         let mut vm = VirtualMachine::new(bigint!(39), Vec::new(), false);
@@ -1083,10 +1083,10 @@ mod tests {
         };
 
         let operands = Operands {
-            dst: MaybeRelocatable::Int(bigint!(11)),
-            res: Some(MaybeRelocatable::Int(bigint!(8))),
-            op0: MaybeRelocatable::Int(bigint!(9)),
-            op1: MaybeRelocatable::Int(bigint!(10)),
+            dst: MaybeRelocatable::from(bigint!(11)),
+            res: Some(MaybeRelocatable::from(bigint!(8))),
+            op0: MaybeRelocatable::from(bigint!(9)),
+            op1: MaybeRelocatable::from(bigint!(10)),
         };
 
         let mut vm = vm!();
@@ -1114,10 +1114,10 @@ mod tests {
         };
 
         let operands = Operands {
-            dst: MaybeRelocatable::Int(bigint!(11)),
+            dst: MaybeRelocatable::from(bigint!(11)),
             res: None,
-            op0: MaybeRelocatable::Int(bigint!(9)),
-            op1: MaybeRelocatable::Int(bigint!(10)),
+            op0: MaybeRelocatable::from(bigint!(9)),
+            op1: MaybeRelocatable::from(bigint!(10)),
         };
 
         let mut vm = vm!();
@@ -1146,10 +1146,10 @@ mod tests {
         };
 
         let operands = Operands {
-            dst: MaybeRelocatable::Int(bigint!(11)),
+            dst: MaybeRelocatable::from(bigint!(11)),
             res: Some(MaybeRelocatable::from((1, 4))),
-            op0: MaybeRelocatable::Int(bigint!(9)),
-            op1: MaybeRelocatable::Int(bigint!(10)),
+            op0: MaybeRelocatable::from(bigint!(9)),
+            op1: MaybeRelocatable::from(bigint!(10)),
         };
 
         let mut vm = vm!();
@@ -1178,10 +1178,10 @@ mod tests {
         };
 
         let operands = Operands {
-            dst: MaybeRelocatable::Int(bigint!(0)),
-            res: Some(MaybeRelocatable::Int(bigint!(0))),
-            op0: MaybeRelocatable::Int(bigint!(9)),
-            op1: MaybeRelocatable::Int(bigint!(10)),
+            dst: MaybeRelocatable::from(bigint!(0)),
+            res: Some(MaybeRelocatable::from(bigint!(0))),
+            op0: MaybeRelocatable::from(bigint!(9)),
+            op1: MaybeRelocatable::from(bigint!(10)),
         };
 
         let mut vm = vm!();
@@ -1208,10 +1208,10 @@ mod tests {
         };
 
         let operands = Operands {
-            dst: MaybeRelocatable::Int(bigint!(11)),
-            res: Some(MaybeRelocatable::Int(bigint!(8))),
-            op0: MaybeRelocatable::Int(bigint!(9)),
-            op1: MaybeRelocatable::Int(bigint!(10)),
+            dst: MaybeRelocatable::from(bigint!(11)),
+            res: Some(MaybeRelocatable::from(bigint!(8))),
+            op0: MaybeRelocatable::from(bigint!(9)),
+            op1: MaybeRelocatable::from(bigint!(10)),
         };
 
         let mut vm = vm!();
@@ -1238,10 +1238,10 @@ mod tests {
         };
 
         let operands = Operands {
-            dst: MaybeRelocatable::Int(bigint!(11)),
-            res: Some(MaybeRelocatable::Int(bigint!(8))),
-            op0: MaybeRelocatable::Int(bigint!(9)),
-            op1: MaybeRelocatable::Int(bigint!(10)),
+            dst: MaybeRelocatable::from(bigint!(11)),
+            res: Some(MaybeRelocatable::from(bigint!(8))),
+            op0: MaybeRelocatable::from(bigint!(9)),
+            op1: MaybeRelocatable::from(bigint!(10)),
         };
 
         let mut vm = VirtualMachine::new(bigint!(39), Vec::new(), false);
@@ -1274,9 +1274,9 @@ mod tests {
 
         let operands = Operands {
             dst: MaybeRelocatable::from((1, 11)),
-            res: Some(MaybeRelocatable::Int(bigint!(8))),
-            op0: MaybeRelocatable::Int(bigint!(9)),
-            op1: MaybeRelocatable::Int(bigint!(10)),
+            res: Some(MaybeRelocatable::from(bigint!(8))),
+            op0: MaybeRelocatable::from(bigint!(9)),
+            op1: MaybeRelocatable::from(bigint!(10)),
         };
 
         let mut vm = vm!();
@@ -1290,7 +1290,7 @@ mod tests {
 
     #[test]
     fn is_zero_int_value() {
-        let value = MaybeRelocatable::Int(bigint!(1));
+        let value = MaybeRelocatable::from(bigint!(1));
         assert_eq!(Ok(false), VirtualMachine::is_zero(value));
     }
 
@@ -1356,12 +1356,12 @@ mod tests {
 
         let vm = vm!();
 
-        let dst = MaybeRelocatable::Int(bigint!(3));
-        let op1 = MaybeRelocatable::Int(bigint!(2));
+        let dst = MaybeRelocatable::from(bigint!(3));
+        let op1 = MaybeRelocatable::from(bigint!(2));
         assert_eq!(
             Ok((
-                Some(MaybeRelocatable::Int(bigint!(1))),
-                Some(MaybeRelocatable::Int(bigint!(3)))
+                Some(MaybeRelocatable::from(bigint!(1))),
+                Some(MaybeRelocatable::from(bigint!(3)))
             )),
             vm.deduce_op0(&instruction, Some(&dst), Some(&op1))
         );
@@ -1408,12 +1408,12 @@ mod tests {
 
         let vm = vm!();
 
-        let dst = MaybeRelocatable::Int(bigint!(4));
-        let op1 = MaybeRelocatable::Int(bigint!(2));
+        let dst = MaybeRelocatable::from(bigint!(4));
+        let op1 = MaybeRelocatable::from(bigint!(2));
         assert_eq!(
             Ok((
-                Some(MaybeRelocatable::Int(bigint!(2))),
-                Some(MaybeRelocatable::Int(bigint!(4)))
+                Some(MaybeRelocatable::from(bigint!(2))),
+                Some(MaybeRelocatable::from(bigint!(4)))
             )),
             vm.deduce_op0(&instruction, Some(&dst), Some(&op1))
         );
@@ -1438,8 +1438,8 @@ mod tests {
 
         let vm = vm!();
 
-        let dst = MaybeRelocatable::Int(bigint!(4));
-        let op1 = MaybeRelocatable::Int(bigint!(0));
+        let dst = MaybeRelocatable::from(bigint!(4));
+        let op1 = MaybeRelocatable::from(bigint!(0));
         assert_eq!(
             Ok((None, None)),
             vm.deduce_op0(&instruction, Some(&dst), Some(&op1))
@@ -1465,8 +1465,8 @@ mod tests {
 
         let vm = vm!();
 
-        let dst = MaybeRelocatable::Int(bigint!(4));
-        let op1 = MaybeRelocatable::Int(bigint!(0));
+        let dst = MaybeRelocatable::from(bigint!(4));
+        let op1 = MaybeRelocatable::from(bigint!(0));
         assert_eq!(
             Ok((None, None)),
             vm.deduce_op0(&instruction, Some(&dst), Some(&op1))
@@ -1492,8 +1492,8 @@ mod tests {
 
         let vm = vm!();
 
-        let dst = MaybeRelocatable::Int(bigint!(4));
-        let op1 = MaybeRelocatable::Int(bigint!(0));
+        let dst = MaybeRelocatable::from(bigint!(4));
+        let op1 = MaybeRelocatable::from(bigint!(0));
         assert_eq!(
             Ok((None, None)),
             vm.deduce_op0(&instruction, Some(&dst), Some(&op1))
@@ -1541,12 +1541,12 @@ mod tests {
 
         let vm = vm!();
 
-        let dst = MaybeRelocatable::Int(bigint!(3));
-        let op0 = MaybeRelocatable::Int(bigint!(2));
+        let dst = MaybeRelocatable::from(bigint!(3));
+        let op0 = MaybeRelocatable::from(bigint!(2));
         assert_eq!(
             Ok((
-                Some(MaybeRelocatable::Int(bigint!(1))),
-                Some(MaybeRelocatable::Int(bigint!(3)))
+                Some(MaybeRelocatable::from(bigint!(1))),
+                Some(MaybeRelocatable::from(bigint!(3)))
             )),
             vm.deduce_op1(&instruction, Some(&dst), Some(op0))
         );
@@ -1593,12 +1593,12 @@ mod tests {
 
         let vm = vm!();
 
-        let dst = MaybeRelocatable::Int(bigint!(4));
-        let op0 = MaybeRelocatable::Int(bigint!(2));
+        let dst = MaybeRelocatable::from(bigint!(4));
+        let op0 = MaybeRelocatable::from(bigint!(2));
         assert_eq!(
             Ok((
-                Some(MaybeRelocatable::Int(bigint!(2))),
-                Some(MaybeRelocatable::Int(bigint!(4)))
+                Some(MaybeRelocatable::from(bigint!(2))),
+                Some(MaybeRelocatable::from(bigint!(4)))
             )),
             vm.deduce_op1(&instruction, Some(&dst), Some(op0))
         );
@@ -1623,8 +1623,8 @@ mod tests {
 
         let vm = vm!();
 
-        let dst = MaybeRelocatable::Int(bigint!(4));
-        let op0 = MaybeRelocatable::Int(bigint!(0));
+        let dst = MaybeRelocatable::from(bigint!(4));
+        let op0 = MaybeRelocatable::from(bigint!(0));
         assert_eq!(
             Ok((None, None)),
             vm.deduce_op1(&instruction, Some(&dst), Some(op0))
@@ -1650,7 +1650,7 @@ mod tests {
 
         let vm = vm!();
 
-        let op0 = MaybeRelocatable::Int(bigint!(0));
+        let op0 = MaybeRelocatable::from(bigint!(0));
         assert_eq!(
             Ok((None, None)),
             vm.deduce_op1(&instruction, None, Some(op0))
@@ -1676,11 +1676,11 @@ mod tests {
 
         let vm = vm!();
 
-        let dst = MaybeRelocatable::Int(bigint!(7));
+        let dst = MaybeRelocatable::from(bigint!(7));
         assert_eq!(
             Ok((
-                Some(MaybeRelocatable::Int(bigint!(7))),
-                Some(MaybeRelocatable::Int(bigint!(7)))
+                Some(MaybeRelocatable::from(bigint!(7))),
+                Some(MaybeRelocatable::from(bigint!(7)))
             )),
             vm.deduce_op1(&instruction, Some(&dst), None)
         );
@@ -1705,10 +1705,10 @@ mod tests {
 
         let vm = vm!();
 
-        let op1 = MaybeRelocatable::Int(bigint!(7));
-        let op0 = MaybeRelocatable::Int(bigint!(9));
+        let op1 = MaybeRelocatable::from(bigint!(7));
+        let op0 = MaybeRelocatable::from(bigint!(9));
         assert_eq!(
-            Ok(Some(MaybeRelocatable::Int(bigint!(7)))),
+            Ok(Some(MaybeRelocatable::from(bigint!(7)))),
             vm.compute_res(&instruction, &op0, &op1)
         );
     }
@@ -1732,10 +1732,10 @@ mod tests {
 
         let vm = vm!();
 
-        let op1 = MaybeRelocatable::Int(bigint!(7));
-        let op0 = MaybeRelocatable::Int(bigint!(9));
+        let op1 = MaybeRelocatable::from(bigint!(7));
+        let op0 = MaybeRelocatable::from(bigint!(9));
         assert_eq!(
-            Ok(Some(MaybeRelocatable::Int(bigint!(16)))),
+            Ok(Some(MaybeRelocatable::from(bigint!(16)))),
             vm.compute_res(&instruction, &op0, &op1)
         );
     }
@@ -1759,10 +1759,10 @@ mod tests {
 
         let vm = vm!();
 
-        let op1 = MaybeRelocatable::Int(bigint!(7));
-        let op0 = MaybeRelocatable::Int(bigint!(9));
+        let op1 = MaybeRelocatable::from(bigint!(7));
+        let op0 = MaybeRelocatable::from(bigint!(9));
         assert_eq!(
-            Ok(Some(MaybeRelocatable::Int(bigint!(63)))),
+            Ok(Some(MaybeRelocatable::from(bigint!(63)))),
             vm.compute_res(&instruction, &op0, &op1)
         );
     }
@@ -1813,8 +1813,8 @@ mod tests {
 
         let vm = vm!();
 
-        let op1 = MaybeRelocatable::Int(bigint!(7));
-        let op0 = MaybeRelocatable::Int(bigint!(9));
+        let op1 = MaybeRelocatable::from(bigint!(7));
+        let op0 = MaybeRelocatable::from(bigint!(9));
         assert_eq!(Ok(None), vm.compute_res(&instruction, &op0, &op1));
     }
 
@@ -1837,9 +1837,9 @@ mod tests {
 
         let vm = vm!();
 
-        let res = MaybeRelocatable::Int(bigint!(7));
+        let res = MaybeRelocatable::from(bigint!(7));
         assert_eq!(
-            Some(MaybeRelocatable::Int(bigint!(7))),
+            Some(MaybeRelocatable::from(bigint!(7))),
             vm.deduce_dst(&instruction, Some(&res))
         );
     }
@@ -1938,11 +1938,11 @@ mod tests {
 
         vm.memory.data.push(Vec::new());
         let dst_addr = MaybeRelocatable::from((1, 0));
-        let dst_addr_value = MaybeRelocatable::Int(bigint!(5));
+        let dst_addr_value = MaybeRelocatable::from(bigint!(5));
         let op0_addr = MaybeRelocatable::from((1, 1));
-        let op0_addr_value = MaybeRelocatable::Int(bigint!(2));
+        let op0_addr_value = MaybeRelocatable::from(bigint!(2));
         let op1_addr = MaybeRelocatable::from((1, 2));
-        let op1_addr_value = MaybeRelocatable::Int(bigint!(3));
+        let op1_addr_value = MaybeRelocatable::from(bigint!(3));
         vm.memory.insert(&dst_addr, &dst_addr_value).unwrap();
         vm.memory.insert(&op0_addr, &op0_addr_value).unwrap();
         vm.memory.insert(&op1_addr, &op1_addr_value).unwrap();
@@ -2108,10 +2108,10 @@ mod tests {
         };
 
         let operands = Operands {
-            dst: MaybeRelocatable::Int(bigint!(8)),
+            dst: MaybeRelocatable::from(bigint!(8)),
             res: None,
-            op0: MaybeRelocatable::Int(bigint!(9)),
-            op1: MaybeRelocatable::Int(bigint!(10)),
+            op0: MaybeRelocatable::from(bigint!(9)),
+            op1: MaybeRelocatable::from(bigint!(10)),
         };
 
         let vm = vm!();
@@ -2138,10 +2138,10 @@ mod tests {
         };
 
         let operands = Operands {
-            dst: MaybeRelocatable::Int(bigint!(9)),
-            res: Some(MaybeRelocatable::Int(bigint!(8))),
-            op0: MaybeRelocatable::Int(bigint!(9)),
-            op1: MaybeRelocatable::Int(bigint!(10)),
+            dst: MaybeRelocatable::from(bigint!(9)),
+            res: Some(MaybeRelocatable::from(bigint!(8))),
+            op0: MaybeRelocatable::from(bigint!(9)),
+            op1: MaybeRelocatable::from(bigint!(10)),
         };
 
         let vm = vm!();
@@ -2438,7 +2438,7 @@ mod tests {
 
         assert_eq!(
             vm.memory.get(&vm.run_context.get_ap()),
-            Ok(Some(&MaybeRelocatable::Int(bigint!(0x4)))),
+            Ok(Some(&MaybeRelocatable::from(bigint!(0x4)))),
         );
         let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
@@ -2450,7 +2450,7 @@ mod tests {
 
         assert_eq!(
             vm.memory.get(&vm.run_context.get_ap()),
-            Ok(Some(&MaybeRelocatable::Int(bigint!(0x5))))
+            Ok(Some(&MaybeRelocatable::from(bigint!(0x5))))
         );
 
         let hint_processor = BuiltinHintProcessor::new_empty();
@@ -2463,7 +2463,7 @@ mod tests {
 
         assert_eq!(
             vm.memory.get(&vm.run_context.get_ap()),
-            Ok(Some(&MaybeRelocatable::Int(bigint!(0x14)))),
+            Ok(Some(&MaybeRelocatable::from(bigint!(0x14)))),
         );
     }
 
@@ -2828,15 +2828,15 @@ mod tests {
             error,
             Err(VirtualMachineError::InconsistentAutoDeduction(
                 String::from("ec_op"),
-                MaybeRelocatable::Int(bigint_str!(
+                MaybeRelocatable::from(bigint_str!(
                     b"2739017437753868763038285897969098325279422804143820990343394856167768859289"
                 )),
-                Some(MaybeRelocatable::Int(bigint_str!(
+                Some(MaybeRelocatable::from(bigint_str!(
                     b"2778063437308421278851140253538604815869848682781135193774472480292420096757"
                 )))
             ))
         );
-        assert_eq!(error.unwrap_err().to_string(), "Inconsistent auto-deduction for builtin ec_op, expected Int(2739017437753868763038285897969098325279422804143820990343394856167768859289), got Some(Int(2778063437308421278851140253538604815869848682781135193774472480292420096757))");
+        assert_eq!(error.unwrap_err().to_string(), "Inconsistent auto-deduction for builtin ec_op, expected Int(FieldElement { num: 2739017437753868763038285897969098325279422804143820990343394856167768859289 }), got Some(Int(FieldElement { num: 2778063437308421278851140253538604815869848682781135193774472480292420096757 }))");
     }
 
     #[test]

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -246,7 +246,7 @@ impl VirtualMachine {
                                 if !num_op1.is_zero() {
                                     return Ok((
                                         Some(MaybeRelocatable::Int(
-                                            (num_dst / num_op1) % &self.prime,
+                                            &(num_dst / &num_op1) % &self.prime,
                                         )),
                                         Some(dst_addr.clone()),
                                     ));
@@ -294,7 +294,7 @@ impl VirtualMachine {
                             if num_op0.num != bigint!(0) {
                                 return Ok((
                                     Some(MaybeRelocatable::Int(
-                                        (num_dst.clone() / &num_op0) % &self.prime,
+                                        &(num_dst / &num_op0) % &self.prime,
                                     )),
                                     Some(dst_addr.clone()),
                                 ));
@@ -337,7 +337,7 @@ impl VirtualMachine {
                 if let (MaybeRelocatable::Int(num_op0), MaybeRelocatable::Int(num_op1)) = (op0, op1)
                 {
                     return Ok(Some(MaybeRelocatable::from(
-                        (num_op0.clone() * num_op1) % (&self.prime),
+                        &(num_op0 * num_op1) % (&self.prime),
                     )));
                 }
                 Err(VirtualMachineError::PureValue)

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -273,7 +273,7 @@ mod memory_tests {
             error,
             Err(MemoryError::InconsistentMemory(key, val_a, val_b))
         );
-        assert_eq!(error.unwrap_err().to_string(), "Inconsistent memory assignment at address RelocatableValue(Relocatable { segment_index: 0, offset: 0 }). Int(5) != Int(6)");
+        assert_eq!(error.unwrap_err().to_string(), "Inconsistent memory assignment at address RelocatableValue(Relocatable { segment_index: 0, offset: 0 }). Int(FieldElement { num: 5 }) != Int(FieldElement { num: 6 })");
     }
 
     #[test]

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use crate::types::relocatable::Relocatable;
+use crate::types::relocatable::{FieldElement, Relocatable};
 use crate::vm::errors::memory_errors::MemoryError;
 use crate::vm::errors::vm_errors::VirtualMachineError;
 use crate::{types::relocatable::MaybeRelocatable, utils::from_relocatable_to_indexes};
@@ -84,10 +84,10 @@ impl Memory {
     //If the value is an MaybeRelocatable::Int(Bigint) return &Bigint
     //else raises Err
     pub fn get_integer(&self, key: &Relocatable) -> Result<&BigInt, VirtualMachineError> {
-        if let Some(MaybeRelocatable::Int(int)) =
+        if let Some(MaybeRelocatable::Int(FieldElement { num })) =
             self.get(key).map_err(VirtualMachineError::MemoryError)?
         {
-            Ok(int)
+            Ok(num)
         } else {
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from(key),


### PR DESCRIPTION
# Abstract the representation of field elements. Phase 1
Issue: #268 

* Create `FieldElement` struct
* Refactor `MaybeRelocatable(Int(BigInt))` to `MaybeRelocatable(Int(FieldElement))`
* Refactor VmCore module to work with FieldElements instead of BigInts

## Checklist
- [x] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
