### PR TITLE
[REFACTOR] Abstract the representation of field elements. Phase 2

### DIFF
--- a/src/hint_processor/builtin_hint_processor/blake2s_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/blake2s_utils.rs
@@ -42,7 +42,7 @@ fn get_maybe_relocatable_array_from_u32(array: &Vec<u32>) -> Vec<MaybeRelocatabl
     new_array
 }
 
-fn get_maybe_relocatable_array_from_bigint(array: &[FieldElement]) -> Vec<MaybeRelocatable> {
+fn get_maybe_relocatable_array_from_felt(array: &[FieldElement]) -> Vec<MaybeRelocatable> {
     array.iter().map(MaybeRelocatable::from).collect()
 }
 /*Helper function for the Cairo blake2s() implementation.
@@ -164,7 +164,7 @@ pub fn blake2s_add_uint256(
         inner_data.push((&low >> (B * i)) & MASK);
     }
     //Insert first batch of data
-    let data = get_maybe_relocatable_array_from_bigint(&inner_data);
+    let data = get_maybe_relocatable_array_from_felt(&inner_data);
     vm_proxy
         .memory
         .load_data(
@@ -179,7 +179,7 @@ pub fn blake2s_add_uint256(
         inner_data.push((&high >> (B * i)) & MASK);
     }
     //Insert second batch of data
-    let data = get_maybe_relocatable_array_from_bigint(&inner_data);
+    let data = get_maybe_relocatable_array_from_felt(&inner_data);
     vm_proxy
         .memory
         .load_data(
@@ -219,7 +219,7 @@ pub fn blake2s_add_uint256_bigend(
         inner_data.push((&high >> (B * (3 - i))) & MASK);
     }
     //Insert first batch of data
-    let data = get_maybe_relocatable_array_from_bigint(&inner_data);
+    let data = get_maybe_relocatable_array_from_felt(&inner_data);
     vm_proxy
         .memory
         .load_data(
@@ -234,7 +234,7 @@ pub fn blake2s_add_uint256_bigend(
         inner_data.push((&low >> (B * (3 - i))) & MASK);
     }
     //Insert second batch of data
-    let data = get_maybe_relocatable_array_from_bigint(&inner_data);
+    let data = get_maybe_relocatable_array_from_felt(&inner_data);
     vm_proxy
         .memory
         .load_data(

--- a/src/hint_processor/builtin_hint_processor/cairo_keccak/keccak_hints.rs
+++ b/src/hint_processor/builtin_hint_processor/cairo_keccak/keccak_hints.rs
@@ -1,3 +1,4 @@
+use crate::felt;
 use crate::hint_processor::builtin_hint_processor::hint_utils::get_integer_from_var_name;
 use crate::hint_processor::builtin_hint_processor::hint_utils::get_ptr_from_var_name;
 use crate::hint_processor::builtin_hint_processor::hint_utils::insert_value_into_ap;
@@ -14,8 +15,8 @@ use num_traits::ToPrimitive;
 use std::collections::HashMap;
 
 lazy_static! {
-    pub static ref BYTES_IN_WORD: BigInt = bigint!(8);
-    pub static ref KECCAK_FULL_RATE_IN_BYTES: BigInt = bigint!(136);
+    pub static ref BYTES_IN_WORD: FieldElement = felt!(8);
+    pub static ref KECCAK_FULL_RATE_IN_BYTES: FieldElement = felt!(136);
 }
 const KECCAK_STATE_SIZE_FELTS: usize = 25;
 const BLOCK_SIZE: usize = 3;
@@ -37,8 +38,8 @@ pub fn keccak_write_args(
     let low = get_integer_from_var_name("low", vm_proxy, ids_data, ap_tracking)?;
     let high = get_integer_from_var_name("high", vm_proxy, ids_data, ap_tracking)?;
 
-    let low_args = [low & bigint!(u64::MAX), low >> 64];
-    let high_args = [high & bigint!(u64::MAX), high >> 64];
+    let low_args = [low & &bigint!(u64::MAX), low >> 64];
+    let high_args = [high & &bigint!(u64::MAX), high >> 64];
 
     vm_proxy
         .memory

--- a/src/hint_processor/builtin_hint_processor/dict_hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/dict_hint_utils.rs
@@ -1,7 +1,7 @@
-use num_bigint::BigInt;
-
 use crate::hint_processor::proxies::exec_scopes_proxy::ExecutionScopesProxy;
 use std::{any::Any, cell::RefCell, collections::HashMap, rc::Rc};
+
+use num_bigint::BigInt;
 
 use crate::{
     any_box,
@@ -56,7 +56,6 @@ pub fn dict_new(
     //Get initial dictionary from scope (defined by an earlier hint)
     let initial_dict =
         copy_initial_dict(exec_scopes_proxy).ok_or(VirtualMachineError::NoInitialDict)?;
-
     //Check if there is a dict manager in scope, create it if there isnt one
     let base = if let Ok(dict_manager) = exec_scopes_proxy.get_dict_manager() {
         dict_manager

--- a/src/hint_processor/builtin_hint_processor/dict_hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/dict_hint_utils.rs
@@ -1,7 +1,8 @@
-use crate::hint_processor::proxies::exec_scopes_proxy::ExecutionScopesProxy;
+use crate::{
+    hint_processor::proxies::exec_scopes_proxy::ExecutionScopesProxy,
+    types::relocatable::FieldElement,
+};
 use std::{any::Any, cell::RefCell, collections::HashMap, rc::Rc};
-
-use num_bigint::BigInt;
 
 use crate::{
     any_box,
@@ -24,14 +25,14 @@ pub const DICT_ACCESS_SIZE: usize = 3;
 
 fn copy_initial_dict(
     exec_scopes_proxy: &mut ExecutionScopesProxy,
-) -> Option<HashMap<BigInt, BigInt>> {
-    let mut initial_dict: Option<HashMap<BigInt, BigInt>> = None;
+) -> Option<HashMap<FieldElement, FieldElement>> {
+    let mut initial_dict: Option<HashMap<FieldElement, FieldElement>> = None;
     if let Some(variable) = exec_scopes_proxy
         .get_local_variables()
         .ok()?
         .get("initial_dict")
     {
-        if let Some(dict) = variable.downcast_ref::<HashMap<BigInt, BigInt>>() {
+        if let Some(dict) = variable.downcast_ref::<HashMap<FieldElement, FieldElement>>() {
             initial_dict = Some(dict.clone());
         }
     }
@@ -200,9 +201,9 @@ pub fn dict_update(
     let current_value = tracker.get_value(key)?;
     if current_value != prev_value {
         return Err(VirtualMachineError::WrongPrevValue(
-            prev_value.clone(),
-            current_value.clone(),
-            key.clone(),
+            prev_value.num.clone(),
+            current_value.num.clone(),
+            key.num.clone(),
         ));
     }
     //Update Value
@@ -272,6 +273,7 @@ pub fn dict_squash_update_ptr(
 #[cfg(test)]
 mod tests {
     use crate::any_box;
+    use crate::felt;
     use crate::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor;
     use crate::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::HintProcessorData;
     use crate::hint_processor::hint_processor_definition::HintProcessor;
@@ -445,7 +447,7 @@ mod tests {
                 .get(&0),
             Some(&DictTracker::new_default_dict(
                 &relocatable!(0, 0),
-                &bigint!(17),
+                &felt!(17),
                 None
             ))
         );

--- a/src/hint_processor/builtin_hint_processor/dict_hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/dict_hint_utils.rs
@@ -1,9 +1,6 @@
 use num_bigint::BigInt;
 
-use crate::{
-    hint_processor::proxies::exec_scopes_proxy::ExecutionScopesProxy,
-    types::relocatable::FieldElement,
-};
+use crate::hint_processor::proxies::exec_scopes_proxy::ExecutionScopesProxy;
 use std::{any::Any, cell::RefCell, collections::HashMap, rc::Rc};
 
 use crate::{
@@ -62,11 +59,9 @@ pub fn dict_new(
 
     //Check if there is a dict manager in scope, create it if there isnt one
     let base = if let Ok(dict_manager) = exec_scopes_proxy.get_dict_manager() {
-        dict_manager.borrow_mut().new_dict(
-            vm_proxy.segments,
-            &mut vm_proxy.memory,
-            initial_dict,
-        )?
+        dict_manager
+            .borrow_mut()
+            .new_dict(vm_proxy.segments, &mut vm_proxy.memory, initial_dict)?
     } else {
         let mut dict_manager = DictManager::new();
         let base =
@@ -282,7 +277,6 @@ pub fn dict_squash_update_ptr(
 #[cfg(test)]
 mod tests {
     use crate::any_box;
-    use crate::felt;
     use crate::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor;
     use crate::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::HintProcessorData;
     use crate::hint_processor::hint_processor_definition::HintProcessor;

--- a/src/hint_processor/builtin_hint_processor/dict_hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/dict_hint_utils.rs
@@ -862,8 +862,8 @@ mod tests {
             variables
                 .get("initial_dict")
                 .unwrap()
-                .downcast_ref::<HashMap<BigInt, BigInt>>(),
-            Some(&HashMap::<BigInt, BigInt>::new())
+                .downcast_ref::<HashMap<FieldElement, FieldElement>>(),
+            Some(&HashMap::<FieldElement, FieldElement>::new())
         );
     }
 
@@ -893,11 +893,11 @@ mod tests {
             variables
                 .get("initial_dict")
                 .unwrap()
-                .downcast_ref::<HashMap<BigInt, BigInt>>(),
+                .downcast_ref::<HashMap<FieldElement, FieldElement>>(),
             Some(&HashMap::from([
-                (bigint!(1), bigint!(2)),
-                (bigint!(3), bigint!(4)),
-                (bigint!(5), bigint!(6))
+                (felt!(1), felt!(2)),
+                (felt!(3), felt!(4)),
+                (felt!(5), felt!(6))
             ]))
         );
     }

--- a/src/hint_processor/builtin_hint_processor/dict_hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/dict_hint_utils.rs
@@ -147,7 +147,7 @@ pub fn dict_write(
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), VirtualMachineError> {
-    let key = &get_integer_from_var_name("key", vm_proxy, ids_data, ap_tracking)?.to_bigint();
+    let key = get_integer_from_var_name("key", vm_proxy, ids_data, ap_tracking)?.to_bigint();
     let new_value =
         get_integer_from_var_name("new_value", vm_proxy, ids_data, ap_tracking)?.to_bigint();
     let dict_ptr = get_ptr_from_var_name("dict_ptr", vm_proxy, ids_data, ap_tracking)?;
@@ -161,9 +161,9 @@ pub fn dict_write(
     //Tracker set to track next dictionary entry
     tracker.current_ptr.offset += DICT_ACCESS_SIZE;
     //Get previous value
-    let prev_value = tracker.get_value(key)?.clone();
+    let prev_value = tracker.get_value(&key)?.clone();
     //Insert new value into tracker
-    tracker.insert_value(key, &new_value);
+    tracker.insert_value(&key, &new_value);
     //Insert previous value into dict_ptr.prev_value
     //Addres for dict_ptr.prev_value should be dict_ptr* + 1 (defined above)
     vm_proxy
@@ -189,11 +189,11 @@ pub fn dict_update(
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), VirtualMachineError> {
-    let key = &get_integer_from_var_name("key", vm_proxy, ids_data, ap_tracking)?.to_bigint();
+    let key = get_integer_from_var_name("key", vm_proxy, ids_data, ap_tracking)?.to_bigint();
     let prev_value =
         get_integer_from_var_name("prev_value", vm_proxy, ids_data, ap_tracking)?.to_bigint();
     let new_value =
-        &get_integer_from_var_name("new_value", vm_proxy, ids_data, ap_tracking)?.to_bigint();
+        get_integer_from_var_name("new_value", vm_proxy, ids_data, ap_tracking)?.to_bigint();
     let dict_ptr = get_ptr_from_var_name("dict_ptr", vm_proxy, ids_data, ap_tracking)?;
 
     //Get tracker for dictionary
@@ -201,7 +201,7 @@ pub fn dict_update(
     let mut dict = dict_manager_ref.borrow_mut();
     let tracker = dict.get_tracker_mut(&dict_ptr)?;
     //Check that prev_value is equal to the current value at the given key
-    let current_value = tracker.get_value(key)?;
+    let current_value = tracker.get_value(&key)?;
     if current_value != &prev_value {
         return Err(VirtualMachineError::WrongPrevValue(
             prev_value,
@@ -210,7 +210,7 @@ pub fn dict_update(
         ));
     }
     //Update Value
-    tracker.insert_value(key, new_value);
+    tracker.insert_value(&key, &new_value);
     tracker.current_ptr.offset += DICT_ACCESS_SIZE;
     Ok(())
 }

--- a/src/hint_processor/builtin_hint_processor/dict_manager.rs
+++ b/src/hint_processor/builtin_hint_processor/dict_manager.rs
@@ -212,7 +212,6 @@ mod tests {
         bigint, hint_processor::proxies::memory_proxy::get_memory_proxy, relocatable,
         vm::vm_memory::memory::Memory,
     };
-    use num_bigint::BigInt;
 
     #[test]
     fn create_dict_manager() {

--- a/src/hint_processor/builtin_hint_processor/dict_manager.rs
+++ b/src/hint_processor/builtin_hint_processor/dict_manager.rs
@@ -4,7 +4,7 @@ use num_bigint::BigInt;
 
 use crate::{
     hint_processor::proxies::memory_proxy::MemoryProxy,
-    types::relocatable::{FieldElement, MaybeRelocatable, Relocatable},
+    types::relocatable::{MaybeRelocatable, Relocatable},
     vm::{
         errors::vm_errors::VirtualMachineError, vm_memory::memory_segments::MemorySegmentManager,
     },
@@ -209,7 +209,7 @@ impl DictTracker {
 mod tests {
     use super::*;
     use crate::{
-        bigint, felt, hint_processor::proxies::memory_proxy::get_memory_proxy, relocatable,
+        bigint, hint_processor::proxies::memory_proxy::get_memory_proxy, relocatable,
         vm::vm_memory::memory::Memory,
     };
     use num_bigint::BigInt;

--- a/src/hint_processor/builtin_hint_processor/dict_manager.rs
+++ b/src/hint_processor/builtin_hint_processor/dict_manager.rs
@@ -210,9 +210,10 @@ impl DictTracker {
 mod tests {
     use super::*;
     use crate::{
-        bigint, hint_processor::proxies::memory_proxy::get_memory_proxy, relocatable,
+        bigint, felt, hint_processor::proxies::memory_proxy::get_memory_proxy, relocatable,
         vm::vm_memory::memory::Memory,
     };
+    use num_bigint::BigInt;
 
     #[test]
     fn create_dict_manager() {
@@ -232,12 +233,12 @@ mod tests {
 
     #[test]
     fn create_dict_tracker_default() {
-        let dict_tracker = DictTracker::new_default_dict(&relocatable!(1, 0), &bigint!(5), None);
+        let dict_tracker = DictTracker::new_default_dict(&relocatable!(1, 0), &felt!(5), None);
         assert_eq!(
             dict_tracker.data,
             Dictionary::DefaultDictionary {
                 dict: HashMap::new(),
-                default_value: bigint!(5)
+                default_value: felt!(5)
             }
         );
         assert_eq!(dict_tracker.current_ptr, relocatable!(1, 0));
@@ -265,14 +266,14 @@ mod tests {
         let mut segments = MemorySegmentManager::new();
         let mut memory = Memory::new();
         let mem_proxy = &mut get_memory_proxy(&mut memory);
-        let base = dict_manager.new_default_dict(&mut segments, mem_proxy, &bigint!(5), None);
+        let base = dict_manager.new_default_dict(&mut segments, mem_proxy, &felt!(5), None);
         assert_eq!(base, Ok(MaybeRelocatable::from((0, 0))));
         assert!(dict_manager.trackers.contains_key(&0));
         assert_eq!(
             dict_manager.trackers.get(&0),
             Some(&DictTracker::new_default_dict(
                 &relocatable!(0, 0),
-                &bigint!(5),
+                &felt!(5),
                 None
             ))
         );
@@ -285,7 +286,7 @@ mod tests {
         let mut segments = MemorySegmentManager::new();
         let mut memory = Memory::new();
         let mut initial_dict = HashMap::<FieldElement, FieldElement>::new();
-        initial_dict.insert(bigint!(5), bigint!(5));
+        initial_dict.insert(felt!(5), felt!(5));
         let mem_proxy = &mut get_memory_proxy(&mut memory);
         let base = dict_manager.new_dict(&mut segments, mem_proxy, initial_dict.clone());
         assert_eq!(base, Ok(MaybeRelocatable::from((0, 0))));
@@ -306,12 +307,12 @@ mod tests {
         let mut segments = MemorySegmentManager::new();
         let mut memory = Memory::new();
         let mut initial_dict = HashMap::<FieldElement, FieldElement>::new();
-        initial_dict.insert(bigint!(5), bigint!(5));
+        initial_dict.insert(felt!(5), felt!(5));
         let mem_proxy = &mut get_memory_proxy(&mut memory);
         let base = dict_manager.new_default_dict(
             &mut segments,
             mem_proxy,
-            &bigint!(7),
+            &felt!(7),
             Some(initial_dict.clone()),
         );
         assert_eq!(base, Ok(MaybeRelocatable::from((0, 0))));
@@ -320,7 +321,7 @@ mod tests {
             dict_manager.trackers.get(&0),
             Some(&DictTracker::new_default_dict(
                 &relocatable!(0, 0),
-                &bigint!(7),
+                &felt!(7),
                 Some(initial_dict)
             ))
         );
@@ -347,7 +348,7 @@ mod tests {
         let mut dict_manager = DictManager::new();
         dict_manager.trackers.insert(
             0,
-            DictTracker::new_default_dict(&relocatable!(0, 0), &bigint!(6), None),
+            DictTracker::new_default_dict(&relocatable!(0, 0), &felt!(6), None),
         );
         let mut segments = MemorySegmentManager::new();
         let mut memory = Memory::new();
@@ -361,19 +362,19 @@ mod tests {
     #[test]
     fn dictionary_get_insert_simple() {
         let mut dictionary = Dictionary::SimpleDictionary(HashMap::new());
-        dictionary.insert(&bigint!(1), &bigint!(2));
-        assert_eq!(dictionary.get(&bigint!(1)), Some(&bigint!(2)));
-        assert_eq!(dictionary.get(&bigint!(2)), None);
+        dictionary.insert(&felt!(1), &felt!(2));
+        assert_eq!(dictionary.get(&felt!(1)), Some(&felt!(2)));
+        assert_eq!(dictionary.get(&felt!(2)), None);
     }
 
     #[test]
     fn dictionary_get_insert_default() {
         let mut dictionary = Dictionary::DefaultDictionary {
             dict: HashMap::new(),
-            default_value: bigint!(7),
+            default_value: felt!(7),
         };
-        dictionary.insert(&bigint!(1), &bigint!(2));
-        assert_eq!(dictionary.get(&bigint!(1)), Some(&bigint!(2)));
-        assert_eq!(dictionary.get(&bigint!(2)), Some(&bigint!(7)));
+        dictionary.insert(&felt!(1), &felt!(2));
+        assert_eq!(dictionary.get(&felt!(1)), Some(&felt!(2)));
+        assert_eq!(dictionary.get(&felt!(2)), Some(&felt!(7)));
     }
 }

--- a/src/hint_processor/builtin_hint_processor/find_element_hint.rs
+++ b/src/hint_processor/builtin_hint_processor/find_element_hint.rs
@@ -150,6 +150,7 @@ pub fn search_sorted_lower(
 mod tests {
     use super::*;
     use crate::any_box;
+    use crate::felt;
     use crate::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor;
     use crate::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::HintProcessorData;
     use crate::hint_processor::builtin_hint_processor::hint_code;
@@ -157,6 +158,7 @@ mod tests {
     use crate::hint_processor::proxies::exec_scopes_proxy::get_exec_scopes_proxy;
     use crate::hint_processor::proxies::vm_proxy::get_vm_proxy;
     use crate::types::exec_scope::ExecutionScopes;
+    use crate::types::relocatable::FieldElement;
     use crate::types::relocatable::MaybeRelocatable;
     use crate::utils::test_utils::vm;
     use crate::utils::test_utils::*;
@@ -243,7 +245,7 @@ mod tests {
     #[test]
     fn element_found_by_oracle() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::new());
-        let mut exec_scopes = scope![("find_element_index", bigint!(1))];
+        let mut exec_scopes = scope![("find_element_index", felt!(1))];
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
         assert_eq!(
             run_hint!(vm, ids_data, hint_code::FIND_ELEMENT, exec_scopes_proxy),
@@ -267,7 +269,7 @@ mod tests {
     #[test]
     fn element_not_found_oracle() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::new());
-        let mut exec_scopes = scope![("find_element_index", bigint!(2))];
+        let mut exec_scopes = scope![("find_element_index", felt!(2))];
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
         assert_eq!(
             run_hint!(vm, ids_data, hint_code::FIND_ELEMENT, exec_scopes_proxy),
@@ -358,7 +360,7 @@ mod tests {
     #[test]
     fn find_elm_n_elms_gt_max_size() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::new());
-        let mut exec_scopes = scope![("find_element_max_size", bigint!(1))];
+        let mut exec_scopes = scope![("find_element_max_size", felt!(1))];
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
         assert_eq!(
             run_hint!(vm, ids_data, hint_code::FIND_ELEMENT, exec_scopes_proxy),
@@ -477,7 +479,7 @@ mod tests {
     #[test]
     fn search_sorted_lower_n_elms_gt_max_size() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::new());
-        let mut exec_scopes = scope![("find_element_max_size", bigint!(1))];
+        let mut exec_scopes = scope![("find_element_max_size", felt!(1))];
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
         assert_eq!(
             run_hint!(

--- a/src/hint_processor/builtin_hint_processor/find_element_hint.rs
+++ b/src/hint_processor/builtin_hint_processor/find_element_hint.rs
@@ -150,7 +150,6 @@ pub fn search_sorted_lower(
 mod tests {
     use super::*;
     use crate::any_box;
-    use crate::felt;
     use crate::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor;
     use crate::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::HintProcessorData;
     use crate::hint_processor::builtin_hint_processor::hint_code;
@@ -158,7 +157,6 @@ mod tests {
     use crate::hint_processor::proxies::exec_scopes_proxy::get_exec_scopes_proxy;
     use crate::hint_processor::proxies::vm_proxy::get_vm_proxy;
     use crate::types::exec_scope::ExecutionScopes;
-    use crate::types::relocatable::FieldElement;
     use crate::types::relocatable::MaybeRelocatable;
     use crate::utils::test_utils::vm;
     use crate::utils::test_utils::*;
@@ -245,7 +243,7 @@ mod tests {
     #[test]
     fn element_found_by_oracle() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::new());
-        let mut exec_scopes = scope![("find_element_index", felt!(1))];
+        let mut exec_scopes = scope![("find_element_index", bigint!(1))];
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
         assert_eq!(
             run_hint!(vm, ids_data, hint_code::FIND_ELEMENT, exec_scopes_proxy),

--- a/src/hint_processor/builtin_hint_processor/find_element_hint.rs
+++ b/src/hint_processor/builtin_hint_processor/find_element_hint.rs
@@ -269,7 +269,7 @@ mod tests {
     #[test]
     fn element_not_found_oracle() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::new());
-        let mut exec_scopes = scope![("find_element_index", felt!(2))];
+        let mut exec_scopes = scope![("find_element_index", bigint!(2))];
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
         assert_eq!(
             run_hint!(vm, ids_data, hint_code::FIND_ELEMENT, exec_scopes_proxy),
@@ -360,7 +360,7 @@ mod tests {
     #[test]
     fn find_elm_n_elms_gt_max_size() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::new());
-        let mut exec_scopes = scope![("find_element_max_size", felt!(1))];
+        let mut exec_scopes = scope![("find_element_max_size", bigint!(1))];
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
         assert_eq!(
             run_hint!(vm, ids_data, hint_code::FIND_ELEMENT, exec_scopes_proxy),
@@ -479,7 +479,7 @@ mod tests {
     #[test]
     fn search_sorted_lower_n_elms_gt_max_size() {
         let (mut vm, ids_data) = init_vm_ids_data(HashMap::new());
-        let mut exec_scopes = scope![("find_element_max_size", felt!(1))];
+        let mut exec_scopes = scope![("find_element_max_size", bigint!(1))];
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
         assert_eq!(
             run_hint!(

--- a/src/hint_processor/builtin_hint_processor/find_element_hint.rs
+++ b/src/hint_processor/builtin_hint_processor/find_element_hint.rs
@@ -2,7 +2,7 @@ use crate::hint_processor::builtin_hint_processor::hint_utils::{
     get_ptr_from_var_name, get_relocatable_from_var_name, insert_value_from_var_name,
 };
 use crate::hint_processor::hint_processor_definition::HintReference;
-use crate::hint_processor::hint_processor_utils::bigint_to_usize;
+use crate::hint_processor::hint_processor_utils::felt_to_usize;
 use crate::hint_processor::proxies::exec_scopes_proxy::ExecutionScopesProxy;
 use crate::hint_processor::proxies::vm_proxy::VMProxy;
 use crate::serde::deserialize_program::ApTracking;
@@ -11,7 +11,6 @@ use crate::{
     bigint, hint_processor::builtin_hint_processor::hint_utils::get_integer_from_var_name,
 };
 use num_bigint::BigInt;
-use num_traits::{Signed, ToPrimitive};
 use std::collections::HashMap;
 
 pub fn find_element(
@@ -27,15 +26,15 @@ pub fn find_element(
     let find_element_index = exec_scopes_proxy.get_int("find_element_index").ok();
     let elm_size = elm_size_bigint
         .to_usize()
-        .ok_or_else(|| VirtualMachineError::ValueOutOfRange(elm_size_bigint.clone()))?;
+        .ok_or_else(|| VirtualMachineError::ValueOutOfRange(elm_size_bigint.num.clone()))?;
     if elm_size == 0 {
         return Err(VirtualMachineError::ValueOutOfRange(
-            elm_size_bigint.clone(),
+            elm_size_bigint.num.clone(),
         ));
     }
 
     if let Some(find_element_index_value) = find_element_index {
-        let find_element_index_usize = bigint_to_usize(&find_element_index_value)?;
+        let find_element_index_usize = felt_to_usize(&find_element_index_value)?;
         let found_key = vm_proxy
             .memory
             .get_integer(&(array_start + (elm_size * find_element_index_usize)))
@@ -43,9 +42,9 @@ pub fn find_element(
 
         if found_key != key {
             return Err(VirtualMachineError::InvalidIndex(
-                find_element_index_value,
-                key.clone(),
-                found_key.clone(),
+                find_element_index_value.num,
+                key.num.clone(),
+                found_key.num.clone(),
             ));
         }
         insert_value_from_var_name(
@@ -59,20 +58,20 @@ pub fn find_element(
         Ok(())
     } else {
         if n_elms.is_negative() {
-            return Err(VirtualMachineError::ValueOutOfRange(n_elms.clone()));
+            return Err(VirtualMachineError::ValueOutOfRange(n_elms.num.clone()));
         }
 
         if let Ok(find_element_max_size) = exec_scopes_proxy.get_int_ref("find_element_max_size") {
             if n_elms > find_element_max_size {
                 return Err(VirtualMachineError::FindElemMaxSize(
-                    find_element_max_size.clone(),
-                    n_elms.clone(),
+                    find_element_max_size.num.clone(),
+                    n_elms.num.clone(),
                 ));
             }
         }
         let n_elms_iter: i32 = n_elms
             .to_i32()
-            .ok_or_else(|| VirtualMachineError::OffsetExceeded(n_elms.clone()))?;
+            .ok_or_else(|| VirtualMachineError::OffsetExceeded(n_elms.num.clone()))?;
 
         for i in 0..n_elms_iter {
             let iter_key = vm_proxy
@@ -91,7 +90,7 @@ pub fn find_element(
             }
         }
 
-        Err(VirtualMachineError::NoValueForKey(key.clone()))
+        Err(VirtualMachineError::NoValueForKey(key.num.clone()))
     }
 }
 
@@ -109,18 +108,18 @@ pub fn search_sorted_lower(
     let key = get_integer_from_var_name("key", vm_proxy, ids_data, ap_tracking)?;
 
     if !elm_size.is_positive() {
-        return Err(VirtualMachineError::ValueOutOfRange(elm_size.clone()));
+        return Err(VirtualMachineError::ValueOutOfRange(elm_size.num.clone()));
     }
 
     if n_elms.is_negative() {
-        return Err(VirtualMachineError::ValueOutOfRange(n_elms.clone()));
+        return Err(VirtualMachineError::ValueOutOfRange(n_elms.num.clone()));
     }
 
     if let Ok(find_element_max_size) = find_element_max_size {
         if n_elms > &find_element_max_size {
             return Err(VirtualMachineError::FindElemMaxSize(
-                find_element_max_size,
-                n_elms.clone(),
+                find_element_max_size.num,
+                n_elms.num.clone(),
             ));
         }
     }

--- a/src/hint_processor/builtin_hint_processor/find_element_hint.rs
+++ b/src/hint_processor/builtin_hint_processor/find_element_hint.rs
@@ -2,7 +2,7 @@ use crate::hint_processor::builtin_hint_processor::hint_utils::{
     get_ptr_from_var_name, get_relocatable_from_var_name, insert_value_from_var_name,
 };
 use crate::hint_processor::hint_processor_definition::HintReference;
-use crate::hint_processor::hint_processor_utils::felt_to_usize;
+use crate::hint_processor::hint_processor_utils::bigint_to_usize;
 use crate::hint_processor::proxies::exec_scopes_proxy::ExecutionScopesProxy;
 use crate::hint_processor::proxies::vm_proxy::VMProxy;
 use crate::serde::deserialize_program::ApTracking;
@@ -34,7 +34,7 @@ pub fn find_element(
     }
 
     if let Some(find_element_index_value) = find_element_index {
-        let find_element_index_usize = felt_to_usize(&find_element_index_value)?;
+        let find_element_index_usize = bigint_to_usize(&find_element_index_value)?;
         let found_key = vm_proxy
             .memory
             .get_integer(&(array_start + (elm_size * find_element_index_usize)))
@@ -42,7 +42,7 @@ pub fn find_element(
 
         if found_key != key {
             return Err(VirtualMachineError::InvalidIndex(
-                find_element_index_value.num,
+                find_element_index_value,
                 key.num.clone(),
                 found_key.num.clone(),
             ));
@@ -62,9 +62,9 @@ pub fn find_element(
         }
 
         if let Ok(find_element_max_size) = exec_scopes_proxy.get_int_ref("find_element_max_size") {
-            if n_elms > find_element_max_size {
+            if &n_elms.to_bigint() > find_element_max_size {
                 return Err(VirtualMachineError::FindElemMaxSize(
-                    find_element_max_size.num.clone(),
+                    find_element_max_size.clone(),
                     n_elms.num.clone(),
                 ));
             }
@@ -116,9 +116,9 @@ pub fn search_sorted_lower(
     }
 
     if let Ok(find_element_max_size) = find_element_max_size {
-        if n_elms > &find_element_max_size {
+        if n_elms.to_bigint() > find_element_max_size {
             return Err(VirtualMachineError::FindElemMaxSize(
-                find_element_max_size.num,
+                find_element_max_size,
                 n_elms.num.clone(),
             ));
         }

--- a/src/hint_processor/builtin_hint_processor/hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/hint_utils.rs
@@ -1,14 +1,14 @@
 use crate::hint_processor::hint_processor_definition::HintReference;
-use crate::hint_processor::hint_processor_utils::bigint_to_usize;
 use crate::hint_processor::hint_processor_utils::compute_addr_from_reference;
+use crate::hint_processor::hint_processor_utils::felt_to_usize;
 use crate::hint_processor::hint_processor_utils::get_integer_from_reference;
 use crate::hint_processor::proxies::memory_proxy::MemoryProxy;
 use crate::hint_processor::proxies::vm_proxy::VMProxy;
 use crate::serde::deserialize_program::ApTracking;
+use crate::types::relocatable::FieldElement;
 use crate::types::relocatable::MaybeRelocatable;
 use crate::types::relocatable::Relocatable;
 use crate::vm::{context::run_context::RunContext, errors::vm_errors::VirtualMachineError};
-use num_bigint::BigInt;
 use std::collections::HashMap;
 
 //Inserts value into the address of the given ids variable
@@ -47,7 +47,7 @@ pub fn get_ptr_from_var_name(
     if hint_reference.dereference {
         let value = vm_proxy.memory.get_relocatable(&var_addr)?;
         if let Some(immediate) = &hint_reference.immediate {
-            let modified_value = value + bigint_to_usize(immediate)?;
+            let modified_value = value + felt_to_usize(immediate)?;
             Ok(modified_value)
         } else {
             Ok(value.clone())
@@ -99,7 +99,7 @@ pub fn get_integer_from_var_name<'a>(
     vm_proxy: &'a VMProxy,
     ids_data: &'a HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
-) -> Result<&'a BigInt, VirtualMachineError> {
+) -> Result<&'a FieldElement, VirtualMachineError> {
     // let relocatable = get_relocatable_from_var_name(var_name, vm_proxy, ids_data, ap_tracking)?;
     // vm_proxy.memory.get_integer(&relocatable)
     let reference = get_reference_from_var_name(var_name, ids_data)?;

--- a/src/hint_processor/builtin_hint_processor/keccak_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/keccak_utils.rs
@@ -50,10 +50,10 @@ pub fn unsafe_keccak(
     let length = get_integer_from_var_name("length", vm_proxy, ids_data, ap_tracking)?;
 
     if let Ok(keccak_max_size) = exec_scopes_proxy.get_int("__keccak_max_size") {
-        if length > &keccak_max_size {
+        if length.to_bigint() > keccak_max_size {
             return Err(VirtualMachineError::KeccakMaxSize(
                 length.num.clone(),
-                keccak_max_size.num,
+                keccak_max_size,
             ));
         }
     }

--- a/src/hint_processor/builtin_hint_processor/math_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/math_utils.rs
@@ -51,7 +51,7 @@ pub fn is_nn_out_of_range(
     let a = get_integer_from_var_name("a", vm_proxy, ids_data, ap_tracking)?;
     let range_check_builtin = get_range_check_builtin(vm_proxy.builtin_runners)?;
     //Main logic (assert a is not negative and within the expected range)
-    let value = if &(-a - felt!(1)) % vm_proxy.prime < felt!(range_check_builtin._bound.clone()) {
+    let value = if &(-a - 1_usize) % vm_proxy.prime < felt!(range_check_builtin._bound.clone()) {
         felt!(0)
     } else {
         felt!(1)
@@ -267,7 +267,7 @@ pub fn split_felt(
     //assert_integer(ids.value) (done by match)
     // ids.low = ids.value & ((1 << 128) - 1)
     // ids.high = ids.value >> 128
-    let low: FieldElement = value & &((felt!(1) << 128) - felt!(1));
+    let low: FieldElement = value & &((felt!(1) << 128) - 1);
     let high: FieldElement = value >> 128;
     insert_value_from_var_name("high", high, vm_proxy, ids_data, ap_tracking)?;
     insert_value_from_var_name("low", low, vm_proxy, ids_data, ap_tracking)

--- a/src/hint_processor/builtin_hint_processor/memcpy_hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/memcpy_hint_utils.rs
@@ -8,6 +8,8 @@ use crate::{
     serde::deserialize_program::ApTracking,
 };
 use num_bigint::BigInt;
+
+use num_traits::Signed;
 use std::any::Any;
 use std::collections::HashMap;
 
@@ -66,7 +68,7 @@ pub fn memcpy_continue_copying(
     // get `n` variable from vm scope
     let n = exec_scopes_proxy.get_int_ref("n")?;
     // this variable will hold the value of `n - 1`
-    let new_n = n - 1;
+    let new_n = n - 1_usize;
     // if it is positive, insert 1 in the address of `continue_copying`
     // else, insert 0
     if new_n.is_positive() {

--- a/src/hint_processor/builtin_hint_processor/memcpy_hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/memcpy_hint_utils.rs
@@ -95,6 +95,7 @@ mod tests {
     use super::*;
     use crate::felt;
     use crate::hint_processor::proxies::vm_proxy::get_vm_proxy;
+    use crate::types::relocatable::FieldElement;
     use crate::types::relocatable::MaybeRelocatable;
     use crate::utils::test_utils::*;
     use crate::vm::errors::memory_errors::MemoryError;

--- a/src/hint_processor/builtin_hint_processor/memcpy_hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/memcpy_hint_utils.rs
@@ -48,8 +48,11 @@ pub fn memcpy_enter_scope(
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), VirtualMachineError> {
-    let len: Box<dyn Any> =
-        Box::new(get_integer_from_var_name("len", vm_proxy, ids_data, ap_tracking)?.clone());
+    let len: Box<dyn Any> = Box::new(
+        get_integer_from_var_name("len", vm_proxy, ids_data, ap_tracking)?
+            .to_bigint()
+            .clone(),
+    );
     exec_scopes_proxy.enter_scope(HashMap::from([(String::from("n"), len)]));
     Ok(())
 }

--- a/src/hint_processor/builtin_hint_processor/memcpy_hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/memcpy_hint_utils.rs
@@ -8,7 +8,6 @@ use crate::{
     serde::deserialize_program::ApTracking,
 };
 use num_bigint::BigInt;
-use num_traits::Signed;
 use std::any::Any;
 use std::collections::HashMap;
 
@@ -67,7 +66,7 @@ pub fn memcpy_continue_copying(
     // get `n` variable from vm scope
     let n = exec_scopes_proxy.get_int_ref("n")?;
     // this variable will hold the value of `n - 1`
-    let new_n = n - 1_i32;
+    let new_n = n - 1;
     // if it is positive, insert 1 in the address of `continue_copying`
     // else, insert 0
     if new_n.is_positive() {
@@ -94,6 +93,7 @@ pub fn memcpy_continue_copying(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::felt;
     use crate::hint_processor::proxies::vm_proxy::get_vm_proxy;
     use crate::types::relocatable::MaybeRelocatable;
     use crate::utils::test_utils::*;
@@ -123,7 +123,7 @@ mod tests {
         let vm_proxy = get_vm_proxy(&mut vm);
         assert_eq!(
             get_integer_from_var_name(var_name, &vm_proxy, &ids_data, &ApTracking::default()),
-            Ok(&bigint!(10))
+            Ok(&felt!(10))
         );
     }
 

--- a/src/hint_processor/builtin_hint_processor/memcpy_hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/memcpy_hint_utils.rs
@@ -8,7 +8,6 @@ use crate::{
     serde::deserialize_program::ApTracking,
 };
 use num_bigint::BigInt;
-
 use num_traits::Signed;
 use std::any::Any;
 use std::collections::HashMap;

--- a/src/hint_processor/builtin_hint_processor/memcpy_hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/memcpy_hint_utils.rs
@@ -48,11 +48,8 @@ pub fn memcpy_enter_scope(
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), VirtualMachineError> {
-    let len: Box<dyn Any> = Box::new(
-        get_integer_from_var_name("len", vm_proxy, ids_data, ap_tracking)?
-            .to_bigint()
-            .clone(),
-    );
+    let len: Box<dyn Any> =
+        Box::new(get_integer_from_var_name("len", vm_proxy, ids_data, ap_tracking)?.to_bigint());
     exec_scopes_proxy.enter_scope(HashMap::from([(String::from("n"), len)]));
     Ok(())
 }

--- a/src/hint_processor/builtin_hint_processor/memset_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/memset_utils.rs
@@ -5,7 +5,6 @@ use crate::serde::deserialize_program::ApTracking;
 use crate::hint_processor::proxies::vm_proxy::VMProxy;
 use crate::vm::errors::vm_errors::VirtualMachineError;
 use num_bigint::BigInt;
-use num_traits::Signed;
 use std::any::Any;
 use std::collections::HashMap;
 
@@ -42,7 +41,7 @@ pub fn memset_continue_loop(
     // get `n` variable from vm scope
     let n = exec_scopes_proxy.get_int_ref("n")?;
     // this variable will hold the value of `n - 1`
-    let new_n = n - 1_i32;
+    let new_n = n - 1;
     // if `new_n` is positive, insert 1 in the address of `continue_loop`
     // else, insert 0
     let should_continue = bigint!(new_n.is_positive() as i32);

--- a/src/hint_processor/builtin_hint_processor/memset_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/memset_utils.rs
@@ -5,6 +5,7 @@ use crate::serde::deserialize_program::ApTracking;
 use crate::hint_processor::proxies::vm_proxy::VMProxy;
 use crate::vm::errors::vm_errors::VirtualMachineError;
 use num_bigint::BigInt;
+use num_traits::Signed;
 use std::any::Any;
 use std::collections::HashMap;
 
@@ -41,7 +42,7 @@ pub fn memset_continue_loop(
     // get `n` variable from vm scope
     let n = exec_scopes_proxy.get_int_ref("n")?;
     // this variable will hold the value of `n - 1`
-    let new_n = n - 1;
+    let new_n = n - 1_i32;
     // if `new_n` is positive, insert 1 in the address of `continue_loop`
     // else, insert 0
     let should_continue = bigint!(new_n.is_positive() as i32);

--- a/src/hint_processor/builtin_hint_processor/memset_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/memset_utils.rs
@@ -21,11 +21,8 @@ pub fn memset_enter_scope(
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), VirtualMachineError> {
-    let n: Box<dyn Any> = Box::new(
-        get_integer_from_var_name("n", vm_proxy, ids_data, ap_tracking)?
-            .to_bigint()
-            .clone(),
-    );
+    let n: Box<dyn Any> =
+        Box::new(get_integer_from_var_name("n", vm_proxy, ids_data, ap_tracking)?.to_bigint());
     exec_scopes_proxy.enter_scope(HashMap::from([(String::from("n"), n)]));
     Ok(())
 }

--- a/src/hint_processor/builtin_hint_processor/memset_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/memset_utils.rs
@@ -21,8 +21,11 @@ pub fn memset_enter_scope(
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), VirtualMachineError> {
-    let n: Box<dyn Any> =
-        Box::new(get_integer_from_var_name("n", vm_proxy, ids_data, ap_tracking)?.clone());
+    let n: Box<dyn Any> = Box::new(
+        get_integer_from_var_name("n", vm_proxy, ids_data, ap_tracking)?
+            .to_bigint()
+            .clone(),
+    );
     exec_scopes_proxy.enter_scope(HashMap::from([(String::from("n"), n)]));
     Ok(())
 }

--- a/src/hint_processor/builtin_hint_processor/pow_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/pow_utils.rs
@@ -1,9 +1,10 @@
+use crate::felt;
 use crate::hint_processor::proxies::vm_proxy::VMProxy;
 use crate::serde::deserialize_program::ApTracking;
+use crate::types::relocatable::FieldElement;
 use crate::vm::errors::vm_errors::VirtualMachineError;
 use crate::{bigint, hint_processor::hint_processor_definition::HintReference};
 use num_bigint::BigInt;
-use num_integer::Integer;
 use std::collections::HashMap;
 
 use crate::hint_processor::builtin_hint_processor::hint_utils::{
@@ -21,8 +22,8 @@ pub fn pow(
 ) -> Result<(), VirtualMachineError> {
     let prev_locs_addr =
         get_relocatable_from_var_name("prev_locs", vm_proxy, ids_data, ap_tracking)?;
-    let prev_locs_exp = vm_proxy.memory.get_integer(&(&prev_locs_addr + 4))?;
-    let locs_bit = prev_locs_exp.mod_floor(vm_proxy.prime) & bigint!(1);
+    let prev_locs_exp = vm_proxy.memory.get_integer(&(&prev_locs_addr + 4_usize))?;
+    let locs_bit = (prev_locs_exp % vm_proxy.prime) & felt!(1_i32);
     insert_value_from_var_name("locs", locs_bit, vm_proxy, ids_data, ap_tracking)?;
     Ok(())
 }

--- a/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
@@ -8,7 +8,6 @@ use crate::hint_processor::hint_processor_definition::HintReference;
 use crate::hint_processor::proxies::exec_scopes_proxy::ExecutionScopesProxy;
 use crate::hint_processor::proxies::vm_proxy::VMProxy;
 use crate::serde::deserialize_program::ApTracking;
-use crate::types::relocatable::FieldElement;
 use crate::vm::errors::vm_errors::VirtualMachineError;
 
 use num_bigint::BigInt;
@@ -30,7 +29,7 @@ pub fn nondet_bigint3(
 ) -> Result<(), VirtualMachineError> {
     let res_reloc = get_relocatable_from_var_name("res", vm_proxy, ids_data, ap_tracking)?;
     let value = exec_scopes_proxy.get_int_ref("value")?;
-    let arg: Vec<FieldElement> = split(value)?.to_vec();
+    let arg: Vec<BigInt> = split(value)?.to_vec();
     vm_proxy
         .memory
         .write_arg(vm_proxy.segments, &res_reloc, &arg, Some(vm_proxy.prime))

--- a/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
@@ -8,6 +8,7 @@ use crate::hint_processor::hint_processor_definition::HintReference;
 use crate::hint_processor::proxies::exec_scopes_proxy::ExecutionScopesProxy;
 use crate::hint_processor::proxies::vm_proxy::VMProxy;
 use crate::serde::deserialize_program::ApTracking;
+use crate::types::relocatable::FieldElement;
 use crate::vm::errors::vm_errors::VirtualMachineError;
 
 use num_bigint::BigInt;
@@ -29,7 +30,7 @@ pub fn nondet_bigint3(
 ) -> Result<(), VirtualMachineError> {
     let res_reloc = get_relocatable_from_var_name("res", vm_proxy, ids_data, ap_tracking)?;
     let value = exec_scopes_proxy.get_int_ref("value")?;
-    let arg: Vec<BigInt> = split(value)?.to_vec();
+    let arg: Vec<FieldElement> = split(value)?.to_vec();
     vm_proxy
         .memory
         .write_arg(vm_proxy.segments, &res_reloc, &arg, Some(vm_proxy.prime))
@@ -47,7 +48,7 @@ pub fn bigint_to_uint256(
     let x_struct = get_relocatable_from_var_name("x", vm_proxy, ids_data, ap_tracking)?;
     let d0 = vm_proxy.memory.get_integer(&x_struct)?;
     let d1 = vm_proxy.memory.get_integer(&(&x_struct + 1))?;
-    let low = (d0 + d1 * &*BASE_86) & bigint!(u128::MAX);
+    let low = (d0 + &(d1 * &*BASE_86)) & &bigint!(u128::MAX);
     insert_value_from_var_name("low", low, vm_proxy, ids_data, ap_tracking)
 }
 

--- a/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
@@ -1,4 +1,3 @@
-use crate::bigint;
 use crate::hint_processor::builtin_hint_processor::hint_utils::{
     get_relocatable_from_var_name, insert_value_from_var_name,
 };
@@ -47,7 +46,7 @@ pub fn bigint_to_uint256(
     let x_struct = get_relocatable_from_var_name("x", vm_proxy, ids_data, ap_tracking)?;
     let d0 = vm_proxy.memory.get_integer(&x_struct)?;
     let d1 = vm_proxy.memory.get_integer(&(&x_struct + 1))?;
-    let low = (d0 + &(d1 * &*BASE_86)) & &bigint!(u128::MAX);
+    let low = (d0 + &(d1 * &*BASE_86)) & u128::MAX;
     insert_value_from_var_name("low", low, vm_proxy, ids_data, ap_tracking)
 }
 

--- a/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
@@ -362,7 +362,7 @@ mod tests {
         //Check 'value' is defined in the vm scope
         assert_eq!(
             exec_scopes_proxy.get_int("value"),
-            Ok(felt_str!(
+            Ok(bigint_str!(
                 b"115792089237316195423569751828682367333329274433232027476421668138471189901786"
             ))
         );

--- a/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
@@ -12,7 +12,6 @@ use crate::vm::errors::vm_errors::VirtualMachineError;
 use num_bigint::BigInt;
 use num_integer::Integer;
 use std::collections::HashMap;
-use std::ops::BitAnd;
 
 use super::secp_utils::pack_from_relocatable;
 
@@ -324,14 +323,12 @@ pub fn ec_mul_inner(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::felt_str;
     use crate::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor;
     use crate::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::HintProcessorData;
     use crate::hint_processor::hint_processor_definition::HintProcessor;
     use crate::hint_processor::proxies::exec_scopes_proxy::get_exec_scopes_proxy;
     use crate::hint_processor::proxies::vm_proxy::get_vm_proxy;
     use crate::types::exec_scope::ExecutionScopes;
-    use crate::types::relocatable::FieldElement;
     use crate::types::relocatable::MaybeRelocatable;
     use crate::types::relocatable::Relocatable;
     use crate::utils::test_utils::*;

--- a/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
@@ -212,7 +212,7 @@ pub fn ec_double_assign_new_y(
         exec_scopes_proxy.get_int("y")?,
     );
 
-    let value = &(slope * (x - new_x) - y) % &*SECP_P;
+    let value = (slope * (x - new_x) - y).mod_floor(&SECP_P);
     exec_scopes_proxy.insert_value("value", value.clone());
     exec_scopes_proxy.insert_value("new_y", value);
     Ok(())
@@ -298,7 +298,7 @@ pub fn fast_ec_add_assign_new_y(
         exec_scopes_proxy.get_int("new_x")?,
         exec_scopes_proxy.get_int("y0")?,
     );
-    let value = &(slope * (x0 - new_x) - y0) % &*SECP_P;
+    let value = (slope * (x0 - new_x) - y0).mod_floor(&SECP_P);
     exec_scopes_proxy.insert_value("value", value.clone());
     exec_scopes_proxy.insert_value("new_y", value);
 

--- a/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
@@ -316,7 +316,7 @@ pub fn ec_mul_inner(
     //(ids.scalar % PRIME) % 2
     let scalar = (get_integer_from_var_name("scalar", vm_proxy, ids_data, ap_tracking)?
         % vm_proxy.prime)
-        & &bigint!(1);
+        & 1_u32;
     insert_value_into_ap(&mut vm_proxy.memory, vm_proxy.run_context, scalar)
 }
 

--- a/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
@@ -315,8 +315,9 @@ pub fn ec_mul_inner(
     ap_tracking: &ApTracking,
 ) -> Result<(), VirtualMachineError> {
     //(ids.scalar % PRIME) % 2
-    let scalar = get_integer_from_var_name("scalar", vm_proxy, ids_data, ap_tracking)?
-        % &vm_proxy.prime.bitand(bigint!(1));
+    let scalar = (get_integer_from_var_name("scalar", vm_proxy, ids_data, ap_tracking)?
+        % vm_proxy.prime)
+        & &bigint!(1);
     insert_value_into_ap(&mut vm_proxy.memory, vm_proxy.run_context, scalar)
 }
 

--- a/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
@@ -132,14 +132,12 @@ mod tests {
     use crate::any_box;
     use crate::bigint;
     use crate::bigint_str;
-    use crate::felt_str;
     use crate::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor;
     use crate::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::HintProcessorData;
     use crate::hint_processor::hint_processor_definition::HintProcessor;
     use crate::hint_processor::proxies::exec_scopes_proxy::get_exec_scopes_proxy;
     use crate::hint_processor::proxies::vm_proxy::get_vm_proxy;
     use crate::types::exec_scope::ExecutionScopes;
-    use crate::types::relocatable::FieldElement;
     use crate::types::relocatable::MaybeRelocatable;
     use crate::types::relocatable::Relocatable;
     use crate::utils::test_utils::*;

--- a/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
@@ -139,6 +139,7 @@ mod tests {
     use crate::hint_processor::proxies::exec_scopes_proxy::get_exec_scopes_proxy;
     use crate::hint_processor::proxies::vm_proxy::get_vm_proxy;
     use crate::types::exec_scope::ExecutionScopes;
+    use crate::types::relocatable::FieldElement;
     use crate::types::relocatable::MaybeRelocatable;
     use crate::types::relocatable::Relocatable;
     use crate::utils::test_utils::*;

--- a/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
@@ -120,7 +120,7 @@ pub fn is_zero_assign_scope_variables(
     //Get `x` variable from vm scope
     let x = exec_scopes_proxy.get_int("x")?;
 
-    let value = div_mod(&bigint!(1), &x, &SECP_P);
+    let value = div_mod(&bigint!(1), &x.num, &SECP_P);
     exec_scopes_proxy.insert_value("value", value.clone());
     exec_scopes_proxy.insert_value("x_inv", value);
     Ok(())
@@ -132,6 +132,7 @@ mod tests {
     use crate::any_box;
     use crate::bigint;
     use crate::bigint_str;
+    use crate::felt_str;
     use crate::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor;
     use crate::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::HintProcessorData;
     use crate::hint_processor::hint_processor_definition::HintProcessor;
@@ -239,7 +240,7 @@ mod tests {
         //Check 'value' is defined in the vm scope
         assert_eq!(
             exec_scopes_proxy.get_int("value"),
-            Ok(bigint_str!(
+            Ok(felt_str!(
                 b"59863107065205964761754162760883789350782881856141750"
             ))
         );
@@ -453,7 +454,7 @@ mod tests {
         //Check 'value' is defined in the vm scope
         assert_eq!(
             exec_scopes_proxy.get_int("value"),
-            Ok(bigint_str!(
+            Ok(felt_str!(
                 b"19429627790501903254364315669614485084365347064625983303617500144471999752609"
             ))
         );
@@ -461,7 +462,7 @@ mod tests {
         //Check 'x_inv' is defined in the vm scope
         assert_eq!(
             exec_scopes_proxy.get_int("x_inv"),
-            Ok(bigint_str!(
+            Ok(felt_str!(
                 b"19429627790501903254364315669614485084365347064625983303617500144471999752609"
             ))
         );

--- a/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
@@ -120,7 +120,7 @@ pub fn is_zero_assign_scope_variables(
     //Get `x` variable from vm scope
     let x = exec_scopes_proxy.get_int("x")?;
 
-    let value = div_mod(&bigint!(1), &x.num, &SECP_P);
+    let value = div_mod(&bigint!(1), &x, &SECP_P);
     exec_scopes_proxy.insert_value("value", value.clone());
     exec_scopes_proxy.insert_value("x_inv", value);
     Ok(())
@@ -241,7 +241,7 @@ mod tests {
         //Check 'value' is defined in the vm scope
         assert_eq!(
             exec_scopes_proxy.get_int("value"),
-            Ok(felt_str!(
+            Ok(bigint_str!(
                 b"59863107065205964761754162760883789350782881856141750"
             ))
         );
@@ -455,7 +455,7 @@ mod tests {
         //Check 'value' is defined in the vm scope
         assert_eq!(
             exec_scopes_proxy.get_int("value"),
-            Ok(felt_str!(
+            Ok(bigint_str!(
                 b"19429627790501903254364315669614485084365347064625983303617500144471999752609"
             ))
         );
@@ -463,7 +463,7 @@ mod tests {
         //Check 'x_inv' is defined in the vm scope
         assert_eq!(
             exec_scopes_proxy.get_int("x_inv"),
-            Ok(felt_str!(
+            Ok(bigint_str!(
                 b"19429627790501903254364315669614485084365347064625983303617500144471999752609"
             ))
         );

--- a/src/hint_processor/builtin_hint_processor/secp/signature.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/signature.rs
@@ -77,9 +77,8 @@ pub fn get_point_from_x(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::any_box;
     use crate::hint_processor::proxies::exec_scopes_proxy::get_exec_scopes_proxy;
-    use crate::types::relocatable::FieldElement;
-    use crate::{any_box, felt};
     use crate::{
         bigint, bigint_str,
         hint_processor::proxies::vm_proxy::get_vm_proxy,

--- a/src/hint_processor/builtin_hint_processor/secp/signature.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/signature.rs
@@ -49,7 +49,7 @@ pub fn div_mod_n_safe_div(
     let b = exec_scopes_proxy.get_int_ref("b")?;
     let res = exec_scopes_proxy.get_int_ref("res")?;
 
-    let value = safe_div(&(&res.num * &b.num - &a.num), &N)?;
+    let value = safe_div(&(res * b - a), &N)?;
 
     exec_scopes_proxy.insert_value("value", value);
     Ok(())
@@ -124,7 +124,7 @@ mod tests {
 
     #[test]
     fn safe_div_fail() {
-        let mut exec_scopes = scope![("a", felt!(0)), ("b", felt!(1)), ("res", felt!(1))];
+        let mut exec_scopes = scope![("a", bigint!(0)), ("b", bigint!(1)), ("res", bigint!(1))];
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
         assert_eq!(Err(VirtualMachineError::SafeDivFail(bigint!(1_usize), bigint_str!(b"115792089237316195423570985008687907852837564279074904382605163141518161494337"))), div_mod_n_safe_div(exec_scopes_proxy));
     }

--- a/src/hint_processor/builtin_hint_processor/secp/signature.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/signature.rs
@@ -49,7 +49,7 @@ pub fn div_mod_n_safe_div(
     let b = exec_scopes_proxy.get_int_ref("b")?;
     let res = exec_scopes_proxy.get_int_ref("res")?;
 
-    let value = safe_div(&(res * b - a), &N)?;
+    let value = safe_div(&(&res.num * &b.num - &a.num), &N)?;
 
     exec_scopes_proxy.insert_value("value", value);
     Ok(())
@@ -67,7 +67,7 @@ pub fn get_point_from_x(
     let mut y = y_cube_int.modpow(&((&*SECP_P + 1) / 4), &*SECP_P);
 
     let v = get_integer_from_var_name("v", vm_proxy, ids_data, ap_tracking)?;
-    if v.mod_floor(&bigint!(2)) != y.mod_floor(&bigint!(2)) {
+    if v.to_bigint().mod_floor(&bigint!(2)) != y.mod_floor(&bigint!(2)) {
         y = (-y).mod_floor(&SECP_P);
     }
     exec_scopes_proxy.insert_value("value", y);
@@ -77,8 +77,9 @@ pub fn get_point_from_x(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::any_box;
     use crate::hint_processor::proxies::exec_scopes_proxy::get_exec_scopes_proxy;
+    use crate::types::relocatable::FieldElement;
+    use crate::{any_box, felt};
     use crate::{
         bigint, bigint_str,
         hint_processor::proxies::vm_proxy::get_vm_proxy,
@@ -123,7 +124,7 @@ mod tests {
 
     #[test]
     fn safe_div_fail() {
-        let mut exec_scopes = scope![("a", bigint!(0)), ("b", bigint!(1)), ("res", bigint!(1))];
+        let mut exec_scopes = scope![("a", felt!(0)), ("b", felt!(1)), ("res", felt!(1))];
         let exec_scopes_proxy = &mut get_exec_scopes_proxy(&mut exec_scopes);
         assert_eq!(Err(VirtualMachineError::SafeDivFail(bigint!(1_usize), bigint_str!(b"115792089237316195423570985008687907852837564279074904382605163141518161494337"))), div_mod_n_safe_div(exec_scopes_proxy));
     }

--- a/src/hint_processor/builtin_hint_processor/set.rs
+++ b/src/hint_processor/builtin_hint_processor/set.rs
@@ -4,7 +4,7 @@ use crate::serde::deserialize_program::ApTracking;
 use crate::types::relocatable::MaybeRelocatable;
 use crate::vm::errors::vm_errors::VirtualMachineError;
 use num_bigint::BigInt;
-use num_traits::{ToPrimitive, Zero};
+use num_traits::Zero;
 use std::collections::HashMap;
 
 use crate::hint_processor::builtin_hint_processor::hint_utils::{

--- a/src/hint_processor/builtin_hint_processor/sha256_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/sha256_utils.rs
@@ -1,7 +1,8 @@
+use crate::felt;
 use crate::hint_processor::builtin_hint_processor::hint_utils::get_integer_from_var_name;
 use crate::hint_processor::builtin_hint_processor::hint_utils::get_ptr_from_var_name;
 use crate::hint_processor::builtin_hint_processor::hint_utils::insert_value_from_var_name;
-use crate::hint_processor::hint_processor_utils::bigint_to_u32;
+use crate::hint_processor::hint_processor_utils::felt_to_u32;
 use crate::hint_processor::proxies::vm_proxy::VMProxy;
 use crate::{
     bigint, serde::deserialize_program::ApTracking, vm::errors::vm_errors::VirtualMachineError,
@@ -14,6 +15,7 @@ use sha2::compress256;
 use std::collections::HashMap;
 
 use crate::hint_processor::hint_processor_definition::HintReference;
+use crate::types::relocatable::FieldElement;
 
 const SHA256_INPUT_CHUNK_SIZE_FELTS: usize = 16;
 const SHA256_STATE_SIZE_FELTS: usize = 8;
@@ -31,7 +33,7 @@ pub fn sha256_input(
 
     insert_value_from_var_name(
         "full_word",
-        if n_bytes >= &bigint!(4) {
+        if n_bytes >= &felt!(4) {
             BigInt::one()
         } else {
             BigInt::zero()
@@ -53,7 +55,7 @@ pub fn sha256_main(
 
     for i in 0..SHA256_INPUT_CHUNK_SIZE_FELTS {
         let input_element = vm_proxy.memory.get_integer(&(&input_ptr + i))?;
-        let bytes = bigint_to_u32(input_element)?.to_be_bytes();
+        let bytes = felt_to_u32(input_element)?.to_be_bytes();
         message.extend(bytes);
     }
 

--- a/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
@@ -325,7 +325,7 @@ mod tests {
     use crate::utils::test_utils::*;
     use crate::vm::runners::builtin_runner::RangeCheckBuiltinRunner;
     use crate::vm::vm_core::VirtualMachine;
-    use crate::{any_box, bigint, bigint_str, felt_str};
+    use crate::{any_box, bigint, bigint_str};
     use num_bigint::Sign;
 
     //Hint code as consts
@@ -523,8 +523,6 @@ mod tests {
             ("current_access_indices", Vec::<BigInt>::new()),
             ("current_access_index", bigint!(1))
         ];
-
-        println!("exec_scopes: {:?}", exec_scopes.data);
 
         //Initialize fp
         vm.run_context.fp = 1;

--- a/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
@@ -109,7 +109,7 @@ pub fn squash_dict_inner_check_access_index(
     let new_access_index = current_access_indices
         .pop()
         .ok_or(VirtualMachineError::EmptyCurrentAccessIndices)?;
-    let index_delta_minus1 = new_access_index.clone() - felt!(current_access_index - 1);
+    let index_delta_minus1 = new_access_index.clone() - current_access_index - 1;
     //loop_temps.delta_minus1 = loop_temps + 0 as it is the first field of the struct
     //Insert loop_temps.delta_minus1 into memory
     insert_value_from_var_name(
@@ -519,10 +519,13 @@ mod tests {
         //Create vm
         let mut vm = vm!();
         //Store scope variables
-        let mut exec_scopes = scope![
+        let mut exec_scopes: ExecutionScopes = scope![
             ("current_access_indices", Vec::<BigInt>::new()),
             ("current_access_index", bigint!(1))
         ];
+
+        println!("exec_scopes: {:?}", exec_scopes.data);
+
         //Initialize fp
         vm.run_context.fp = 1;
         //Insert ids into memory (loop_temps)

--- a/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
@@ -327,7 +327,7 @@ mod tests {
     use crate::utils::test_utils::*;
     use crate::vm::runners::builtin_runner::RangeCheckBuiltinRunner;
     use crate::vm::vm_core::VirtualMachine;
-    use crate::{any_box, bigint, bigint_str};
+    use crate::{any_box, bigint, bigint_str, felt_str};
     use num_bigint::Sign;
 
     //Hint code as consts
@@ -1119,9 +1119,9 @@ mod tests {
         );
         //Check scope variables
         check_scope!(exec_scopes_proxy, [("access_indices", HashMap::from([(
-           bigint_str!(b"3618502761706184546546682988428055018603476541694452277432519575032261771265"),
+           felt_str!(b"3618502761706184546546682988428055018603476541694452277432519575032261771265"),
             vec![felt!(0), felt!(1)]
-        )])), ("keys", Vec::<FieldElement>::new()), ("key", bigint_str!(b"3618502761706184546546682988428055018603476541694452277432519575032261771265"))]);
+        )])), ("keys", Vec::<FieldElement>::new()), ("key", felt_str!(b"3618502761706184546546682988428055018603476541694452277432519575032261771265"))]);
         //Check ids variables
         check_memory![
             vm.memory,

--- a/src/hint_processor/builtin_hint_processor/uint256_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/uint256_utils.rs
@@ -192,10 +192,10 @@ pub fn uint256_unsigned_div_rem(
     //Then, div_mod_floor equals Python divmod
     let (quotient, remainder) = a.div_mod_floor(&div);
 
-    let quotient_low = &quotient & &felt!(u128::MAX);
+    let quotient_low = &quotient & u128::MAX;
     let quotient_high = quotient.shr(128);
 
-    let remainder_low = &remainder & &felt!(u128::MAX);
+    let remainder_low = &remainder & u128::MAX;
     let remainder_high = remainder.shr(128);
 
     //Insert ids.quotient.low

--- a/src/hint_processor/builtin_hint_processor/usort.rs
+++ b/src/hint_processor/builtin_hint_processor/usort.rs
@@ -1,13 +1,14 @@
+use crate::felt;
 use crate::hint_processor::builtin_hint_processor::hint_utils::get_integer_from_var_name;
 use crate::hint_processor::builtin_hint_processor::hint_utils::get_ptr_from_var_name;
 use crate::hint_processor::builtin_hint_processor::hint_utils::insert_value_from_var_name;
 use crate::hint_processor::proxies::exec_scopes_proxy::ExecutionScopesProxy;
 use crate::hint_processor::proxies::vm_proxy::VMProxy;
+use crate::types::relocatable::FieldElement;
 use crate::{
     bigint, serde::deserialize_program::ApTracking, vm::errors::vm_errors::VirtualMachineError,
 };
 use num_bigint::BigInt;
-use num_traits::ToPrimitive;
 use std::{any::Any, collections::HashMap};
 
 use crate::hint_processor::hint_processor_definition::HintReference;
@@ -44,12 +45,12 @@ pub fn usort_body(
         if input_len_u64 > usort_max_size {
             return Err(VirtualMachineError::UsortOutOfRange(
                 usort_max_size,
-                input_len.clone(),
+                input_len.num.clone(),
             ));
         }
     }
-    let mut positions_dict: HashMap<BigInt, Vec<u64>> = HashMap::new();
-    let mut output: Vec<BigInt> = Vec::new();
+    let mut positions_dict: HashMap<FieldElement, Vec<u64>> = HashMap::new();
+    let mut output: Vec<FieldElement> = Vec::new();
     for i in 0..input_len_u64 {
         let val = vm_proxy.memory.get_integer(&(&input_ptr + i as usize))?;
         if let Err(output_index) = output.binary_search(val) {
@@ -137,7 +138,7 @@ pub fn verify_multiplicity_body(
         .get_mut_listu64_ref("positions")?
         .pop()
         .ok_or(VirtualMachineError::CouldntPopPositions)?;
-    let pos_diff = bigint!(current_pos) - exec_scopes_proxy.get_int("last_pos")?;
+    let pos_diff = felt!(current_pos) - exec_scopes_proxy.get_int("last_pos")?;
     insert_value_from_var_name("next_item_index", pos_diff, vm_proxy, ids_data, ap_tracking)?;
     exec_scopes_proxy.insert_value("last_pos", bigint!(current_pos + 1));
     Ok(())

--- a/src/hint_processor/builtin_hint_processor/usort.rs
+++ b/src/hint_processor/builtin_hint_processor/usort.rs
@@ -113,7 +113,7 @@ pub fn verify_usort(
         .ok_or(VirtualMachineError::UnexpectedPositionsDictFail)?;
     positions.reverse();
     exec_scopes_proxy.insert_value("positions", positions);
-    exec_scopes_proxy.insert_value("last_pos", bigint!(0));
+    exec_scopes_proxy.insert_value("last_pos", felt!(0));
     Ok(())
 }
 
@@ -140,7 +140,7 @@ pub fn verify_multiplicity_body(
         .ok_or(VirtualMachineError::CouldntPopPositions)?;
     let pos_diff = felt!(current_pos) - exec_scopes_proxy.get_int("last_pos")?;
     insert_value_from_var_name("next_item_index", pos_diff, vm_proxy, ids_data, ap_tracking)?;
-    exec_scopes_proxy.insert_value("last_pos", bigint!(current_pos + 1));
+    exec_scopes_proxy.insert_value("last_pos", felt!(current_pos + 1));
     Ok(())
 }
 

--- a/src/hint_processor/builtin_hint_processor/usort.rs
+++ b/src/hint_processor/builtin_hint_processor/usort.rs
@@ -1,10 +1,8 @@
-use crate::felt;
 use crate::hint_processor::builtin_hint_processor::hint_utils::get_integer_from_var_name;
 use crate::hint_processor::builtin_hint_processor::hint_utils::get_ptr_from_var_name;
 use crate::hint_processor::builtin_hint_processor::hint_utils::insert_value_from_var_name;
 use crate::hint_processor::proxies::exec_scopes_proxy::ExecutionScopesProxy;
 use crate::hint_processor::proxies::vm_proxy::VMProxy;
-use crate::types::relocatable::FieldElement;
 use crate::{
     bigint, serde::deserialize_program::ApTracking, vm::errors::vm_errors::VirtualMachineError,
 };

--- a/src/hint_processor/builtin_hint_processor/usort.rs
+++ b/src/hint_processor/builtin_hint_processor/usort.rs
@@ -49,10 +49,13 @@ pub fn usort_body(
             ));
         }
     }
-    let mut positions_dict: HashMap<FieldElement, Vec<u64>> = HashMap::new();
-    let mut output: Vec<FieldElement> = Vec::new();
+    let mut positions_dict: HashMap<BigInt, Vec<u64>> = HashMap::new();
+    let mut output: Vec<BigInt> = Vec::new();
     for i in 0..input_len_u64 {
-        let val = vm_proxy.memory.get_integer(&(&input_ptr + i as usize))?;
+        let val = &vm_proxy
+            .memory
+            .get_integer(&(&input_ptr + i as usize))?
+            .to_bigint();
         if let Err(output_index) = output.binary_search(val) {
             output.insert(output_index, val.clone());
         }
@@ -106,14 +109,16 @@ pub fn verify_usort(
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), VirtualMachineError> {
-    let value = get_integer_from_var_name("value", vm_proxy, ids_data, ap_tracking)?.clone();
+    let value = get_integer_from_var_name("value", vm_proxy, ids_data, ap_tracking)?
+        .clone()
+        .to_bigint();
     let mut positions = exec_scopes_proxy
         .get_mut_dict_int_list_u64_ref("positions_dict")?
         .remove(&value)
         .ok_or(VirtualMachineError::UnexpectedPositionsDictFail)?;
     positions.reverse();
     exec_scopes_proxy.insert_value("positions", positions);
-    exec_scopes_proxy.insert_value("last_pos", felt!(0));
+    exec_scopes_proxy.insert_value("last_pos", bigint!(0));
     Ok(())
 }
 

--- a/src/hint_processor/builtin_hint_processor/usort.rs
+++ b/src/hint_processor/builtin_hint_processor/usort.rs
@@ -138,9 +138,9 @@ pub fn verify_multiplicity_body(
         .get_mut_listu64_ref("positions")?
         .pop()
         .ok_or(VirtualMachineError::CouldntPopPositions)?;
-    let pos_diff = felt!(current_pos) - exec_scopes_proxy.get_int("last_pos")?;
+    let pos_diff = bigint!(current_pos) - exec_scopes_proxy.get_int("last_pos")?;
     insert_value_from_var_name("next_item_index", pos_diff, vm_proxy, ids_data, ap_tracking)?;
-    exec_scopes_proxy.insert_value("last_pos", felt!(current_pos + 1));
+    exec_scopes_proxy.insert_value("last_pos", bigint!(current_pos + 1));
     Ok(())
 }
 

--- a/src/hint_processor/hint_processor_definition.rs
+++ b/src/hint_processor/hint_processor_definition.rs
@@ -2,8 +2,8 @@ use crate::hint_processor::proxies::exec_scopes_proxy::ExecutionScopesProxy;
 use crate::hint_processor::proxies::vm_proxy::VMProxy;
 use crate::serde::deserialize_program::ApTracking;
 use crate::types::instruction::Register;
+use crate::types::relocatable::FieldElement;
 use crate::vm::errors::vm_errors::VirtualMachineError;
-use num_bigint::BigInt;
 use std::any::Any;
 use std::collections::HashMap;
 
@@ -44,7 +44,7 @@ pub struct HintReference {
     pub dereference: bool,
     pub inner_dereference: bool,
     pub ap_tracking_data: Option<ApTracking>,
-    pub immediate: Option<BigInt>,
+    pub immediate: Option<FieldElement>,
 }
 
 impl HintReference {

--- a/src/hint_processor/proxies/exec_scopes_proxy.rs
+++ b/src/hint_processor/proxies/exec_scopes_proxy.rs
@@ -15,7 +15,7 @@ use crate::vm::errors::vm_errors::VirtualMachineError;
 ///Structure representing a limited access to the execution scopes
 ///Allows adding and removing scopes, but will only allow modifications to the last scope present before hint execution
 pub struct ExecutionScopesProxy<'a> {
-    scopes: &'a mut ExecutionScopes,
+    pub scopes: &'a mut ExecutionScopes,
     current_scope: usize,
 }
 
@@ -70,6 +70,11 @@ impl ExecutionScopesProxy<'_> {
         &self,
     ) -> Result<&HashMap<String, Box<dyn Any>>, VirtualMachineError> {
         if self.scopes.data.len() > self.current_scope {
+            println!("self.current_scope: {:?}", self.current_scope);
+            println!(
+                "&self.scopes.data[self.current_scope]: {:?}",
+                &self.scopes.data[self.current_scope]
+            );
             return Ok(&self.scopes.data[self.current_scope]);
         }
         Err(VirtualMachineError::MainScopeError(
@@ -162,10 +167,10 @@ impl ExecutionScopesProxy<'_> {
     pub fn get_mut_list_ref(
         &mut self,
         name: &str,
-    ) -> Result<&mut Vec<FieldElement>, VirtualMachineError> {
-        let mut val: Option<&mut Vec<FieldElement>> = None;
+    ) -> Result<&mut Vec<BigInt>, VirtualMachineError> {
+        let mut val: Option<&mut Vec<BigInt>> = None;
         if let Some(variable) = self.get_local_variables_mut()?.get_mut(name) {
-            if let Some(list) = variable.downcast_mut::<Vec<FieldElement>>() {
+            if let Some(list) = variable.downcast_mut::<Vec<BigInt>>() {
                 val = Some(list);
             }
         }

--- a/src/hint_processor/proxies/exec_scopes_proxy.rs
+++ b/src/hint_processor/proxies/exec_scopes_proxy.rs
@@ -142,10 +142,10 @@ impl ExecutionScopesProxy<'_> {
     }
 
     ///Returns the value in the current execution scope that matches the name and is of type List
-    pub fn get_list(&self, name: &str) -> Result<Vec<FieldElement>, VirtualMachineError> {
-        let mut val: Option<Vec<FieldElement>> = None;
+    pub fn get_list(&self, name: &str) -> Result<Vec<BigInt>, VirtualMachineError> {
+        let mut val: Option<Vec<BigInt>> = None;
         if let Some(variable) = self.get_local_variables()?.get(name) {
-            if let Some(list) = variable.downcast_ref::<Vec<FieldElement>>() {
+            if let Some(list) = variable.downcast_ref::<Vec<BigInt>>() {
                 val = Some(list.clone());
             }
         }
@@ -153,10 +153,10 @@ impl ExecutionScopesProxy<'_> {
     }
 
     ///Returns a reference to the value in the current execution scope that matches the name and is of type List
-    pub fn get_list_ref(&self, name: &str) -> Result<&Vec<FieldElement>, VirtualMachineError> {
-        let mut val: Option<&Vec<FieldElement>> = None;
+    pub fn get_list_ref(&self, name: &str) -> Result<&Vec<BigInt>, VirtualMachineError> {
+        let mut val: Option<&Vec<BigInt>> = None;
         if let Some(variable) = self.get_local_variables()?.get(name) {
-            if let Some(list) = variable.downcast_ref::<Vec<FieldElement>>() {
+            if let Some(list) = variable.downcast_ref::<Vec<BigInt>>() {
                 val = Some(list);
             }
         }

--- a/src/hint_processor/proxies/exec_scopes_proxy.rs
+++ b/src/hint_processor/proxies/exec_scopes_proxy.rs
@@ -3,6 +3,8 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
+use num_bigint::BigInt;
+
 use crate::any_box;
 use crate::hint_processor::builtin_hint_processor::dict_manager::DictManager;
 use crate::types::exec_scope::ExecutionScopes;
@@ -75,11 +77,11 @@ impl ExecutionScopesProxy<'_> {
         ))
     }
 
-    ///Returns the value in the current execution scope that matches the name and is of type FieldElement
-    pub fn get_int(&self, name: &str) -> Result<FieldElement, VirtualMachineError> {
-        let mut val: Option<FieldElement> = None;
+    ///Returns the value in the current execution scope that matches the name and is of type BigInt
+    pub fn get_int(&self, name: &str) -> Result<BigInt, VirtualMachineError> {
+        let mut val: Option<BigInt> = None;
         if let Some(variable) = self.get_local_variables()?.get(name) {
-            if let Some(int) = variable.downcast_ref::<FieldElement>() {
+            if let Some(int) = variable.downcast_ref::<BigInt>() {
                 val = Some(int.clone());
             }
         }
@@ -109,11 +111,11 @@ impl ExecutionScopesProxy<'_> {
         ))
     }
 
-    ///Returns a reference to the value in the current execution scope that matches the name and is of type FieldElement
-    pub fn get_int_ref(&self, name: &str) -> Result<&FieldElement, VirtualMachineError> {
-        let mut val: Option<&FieldElement> = None;
+    ///Returns a reference to the value in the current execution scope that matches the name and is of type BigInt
+    pub fn get_int_ref(&self, name: &str) -> Result<&BigInt, VirtualMachineError> {
+        let mut val: Option<&BigInt> = None;
         if let Some(variable) = self.get_local_variables()?.get(name) {
-            if let Some(int) = variable.downcast_ref::<FieldElement>() {
+            if let Some(int) = variable.downcast_ref::<BigInt>() {
                 val = Some(int);
             }
         }

--- a/src/hint_processor/proxies/exec_scopes_proxy.rs
+++ b/src/hint_processor/proxies/exec_scopes_proxy.rs
@@ -128,13 +128,10 @@ impl ExecutionScopesProxy<'_> {
     }
 
     ///Returns a mutable reference to the value in the current execution scope that matches the name and is of type FieldElement
-    pub fn get_mut_int_ref(
-        &mut self,
-        name: &str,
-    ) -> Result<&mut FieldElement, VirtualMachineError> {
-        let mut val: Option<&mut FieldElement> = None;
+    pub fn get_mut_int_ref(&mut self, name: &str) -> Result<&mut BigInt, VirtualMachineError> {
+        let mut val: Option<&mut BigInt> = None;
         if let Some(variable) = self.get_local_variables_mut()?.get_mut(name) {
-            if let Some(int) = variable.downcast_mut::<FieldElement>() {
+            if let Some(int) = variable.downcast_mut::<BigInt>() {
                 val = Some(int);
             }
         }
@@ -257,10 +254,10 @@ impl ExecutionScopesProxy<'_> {
     pub fn get_mut_dict_int_list_u64_ref(
         &mut self,
         name: &str,
-    ) -> Result<&mut HashMap<FieldElement, Vec<u64>>, VirtualMachineError> {
-        let mut val: Option<&mut HashMap<FieldElement, Vec<u64>>> = None;
+    ) -> Result<&mut HashMap<BigInt, Vec<u64>>, VirtualMachineError> {
+        let mut val: Option<&mut HashMap<BigInt, Vec<u64>>> = None;
         if let Some(variable) = self.get_local_variables_mut()?.get_mut(name) {
-            if let Some(dict) = variable.downcast_mut::<HashMap<FieldElement, Vec<u64>>>() {
+            if let Some(dict) = variable.downcast_mut::<HashMap<BigInt, Vec<u64>>>() {
                 val = Some(dict);
             }
         }

--- a/src/hint_processor/proxies/exec_scopes_proxy.rs
+++ b/src/hint_processor/proxies/exec_scopes_proxy.rs
@@ -8,7 +8,6 @@ use num_bigint::BigInt;
 use crate::any_box;
 use crate::hint_processor::builtin_hint_processor::dict_manager::DictManager;
 use crate::types::exec_scope::ExecutionScopes;
-use crate::types::relocatable::FieldElement;
 use crate::vm::errors::exec_scope_errors::ExecScopeError;
 use crate::vm::errors::vm_errors::VirtualMachineError;
 
@@ -70,11 +69,6 @@ impl ExecutionScopesProxy<'_> {
         &self,
     ) -> Result<&HashMap<String, Box<dyn Any>>, VirtualMachineError> {
         if self.scopes.data.len() > self.current_scope {
-            println!("self.current_scope: {:?}", self.current_scope);
-            println!(
-                "&self.scopes.data[self.current_scope]: {:?}",
-                &self.scopes.data[self.current_scope]
-            );
             return Ok(&self.scopes.data[self.current_scope]);
         }
         Err(VirtualMachineError::MainScopeError(

--- a/src/hint_processor/proxies/exec_scopes_proxy.rs
+++ b/src/hint_processor/proxies/exec_scopes_proxy.rs
@@ -14,7 +14,7 @@ use crate::vm::errors::vm_errors::VirtualMachineError;
 ///Structure representing a limited access to the execution scopes
 ///Allows adding and removing scopes, but will only allow modifications to the last scope present before hint execution
 pub struct ExecutionScopesProxy<'a> {
-    pub scopes: &'a mut ExecutionScopes,
+    scopes: &'a mut ExecutionScopes,
     current_scope: usize,
 }
 

--- a/src/hint_processor/proxies/exec_scopes_proxy.rs
+++ b/src/hint_processor/proxies/exec_scopes_proxy.rs
@@ -3,11 +3,10 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use num_bigint::BigInt;
-
 use crate::any_box;
 use crate::hint_processor::builtin_hint_processor::dict_manager::DictManager;
 use crate::types::exec_scope::ExecutionScopes;
+use crate::types::relocatable::FieldElement;
 use crate::vm::errors::exec_scope_errors::ExecScopeError;
 use crate::vm::errors::vm_errors::VirtualMachineError;
 
@@ -76,11 +75,11 @@ impl ExecutionScopesProxy<'_> {
         ))
     }
 
-    ///Returns the value in the current execution scope that matches the name and is of type BigInt
-    pub fn get_int(&self, name: &str) -> Result<BigInt, VirtualMachineError> {
-        let mut val: Option<BigInt> = None;
+    ///Returns the value in the current execution scope that matches the name and is of type FieldElement
+    pub fn get_int(&self, name: &str) -> Result<FieldElement, VirtualMachineError> {
+        let mut val: Option<FieldElement> = None;
         if let Some(variable) = self.get_local_variables()?.get(name) {
-            if let Some(int) = variable.downcast_ref::<BigInt>() {
+            if let Some(int) = variable.downcast_ref::<FieldElement>() {
                 val = Some(int.clone());
             }
         }
@@ -110,22 +109,25 @@ impl ExecutionScopesProxy<'_> {
         ))
     }
 
-    ///Returns a reference to the value in the current execution scope that matches the name and is of type BigInt
-    pub fn get_int_ref(&self, name: &str) -> Result<&BigInt, VirtualMachineError> {
-        let mut val: Option<&BigInt> = None;
+    ///Returns a reference to the value in the current execution scope that matches the name and is of type FieldElement
+    pub fn get_int_ref(&self, name: &str) -> Result<&FieldElement, VirtualMachineError> {
+        let mut val: Option<&FieldElement> = None;
         if let Some(variable) = self.get_local_variables()?.get(name) {
-            if let Some(int) = variable.downcast_ref::<BigInt>() {
+            if let Some(int) = variable.downcast_ref::<FieldElement>() {
                 val = Some(int);
             }
         }
         val.ok_or_else(|| VirtualMachineError::VariableNotInScopeError(name.to_string()))
     }
 
-    ///Returns a mutable reference to the value in the current execution scope that matches the name and is of type BigInt
-    pub fn get_mut_int_ref(&mut self, name: &str) -> Result<&mut BigInt, VirtualMachineError> {
-        let mut val: Option<&mut BigInt> = None;
+    ///Returns a mutable reference to the value in the current execution scope that matches the name and is of type FieldElement
+    pub fn get_mut_int_ref(
+        &mut self,
+        name: &str,
+    ) -> Result<&mut FieldElement, VirtualMachineError> {
+        let mut val: Option<&mut FieldElement> = None;
         if let Some(variable) = self.get_local_variables_mut()?.get_mut(name) {
-            if let Some(int) = variable.downcast_mut::<BigInt>() {
+            if let Some(int) = variable.downcast_mut::<FieldElement>() {
                 val = Some(int);
             }
         }
@@ -133,10 +135,10 @@ impl ExecutionScopesProxy<'_> {
     }
 
     ///Returns the value in the current execution scope that matches the name and is of type List
-    pub fn get_list(&self, name: &str) -> Result<Vec<BigInt>, VirtualMachineError> {
-        let mut val: Option<Vec<BigInt>> = None;
+    pub fn get_list(&self, name: &str) -> Result<Vec<FieldElement>, VirtualMachineError> {
+        let mut val: Option<Vec<FieldElement>> = None;
         if let Some(variable) = self.get_local_variables()?.get(name) {
-            if let Some(list) = variable.downcast_ref::<Vec<BigInt>>() {
+            if let Some(list) = variable.downcast_ref::<Vec<FieldElement>>() {
                 val = Some(list.clone());
             }
         }
@@ -144,10 +146,10 @@ impl ExecutionScopesProxy<'_> {
     }
 
     ///Returns a reference to the value in the current execution scope that matches the name and is of type List
-    pub fn get_list_ref(&self, name: &str) -> Result<&Vec<BigInt>, VirtualMachineError> {
-        let mut val: Option<&Vec<BigInt>> = None;
+    pub fn get_list_ref(&self, name: &str) -> Result<&Vec<FieldElement>, VirtualMachineError> {
+        let mut val: Option<&Vec<FieldElement>> = None;
         if let Some(variable) = self.get_local_variables()?.get(name) {
-            if let Some(list) = variable.downcast_ref::<Vec<BigInt>>() {
+            if let Some(list) = variable.downcast_ref::<Vec<FieldElement>>() {
                 val = Some(list);
             }
         }
@@ -158,10 +160,10 @@ impl ExecutionScopesProxy<'_> {
     pub fn get_mut_list_ref(
         &mut self,
         name: &str,
-    ) -> Result<&mut Vec<BigInt>, VirtualMachineError> {
-        let mut val: Option<&mut Vec<BigInt>> = None;
+    ) -> Result<&mut Vec<FieldElement>, VirtualMachineError> {
+        let mut val: Option<&mut Vec<FieldElement>> = None;
         if let Some(variable) = self.get_local_variables_mut()?.get_mut(name) {
-            if let Some(list) = variable.downcast_mut::<Vec<BigInt>>() {
+            if let Some(list) = variable.downcast_mut::<Vec<FieldElement>>() {
                 val = Some(list);
             }
         }
@@ -248,10 +250,10 @@ impl ExecutionScopesProxy<'_> {
     pub fn get_mut_dict_int_list_u64_ref(
         &mut self,
         name: &str,
-    ) -> Result<&mut HashMap<BigInt, Vec<u64>>, VirtualMachineError> {
-        let mut val: Option<&mut HashMap<BigInt, Vec<u64>>> = None;
+    ) -> Result<&mut HashMap<FieldElement, Vec<u64>>, VirtualMachineError> {
+        let mut val: Option<&mut HashMap<FieldElement, Vec<u64>>> = None;
         if let Some(variable) = self.get_local_variables_mut()?.get_mut(name) {
-            if let Some(dict) = variable.downcast_mut::<HashMap<BigInt, Vec<u64>>>() {
+            if let Some(dict) = variable.downcast_mut::<HashMap<FieldElement, Vec<u64>>>() {
                 val = Some(dict);
             }
         }

--- a/src/hint_processor/proxies/memory_proxy.rs
+++ b/src/hint_processor/proxies/memory_proxy.rs
@@ -3,7 +3,7 @@ use std::any::Any;
 use num_bigint::BigInt;
 
 use crate::{
-    types::relocatable::{MaybeRelocatable, Relocatable},
+    types::relocatable::{FieldElement, MaybeRelocatable, Relocatable},
     vm::{
         errors::{memory_errors::MemoryError, vm_errors::VirtualMachineError},
         vm_memory::{memory::Memory, memory_segments::MemorySegmentManager},
@@ -31,7 +31,7 @@ impl MemoryProxy<'_> {
     }
 
     ///Gets the integer value corresponding to the Relocatable address
-    pub fn get_integer(&self, key: &Relocatable) -> Result<&BigInt, VirtualMachineError> {
+    pub fn get_integer(&self, key: &Relocatable) -> Result<&FieldElement, VirtualMachineError> {
         self.memory.get_integer(key)
     }
 

--- a/src/math_utils.rs
+++ b/src/math_utils.rs
@@ -19,7 +19,7 @@ pub fn isqrt(n: &FieldElement) -> Result<FieldElement, VirtualMachineError> {
     let mut y = (x.clone() + felt!(1)).shr(1);
     while y < x {
         x = y;
-        y = (x.clone() + (n % &x)).shr(1);
+        y = (x.clone() + (n.div_floor(&x))).shr(1);
     }
     if !(x.pow(2) <= *n && *n < (x.clone() + felt!(1)).pow(2)) {
         return Err(VirtualMachineError::FailedToGetSqrt(n.num.clone()));

--- a/src/math_utils.rs
+++ b/src/math_utils.rs
@@ -1,6 +1,8 @@
 use std::ops::Shr;
 
-use crate::{bigint, vm::errors::vm_errors::VirtualMachineError};
+use crate::{
+    bigint, felt, types::relocatable::FieldElement, vm::errors::vm_errors::VirtualMachineError,
+};
 use num_bigint::BigInt;
 use num_integer::Integer;
 use num_traits::{Signed, Zero};
@@ -8,19 +10,19 @@ use num_traits::{Signed, Zero};
 ///Returns the integer square root of the nonnegative integer n.
 ///This is the floor of the exact square root of n.
 ///Unlike math.sqrt(), this function doesn't have rounding error issues.
-pub fn isqrt(n: &BigInt) -> Result<BigInt, VirtualMachineError> {
+pub fn isqrt(n: &FieldElement) -> Result<FieldElement, VirtualMachineError> {
     //n.shr(1) = n.div_floor(2)
     if n.is_negative() {
-        return Err(VirtualMachineError::SqrtNegative(n.clone()));
+        return Err(VirtualMachineError::SqrtNegative(n.num.clone()));
     }
     let mut x = n.clone();
-    let mut y = (x.clone() + bigint!(1)).shr(1_i32);
+    let mut y = (x.clone() + felt!(1)).shr(1);
     while y < x {
         x = y;
-        y = (x.clone() + n.div_floor(&x)).shr(1_i32);
+        y = (x.clone() + (n % &x)).shr(1);
     }
-    if !(x.pow(2) <= *n && *n < (x.clone() + bigint!(1)).pow(2)) {
-        return Err(VirtualMachineError::FailedToGetSqrt(n.clone()));
+    if !(x.pow(2) <= *n && *n < (x.clone() + felt!(1)).pow(2)) {
+        return Err(VirtualMachineError::FailedToGetSqrt(n.num.clone()));
     };
     Ok(x)
 }
@@ -41,12 +43,12 @@ pub fn safe_div(x: &BigInt, y: &BigInt) -> Result<BigInt, VirtualMachineError> {
 }
 
 /// Returns the lift of the given field element, val, as an integer in the range (-prime/2, prime/2).
-pub fn as_int(val: &BigInt, prime: &BigInt) -> BigInt {
+pub fn as_int(val: &FieldElement, prime: &BigInt) -> BigInt {
     //n.shr(1) = n.div_floor(2)
-    if *val < prime.shr(1) {
-        val.clone()
+    if val.num < prime.shr(1) {
+        val.num.clone()
     } else {
-        val - prime
+        val.num.clone() - prime
     }
 }
 
@@ -135,7 +137,7 @@ pub fn ec_double_slope(point: (BigInt, BigInt), alpha: &BigInt, prime: &BigInt) 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bigint_str;
+    use crate::{bigint_str, felt_str};
 
     #[test]
     fn calculate_igcdex() {
@@ -487,19 +489,19 @@ mod tests {
 
     #[test]
     fn calculate_isqrt_a() {
-        let n = bigint!(81);
-        assert_eq!(isqrt(&n), Ok(bigint!(9)));
+        let n = felt!(81);
+        assert_eq!(isqrt(&n), Ok(felt!(9)));
     }
 
     #[test]
     fn calculate_isqrt_b() {
-        let n = bigint_str!(b"4573659632505831259480");
+        let n = felt_str!(b"4573659632505831259480");
         assert_eq!(isqrt(&(n.pow(2))), Ok(n));
     }
 
     #[test]
     fn calculate_isqrt_c() {
-        let n = bigint_str!(
+        let n = felt_str!(
             b"3618502788666131213697322783095070105623107215331596699973092056135872020481"
         );
         assert_eq!(isqrt(&(n.pow(2))), Ok(n));
@@ -507,13 +509,13 @@ mod tests {
 
     #[test]
     fn calculate_isqrt_zero() {
-        let n = bigint!(0);
-        assert_eq!(isqrt(&n), Ok(bigint!(0)));
+        let n = felt!(0);
+        assert_eq!(isqrt(&n), Ok(felt!(0)));
     }
 
     #[test]
     fn calculate_isqrt_negative() {
-        let n = bigint!(-1);
-        assert_eq!(isqrt(&n), Err(VirtualMachineError::SqrtNegative(n)));
+        let n = felt!(-1);
+        assert_eq!(isqrt(&n), Err(VirtualMachineError::SqrtNegative(n.num)));
     }
 }

--- a/src/types/relocatable.rs
+++ b/src/types/relocatable.rs
@@ -200,6 +200,15 @@ impl Sub<&FieldElement> for &FieldElement {
     }
 }
 
+impl Sub<usize> for FieldElement {
+    type Output = FieldElement;
+    fn sub(self, other: usize) -> FieldElement {
+        FieldElement {
+            num: self.num - other,
+        }
+    }
+}
+
 impl Sub<usize> for &FieldElement {
     type Output = FieldElement;
     fn sub(self, other: usize) -> FieldElement {
@@ -293,6 +302,24 @@ impl BitAnd<u32> for FieldElement {
     fn bitand(self, rhs: u32) -> FieldElement {
         FieldElement {
             num: self.num & bigint!(rhs),
+        }
+    }
+}
+
+impl BitAnd<u128> for FieldElement {
+    type Output = FieldElement;
+    fn bitand(self, rhs: u128) -> FieldElement {
+        FieldElement {
+            num: self.num & bigint!(rhs),
+        }
+    }
+}
+
+impl BitAnd<u128> for &FieldElement {
+    type Output = FieldElement;
+    fn bitand(self, rhs: u128) -> FieldElement {
+        FieldElement {
+            num: &self.num & bigint!(rhs),
         }
     }
 }

--- a/src/types/relocatable.rs
+++ b/src/types/relocatable.rs
@@ -414,6 +414,12 @@ impl FieldElement {
         (FieldElement { num: q }, FieldElement { num: r })
     }
 
+    pub fn div_floor(&self, other: &FieldElement) -> FieldElement {
+        FieldElement {
+            num: self.num.div_floor(&other.num),
+        }
+    }
+
     pub fn pow(&self, exp: u32) -> FieldElement {
         FieldElement {
             num: self.num.pow(exp),

--- a/src/types/relocatable.rs
+++ b/src/types/relocatable.rs
@@ -381,6 +381,10 @@ impl FieldElement {
         self.num.is_negative()
     }
 
+    pub fn is_multiple_of(&self, other: &BigInt) -> bool {
+        self.num.is_multiple_of(other)
+    }
+
     pub fn to_bigint(&self) -> BigInt {
         self.num.clone()
     }

--- a/src/types/relocatable.rs
+++ b/src/types/relocatable.rs
@@ -218,6 +218,15 @@ impl Mul<&FieldElement> for &FieldElement {
     }
 }
 
+impl Mul<FieldElement> for FieldElement {
+    type Output = FieldElement;
+    fn mul(self, rhs: FieldElement) -> FieldElement {
+        FieldElement {
+            num: self.num * rhs.num,
+        }
+    }
+}
+
 impl Mul<&BigInt> for &FieldElement {
     type Output = FieldElement;
     fn mul(self, rhs: &BigInt) -> FieldElement {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -21,6 +21,19 @@ macro_rules! bigint_str {
 }
 
 #[macro_export]
+macro_rules! felt {
+    ($val : expr) => {
+        FieldElement::from(bigint!($val))
+    };
+}
+#[macro_export]
+macro_rules! felt_str {
+    ($val : expr) => {
+        FieldElement::from(bigint_str!($val))
+    };
+}
+
+#[macro_export]
 macro_rules! relocatable {
     ($val1 : expr, $val2 : expr) => {
         Relocatable {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -362,8 +362,8 @@ pub mod test_utils {
                         .trackers
                         .get_mut(&$tracker_num)
                         .unwrap()
-                        .get_value(&bigint!($key)),
-                    Ok(&bigint!($val))
+                        .get_value(&felt!($key)),
+                    Ok(&felt!($val))
                 );
             )*
         };
@@ -391,7 +391,7 @@ pub mod test_utils {
         ($exec_scopes_proxy:expr, $tracker_num:expr, $( ($key:expr, $val:expr )),* ) => {
             let mut tracker = DictTracker::new_empty(&relocatable!($tracker_num, 0));
             $(
-            tracker.insert_value(&bigint!($key), &bigint!($val));
+            tracker.insert_value(&felt!($key), &felt!($val));
             )*
             let mut dict_manager = DictManager::new();
             dict_manager.trackers.insert(2, tracker);
@@ -409,16 +409,16 @@ pub mod test_utils {
 
     macro_rules! dict_manager_default {
         ($exec_scopes_proxy:expr, $tracker_num:expr,$default:expr, $( ($key:expr, $val:expr )),* ) => {
-            let mut tracker = DictTracker::new_default_dict(&relocatable!($tracker_num, 0), &bigint!($default), None);
+            let mut tracker = DictTracker::new_default_dict(&relocatable!($tracker_num, 0), &felt!($default), None);
             $(
-            tracker.insert_value(&bigint!($key), &bigint!($val));
+            tracker.insert_value(&felt!($key), &felt!($val));
             )*
             let mut dict_manager = DictManager::new();
             dict_manager.trackers.insert(2, tracker);
             $exec_scopes_proxy.insert_value("dict_manager", Rc::new(RefCell::new(dict_manager)))
         };
         ($exec_scopes_proxy:expr, $tracker_num:expr,$default:expr) => {
-            let tracker = DictTracker::new_default_dict(&relocatable!($tracker_num, 0), &bigint!($default), None);
+            let tracker = DictTracker::new_default_dict(&relocatable!($tracker_num, 0), &felt!($default), None);
             let mut dict_manager = DictManager::new();
             dict_manager.trackers.insert(2, tracker);
             $exec_scopes_proxy.insert_value("dict_manager", Rc::new(RefCell::new(dict_manager)))
@@ -474,6 +474,7 @@ mod test {
 
     use super::*;
     use crate::hint_processor::hint_processor_definition::HintReference;
+    use crate::types::relocatable::FieldElement;
     use crate::types::relocatable::MaybeRelocatable;
     use crate::vm::errors::memory_errors::MemoryError;
     use crate::vm::trace::trace_entry::TraceEntry;
@@ -770,7 +771,7 @@ mod test {
     #[test]
     fn check_dictionary_pass() {
         let mut tracker = DictTracker::new_empty(&relocatable!(2, 0));
-        tracker.insert_value(&bigint!(5), &bigint!(10));
+        tracker.insert_value(&felt!(5), &felt!(10));
         let mut dict_manager = DictManager::new();
         dict_manager.trackers.insert(2, tracker);
         let mut exec_scopes = ExecutionScopes::new();
@@ -786,7 +787,7 @@ mod test {
     #[should_panic]
     fn check_dictionary_fail() {
         let mut tracker = DictTracker::new_empty(&relocatable!(2, 0));
-        tracker.insert_value(&bigint!(5), &bigint!(10));
+        tracker.insert_value(&felt!(5), &felt!(10));
         let mut dict_manager = DictManager::new();
         dict_manager.trackers.insert(2, tracker);
         let mut exec_scopes = ExecutionScopes::new();
@@ -843,7 +844,7 @@ mod test {
 
     #[test]
     fn dict_manager_default_macro() {
-        let tracker = DictTracker::new_default_dict(&relocatable!(2, 0), &bigint!(17), None);
+        let tracker = DictTracker::new_default_dict(&relocatable!(2, 0), &felt!(17), None);
         let mut dict_manager = DictManager::new();
         dict_manager.trackers.insert(2, tracker);
         let mut exec_scopes = ExecutionScopes::new();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -474,7 +474,6 @@ mod test {
 
     use super::*;
     use crate::hint_processor::hint_processor_definition::HintReference;
-    use crate::types::relocatable::FieldElement;
     use crate::types::relocatable::MaybeRelocatable;
     use crate::vm::errors::memory_errors::MemoryError;
     use crate::vm::trace::trace_entry::TraceEntry;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -362,8 +362,8 @@ pub mod test_utils {
                         .trackers
                         .get_mut(&$tracker_num)
                         .unwrap()
-                        .get_value(&felt!($key)),
-                    Ok(&felt!($val))
+                        .get_value(&bigint!($key)),
+                    Ok(&bigint!($val))
                 );
             )*
         };
@@ -391,7 +391,7 @@ pub mod test_utils {
         ($exec_scopes_proxy:expr, $tracker_num:expr, $( ($key:expr, $val:expr )),* ) => {
             let mut tracker = DictTracker::new_empty(&relocatable!($tracker_num, 0));
             $(
-            tracker.insert_value(&felt!($key), &felt!($val));
+            tracker.insert_value(&bigint!($key), &bigint!($val));
             )*
             let mut dict_manager = DictManager::new();
             dict_manager.trackers.insert(2, tracker);
@@ -409,16 +409,16 @@ pub mod test_utils {
 
     macro_rules! dict_manager_default {
         ($exec_scopes_proxy:expr, $tracker_num:expr,$default:expr, $( ($key:expr, $val:expr )),* ) => {
-            let mut tracker = DictTracker::new_default_dict(&relocatable!($tracker_num, 0), &felt!($default), None);
+            let mut tracker = DictTracker::new_default_dict(&relocatable!($tracker_num, 0), &bigint!($default), None);
             $(
-            tracker.insert_value(&felt!($key), &felt!($val));
+            tracker.insert_value(&bigint!($key), &bigint!($val));
             )*
             let mut dict_manager = DictManager::new();
             dict_manager.trackers.insert(2, tracker);
             $exec_scopes_proxy.insert_value("dict_manager", Rc::new(RefCell::new(dict_manager)))
         };
         ($exec_scopes_proxy:expr, $tracker_num:expr,$default:expr) => {
-            let tracker = DictTracker::new_default_dict(&relocatable!($tracker_num, 0), &felt!($default), None);
+            let tracker = DictTracker::new_default_dict(&relocatable!($tracker_num, 0), &bigint!($default), None);
             let mut dict_manager = DictManager::new();
             dict_manager.trackers.insert(2, tracker);
             $exec_scopes_proxy.insert_value("dict_manager", Rc::new(RefCell::new(dict_manager)))
@@ -771,7 +771,7 @@ mod test {
     #[test]
     fn check_dictionary_pass() {
         let mut tracker = DictTracker::new_empty(&relocatable!(2, 0));
-        tracker.insert_value(&felt!(5), &felt!(10));
+        tracker.insert_value(&bigint!(5), &bigint!(10));
         let mut dict_manager = DictManager::new();
         dict_manager.trackers.insert(2, tracker);
         let mut exec_scopes = ExecutionScopes::new();
@@ -787,7 +787,7 @@ mod test {
     #[should_panic]
     fn check_dictionary_fail() {
         let mut tracker = DictTracker::new_empty(&relocatable!(2, 0));
-        tracker.insert_value(&felt!(5), &felt!(10));
+        tracker.insert_value(&bigint!(5), &bigint!(10));
         let mut dict_manager = DictManager::new();
         dict_manager.trackers.insert(2, tracker);
         let mut exec_scopes = ExecutionScopes::new();
@@ -844,7 +844,7 @@ mod test {
 
     #[test]
     fn dict_manager_default_macro() {
-        let tracker = DictTracker::new_default_dict(&relocatable!(2, 0), &felt!(17), None);
+        let tracker = DictTracker::new_default_dict(&relocatable!(2, 0), &bigint!(17), None);
         let mut dict_manager = DictManager::new();
         dict_manager.trackers.insert(2, tracker);
         let mut exec_scopes = ExecutionScopes::new();

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -5,7 +5,7 @@ use crate::{
         exec_scope::ExecutionScopes,
         instruction::Register,
         program::Program,
-        relocatable::{relocate_value, MaybeRelocatable, Relocatable},
+        relocatable::{relocate_value, FieldElement, MaybeRelocatable, Relocatable},
     },
     utils::{is_subsequence, to_field_element},
     vm::{
@@ -226,7 +226,9 @@ impl<'a> CairoRunner<'a> {
                     offset2: reference.value_address.offset2,
                     inner_dereference: reference.value_address.inner_dereference,
                     dereference: reference.value_address.dereference,
-                    immediate: reference.value_address.immediate.clone(),
+                    immediate: option_bigint_into_option_field_element(
+                        reference.value_address.immediate.clone(),
+                    ),
                     // only store `ap` tracking data if the reference is referred to it
                     ap_tracking_data: if reference.value_address.register == Some(Register::FP) {
                         None
@@ -379,13 +381,20 @@ impl<'a> CairoRunner<'a> {
                 writeln!(
                     stdout,
                     "{}",
-                    to_field_element(value.clone(), self.vm.prime.clone())
+                    to_field_element(value.num.clone(), self.vm.prime.clone())
                 )
                 .map_err(|_| RunnerError::WriteFail)?;
             }
         }
         Ok(())
     }
+}
+
+fn option_bigint_into_option_field_element(some_bigint: Option<BigInt>) -> Option<FieldElement> {
+    if let Some(num) = some_bigint {
+        return Some(FieldElement::from(num));
+    }
+    None
 }
 
 #[cfg(test)]

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -83,11 +83,11 @@ impl Memory {
     //Gets the value from memory address.
     //If the value is an MaybeRelocatable::Int(Bigint) return &Bigint
     //else raises Err
-    pub fn get_integer(&self, key: &Relocatable) -> Result<&BigInt, VirtualMachineError> {
-        if let Some(MaybeRelocatable::Int(FieldElement { num })) =
+    pub fn get_integer(&self, key: &Relocatable) -> Result<&FieldElement, VirtualMachineError> {
+        if let Some(MaybeRelocatable::Int(felt)) =
             self.get(key).map_err(VirtualMachineError::MemoryError)?
         {
-            Ok(num)
+            Ok(felt)
         } else {
             Err(VirtualMachineError::ExpectedInteger(
                 MaybeRelocatable::from(key),
@@ -166,7 +166,7 @@ impl Memory {
         let mut values = Vec::new();
 
         for i in 0..size {
-            values.push(self.get_integer(&(addr + i))?);
+            values.push(&self.get_integer(&(addr + i))?.num);
         }
 
         Ok(values)
@@ -182,7 +182,7 @@ impl Default for Memory {
 #[cfg(test)]
 mod memory_tests {
     use crate::{
-        bigint,
+        bigint, felt,
         vm::{
             runners::builtin_runner::{BuiltinRunner, RangeCheckBuiltinRunner},
             vm_memory::memory_segments::MemorySegmentManager,
@@ -431,7 +431,7 @@ mod memory_tests {
             .unwrap();
         assert_eq!(
             memory.get_integer(&Relocatable::from((0, 0))),
-            Ok(&bigint!(10))
+            Ok(&felt!(10))
         );
     }
 


### PR DESCRIPTION
# [REFACTOR] Abstract the representation of field elements. Phase 2
Issue: #268 
Waiting for PR #427 

## Description
* Add multiple FieldElement methods
* Refactor Memory.get_integer to return a FieldElement.
Because of this change every time a hint function gets a variable value from memory (`get_integer_from_var_name`) it now gets a FieldElement. So this refactor includes adaptations in all the hints implementation, so as to work with FielElements.

One thing to take into account. Scope variables still use BigInts, because they can operate with negative numbers instead of FieldElements.
 
## Checklist
- [x] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
