### PR TITLE
[Remove VMProxy -1] add Segments

### DIFF
--- a/src/hint_processor/builtin_hint_processor/hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/hint_utils.rs
@@ -68,8 +68,7 @@ pub fn get_address_from_var_name(
         ids_data
             .get(var_name)
             .ok_or(VirtualMachineError::FailedToGetIds)?,
-        vm_proxy.run_context,
-        &vm_proxy.memory,
+        vm_proxy,
         ap_tracking,
     )?))
 }
@@ -85,8 +84,7 @@ pub fn get_relocatable_from_var_name(
         ids_data
             .get(var_name)
             .ok_or(VirtualMachineError::FailedToGetIds)?,
-        vm_proxy.run_context,
-        &vm_proxy.memory,
+        vm_proxy,
         ap_tracking,
     )
 }

--- a/src/hint_processor/builtin_hint_processor/memcpy_hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/memcpy_hint_utils.rs
@@ -20,7 +20,6 @@ use crate::{
 //Implements hint: memory[ap] = segments.add()
 pub fn add_segment(vm_proxy: &mut VMProxy) -> Result<(), VirtualMachineError> {
     let new_segment_base = vm_proxy.add_memory_segment();
-    // let new_segment_base = vm_proxy.add_memory_segment();
     insert_value_into_ap(&mut vm_proxy.memory, vm_proxy.run_context, new_segment_base)
 }
 

--- a/src/hint_processor/builtin_hint_processor/memcpy_hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/memcpy_hint_utils.rs
@@ -19,7 +19,8 @@ use crate::{
 
 //Implements hint: memory[ap] = segments.add()
 pub fn add_segment(vm_proxy: &mut VMProxy) -> Result<(), VirtualMachineError> {
-    let new_segment_base = vm_proxy.memory.add_segment(vm_proxy.segments);
+    let new_segment_base = vm_proxy.add_memory_segment();
+    // let new_segment_base = vm_proxy.add_memory_segment();
     insert_value_into_ap(&mut vm_proxy.memory, vm_proxy.run_context, new_segment_base)
 }
 

--- a/src/hint_processor/proxies/vm_proxy.rs
+++ b/src/hint_processor/proxies/vm_proxy.rs
@@ -1,8 +1,11 @@
 use num_bigint::BigInt;
 
-use crate::vm::{
-    context::run_context::RunContext, runners::builtin_runner::BuiltinRunner,
-    vm_core::VirtualMachine, vm_memory::memory_segments::MemorySegmentManager,
+use crate::{
+    types::relocatable::Relocatable,
+    vm::{
+        context::run_context::RunContext, runners::builtin_runner::BuiltinRunner,
+        vm_core::VirtualMachine, vm_memory::memory_segments::MemorySegmentManager,
+    },
 };
 
 use super::memory_proxy::{get_memory_proxy, MemoryProxy};
@@ -24,5 +27,11 @@ pub fn get_vm_proxy(vm: &mut VirtualMachine) -> VMProxy {
         run_context: &mut vm.run_context,
         builtin_runners: &vm.builtin_runners,
         prime: &vm.prime,
+    }
+}
+
+impl VMProxy<'_> {
+    pub fn add_memory_segment(&mut self) -> Relocatable {
+        self.memory.add_segment(self.segments)
     }
 }

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -626,6 +626,10 @@ impl VirtualMachine {
         }
         Ok(())
     }
+
+    pub fn add_memory_segment(&mut self) -> Relocatable {
+        self.segments.add(&mut self.memory)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Remove VMProxy add Segments [Phase 1]

## Description
* Add method add_memory_segment to VirtualMachine and VMProxy
* Refactor fn `compute_addr_from_reference` to receive VMProxy as input

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
