### PR TITLE
removes extra / from comment

### DIFF
--- a/src/hint_processor/builtin_hint_processor/memcpy_hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/memcpy_hint_utils.rs
@@ -17,7 +17,7 @@ use crate::{
     vm::errors::vm_errors::VirtualMachineError,
 };
 
-///Implements hint: memory[ap] = segments.add()
+//Implements hint: memory[ap] = segments.add()
 pub fn add_segment(vm_proxy: &mut VMProxy) -> Result<(), VirtualMachineError> {
     let new_segment_base = vm_proxy.memory.add_segment(vm_proxy.segments);
     insert_value_into_ap(&mut vm_proxy.memory, vm_proxy.run_context, new_segment_base)


### PR DESCRIPTION
# TITLE

## Description

Removes extra / from a comment that made cargo doc fail.

Closes #436 

## Checklist
- [x] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
