### PR TITLE
Decouple VM from CairoRunner

### DIFF
--- a/bench/criterion_benchmark.rs
+++ b/bench/criterion_benchmark.rs
@@ -24,6 +24,7 @@ pub fn criterion_benchmarks(c: &mut Criterion) {
                     black_box(Path::new(&benchmark_name.1)),
                     "main",
                     false,
+                    false,
                     &hint_processor,
                 )
             })

--- a/src/cairo_run.rs
+++ b/src/cairo_run.rs
@@ -3,6 +3,7 @@ use crate::types::program::Program;
 use crate::vm::errors::{cairo_run_errors::CairoRunError, runner_errors::RunnerError};
 use crate::vm::runners::cairo_runner::CairoRunner;
 use crate::vm::trace::trace_entry::RelocatedTraceEntry;
+use crate::vm::vm_core::VirtualMachine;
 use num_bigint::BigInt;
 use std::fs::File;
 use std::io::{self, BufWriter, Error, ErrorKind, Write};
@@ -12,6 +13,7 @@ pub fn cairo_run<'a>(
     path: &'a Path,
     entrypoint: &'a str,
     trace_enabled: bool,
+    print_output: bool,
     hint_processor: &'a dyn HintProcessor,
 ) -> Result<CairoRunner<'a>, CairoRunError> {
     let program = match Program::new(path, entrypoint) {
@@ -19,39 +21,48 @@ pub fn cairo_run<'a>(
         Err(error) => return Err(CairoRunError::Program(error)),
     };
 
-    let mut cairo_runner = CairoRunner::new(&program, trace_enabled, hint_processor)?;
-    cairo_runner.initialize_segments(None);
+    let mut cairo_runner = CairoRunner::new(&program, hint_processor)?;
+    let mut vm = VirtualMachine::new(program.prime, trace_enabled);
+    cairo_runner.initialize_builtins(&mut vm)?;
+    cairo_runner.initialize_segments(&mut vm, None);
 
-    let end = match cairo_runner.initialize_main_entrypoint() {
+    let end = match cairo_runner.initialize_main_entrypoint(&mut vm) {
         Ok(end) => end,
         Err(error) => return Err(CairoRunError::Runner(error)),
     };
 
-    if let Err(error) = cairo_runner.initialize_vm() {
+    if let Err(error) = cairo_runner.initialize_vm(&mut vm) {
         return Err(CairoRunError::Runner(error));
     }
 
-    if let Err(error) = cairo_runner.run_until_pc(end) {
+    if let Err(error) = cairo_runner.run_until_pc(end, &mut vm) {
         return Err(CairoRunError::VirtualMachine(error));
     }
 
-    if let Err(error) = cairo_runner.vm.verify_auto_deductions() {
+    if let Err(error) = vm.verify_auto_deductions() {
         return Err(CairoRunError::VirtualMachine(error));
     }
 
-    if let Err(error) = cairo_runner.relocate() {
+    if let Err(error) = cairo_runner.relocate(&mut vm) {
         return Err(CairoRunError::Trace(error));
+    }
+
+    if print_output {
+        write_output(&mut cairo_runner, &mut vm)?;
     }
 
     Ok(cairo_runner)
 }
 
-pub fn write_output(cairo_runner: &mut CairoRunner) -> Result<(), CairoRunError> {
+pub fn write_output(
+    cairo_runner: &mut CairoRunner,
+    vm: &mut VirtualMachine,
+) -> Result<(), CairoRunError> {
     let mut buffer = BufWriter::new(io::stdout());
     writeln!(&mut buffer, "Program Output: ")
         .map_err(|_| CairoRunError::Runner(RunnerError::WriteFail))?;
     cairo_runner
-        .write_output(&mut buffer)
+        .write_output(vm, &mut buffer)
         .map_err(CairoRunError::Runner)?;
     buffer
         .flush()
@@ -127,48 +138,51 @@ mod tests {
     use crate::{
         bigint,
         hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor,
+        utils::test_utils::vm,
     };
+    use num_bigint::Sign;
     use std::io::Read;
 
     fn run_test_program<'a>(
         program_path: &Path,
         hint_processor: &'a dyn HintProcessor,
-    ) -> Result<CairoRunner<'a>, CairoRunError> {
+    ) -> Result<(CairoRunner<'a>, VirtualMachine), CairoRunError> {
         let program = match Program::new(program_path, "main") {
             Ok(program) => program,
             Err(e) => return Err(CairoRunError::Program(e)),
         };
 
-        let mut cairo_runner = CairoRunner::new(&program, true, hint_processor).unwrap();
+        let mut cairo_runner = CairoRunner::new(&program, hint_processor).unwrap();
+        let mut vm = vm!(true);
+        cairo_runner.initialize_builtins(&mut vm).unwrap();
+        cairo_runner.initialize_segments(&mut vm, None);
 
-        cairo_runner.initialize_segments(None);
-
-        let end = match cairo_runner.initialize_main_entrypoint() {
+        let end = match cairo_runner.initialize_main_entrypoint(&mut vm) {
             Ok(end) => end,
             Err(e) => return Err(CairoRunError::Runner(e)),
         };
 
-        assert!(cairo_runner.initialize_vm().is_ok());
+        assert!(cairo_runner.initialize_vm(&mut vm).is_ok());
 
-        assert!(cairo_runner.run_until_pc(end).is_ok());
+        assert!(cairo_runner.run_until_pc(end, &mut vm).is_ok());
 
-        Ok(cairo_runner)
+        Ok((cairo_runner, vm))
     }
 
     #[test]
     fn cairo_run_custom_entry_point() {
         let program_path = Path::new("cairo_programs/not_main.json");
         let program = Program::new(program_path, "not_main").unwrap();
-
+        let mut vm = vm!();
         let hint_processor = BuiltinHintProcessor::new_empty();
-        let mut cairo_runner = CairoRunner::new(&program, false, &hint_processor).unwrap();
-        cairo_runner.initialize_segments(None);
+        let mut cairo_runner = CairoRunner::new(&program, &hint_processor).unwrap();
+        cairo_runner.initialize_segments(&mut vm, None);
 
-        let end = cairo_runner.initialize_main_entrypoint().unwrap();
+        let end = cairo_runner.initialize_main_entrypoint(&mut vm).unwrap();
 
-        assert!(cairo_runner.initialize_vm().is_ok());
-        assert!(cairo_runner.run_until_pc(end).is_ok());
-        assert!(cairo_runner.relocate().is_ok());
+        assert!(cairo_runner.initialize_vm(&mut vm).is_ok());
+        assert!(cairo_runner.run_until_pc(end, &mut vm).is_ok());
+        assert!(cairo_runner.relocate(&mut vm).is_ok());
         // `main` returns without doing nothing, but `not_main` sets `[ap]` to `1`
         // Memory location was found empirically and simply hardcoded
         assert_eq!(cairo_runner.relocated_memory[2], Some(bigint!(123)));
@@ -198,7 +212,7 @@ mod tests {
         // it should fail when the program is loaded.
         let no_data_program_path = Path::new("cairo_programs/no_data_program.json");
         let hint_processor = BuiltinHintProcessor::new_empty();
-        assert!(cairo_run(no_data_program_path, "main", false, &hint_processor).is_err());
+        assert!(cairo_run(no_data_program_path, "main", false, false, &hint_processor).is_err());
     }
 
     #[test]
@@ -207,7 +221,7 @@ mod tests {
         // it should fail when trying to run initialize_main_entrypoint.
         let no_main_program_path = Path::new("cairo_programs/no_main_program.json");
         let hint_processor = BuiltinHintProcessor::new_empty();
-        assert!(cairo_run(no_main_program_path, "main", false, &hint_processor).is_err());
+        assert!(cairo_run(no_main_program_path, "main", false, false, &hint_processor).is_err());
     }
 
     #[test]
@@ -216,7 +230,7 @@ mod tests {
         // decode the instruction.
         let invalid_memory = Path::new("cairo_programs/invalid_memory.json");
         let hint_processor = BuiltinHintProcessor::new_empty();
-        assert!(cairo_run(invalid_memory, "main", false, &hint_processor).is_err());
+        assert!(cairo_run(invalid_memory, "main", false, false, &hint_processor).is_err());
     }
 
     #[test]
@@ -228,11 +242,11 @@ mod tests {
         // run test program until the end
         let hint_processor = BuiltinHintProcessor::new_empty();
         let cairo_runner_result = run_test_program(program_path, &hint_processor);
-        let mut cairo_runner = cairo_runner_result.unwrap();
+        let (mut cairo_runner, mut vm) = cairo_runner_result.unwrap();
 
         // relocate memory so we can dump it to file
-        assert!(cairo_runner.relocate().is_ok());
-        assert!(cairo_runner.vm.trace.is_some());
+        assert!(cairo_runner.relocate(&mut vm).is_ok());
+        assert!(vm.trace.is_some());
         assert!(cairo_runner.relocated_trace.is_some());
 
         // write cairo_rs vm trace file
@@ -253,10 +267,10 @@ mod tests {
         // run test program until the end
         let hint_processor = BuiltinHintProcessor::new_empty();
         let cairo_runner_result = run_test_program(program_path, &hint_processor);
-        let mut cairo_runner = cairo_runner_result.unwrap();
+        let (mut cairo_runner, mut vm) = cairo_runner_result.unwrap();
 
         // relocate memory so we can dump it to file
-        assert!(cairo_runner.relocate().is_ok());
+        assert!(cairo_runner.relocate(&mut vm).is_ok());
 
         // write cairo_rs vm memory file
         assert!(write_binary_memory(&cairo_runner.relocated_memory, cairo_rs_memory_path).is_ok());
@@ -270,11 +284,12 @@ mod tests {
         let program_path = Path::new("cairo_programs/struct.json");
         let program = Program::new(program_path, "main").unwrap();
         let hint_processor = BuiltinHintProcessor::new_empty();
-        let mut cairo_runner = CairoRunner::new(&program, false, &hint_processor).unwrap();
-        cairo_runner.initialize_segments(None);
-        let end = cairo_runner.initialize_main_entrypoint().unwrap();
-        assert!(cairo_runner.initialize_vm().is_ok());
-        assert!(cairo_runner.run_until_pc(end).is_ok());
-        assert!(cairo_runner.vm.trace.is_none());
+        let mut cairo_runner = CairoRunner::new(&program, &hint_processor).unwrap();
+        let mut vm = vm!();
+        cairo_runner.initialize_segments(&mut vm, None);
+        let end = cairo_runner.initialize_main_entrypoint(&mut vm).unwrap();
+        assert!(cairo_runner.initialize_vm(&mut vm).is_ok());
+        assert!(cairo_runner.run_until_pc(end, &mut vm).is_ok());
+        assert!(vm.trace.is_none());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,10 +35,11 @@ fn main() -> Result<(), CairoRunError> {
 
     let args = Args::parse();
     let trace_enabled = args.trace_file.is_some();
-    let mut cairo_runner = match cairo_run::cairo_run(
+    let cairo_runner = match cairo_run::cairo_run(
         &args.filename,
         &args.entrypoint,
         trace_enabled,
+        args.print_output,
         &hint_processor,
     ) {
         Ok(runner) => runner,
@@ -54,10 +55,6 @@ fn main() -> Result<(), CairoRunError> {
             Ok(()) => (),
             Err(_e) => return Err(CairoRunError::Runner(RunnerError::WriteFail)),
         }
-    }
-
-    if args.print_output {
-        cairo_run::write_output(&mut cairo_runner)?;
     }
 
     if let Some(memory_path) = args.memory_file {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -178,16 +178,17 @@ pub mod test_utils {
     pub(crate) use references;
 
     macro_rules! vm_with_range_check {
-        () => {
-            VirtualMachine::new(
+        () => {{
+            let mut vm = VirtualMachine::new(
                 BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-                vec![(
-                    "range_check".to_string(),
-                    Box::new(RangeCheckBuiltinRunner::new(bigint!(8), 8)),
-                )],
                 false,
-            )
-        };
+            );
+            vm.builtin_runners = vec![(
+                "range_check".to_string(),
+                Box::new(RangeCheckBuiltinRunner::new(bigint!(8), 8)),
+            )];
+            vm
+        }};
     }
     pub(crate) use vm_with_range_check;
 
@@ -195,7 +196,6 @@ pub mod test_utils {
         () => {{
             VirtualMachine::new(
                 BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-                vec![],
                 false,
             )
         }};
@@ -203,7 +203,6 @@ pub mod test_utils {
         ($use_trace:expr) => {{
             VirtualMachine::new(
                 BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-                vec![],
                 $use_trace,
             )
         }};

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -71,11 +71,7 @@ impl HintData {
 }
 
 impl VirtualMachine {
-    pub fn new(
-        prime: BigInt,
-        builtin_runners: Vec<(String, Box<dyn BuiltinRunner>)>,
-        trace_enabled: bool,
-    ) -> VirtualMachine {
+    pub fn new(prime: BigInt, trace_enabled: bool) -> VirtualMachine {
         let run_context = RunContext {
             pc: Relocatable::from((0, 0)),
             ap: 0,
@@ -92,7 +88,7 @@ impl VirtualMachine {
         VirtualMachine {
             run_context,
             prime,
-            builtin_runners,
+            builtin_runners: Vec::new(),
             _program_base: None,
             memory: Memory::new(),
             accessed_addresses: None,
@@ -798,7 +794,7 @@ mod tests {
             op1: MaybeRelocatable::Int(bigint!(10)),
         };
 
-        let mut vm = VirtualMachine::new(bigint!(39), Vec::new(), false);
+        let mut vm = VirtualMachine::new(bigint!(39), false);
         vm.run_context.pc = Relocatable::from((0, 4));
         vm.run_context.ap = 5;
         vm.run_context.fp = 6;
@@ -831,7 +827,7 @@ mod tests {
             op1: MaybeRelocatable::Int(bigint!(10)),
         };
 
-        let mut vm = VirtualMachine::new(bigint!(39), Vec::new(), false);
+        let mut vm = vm!();
         vm.run_context.pc = Relocatable::from((0, 4));
         vm.run_context.ap = 5;
         vm.run_context.fp = 6;
@@ -866,7 +862,7 @@ mod tests {
             op1: MaybeRelocatable::Int(bigint!(10)),
         };
 
-        let mut vm = VirtualMachine::new(bigint!(39), Vec::new(), false);
+        let mut vm = vm!();
         vm.run_context.pc = Relocatable::from((0, 4));
         vm.run_context.ap = 5;
         vm.run_context.fp = 6;
@@ -899,7 +895,7 @@ mod tests {
             op1: MaybeRelocatable::Int(bigint!(10)),
         };
 
-        let mut vm = VirtualMachine::new(bigint!(39), Vec::new(), false);
+        let mut vm = vm!();
         vm.run_context.pc = Relocatable::from((0, 4));
         vm.run_context.ap = 5;
         vm.run_context.fp = 6;
@@ -932,7 +928,7 @@ mod tests {
             op1: MaybeRelocatable::Int(bigint!(10)),
         };
 
-        let mut vm = VirtualMachine::new(bigint!(39), Vec::new(), false);
+        let mut vm = vm!();
         vm.run_context.pc = Relocatable::from((0, 4));
         vm.run_context.ap = 5;
         vm.run_context.fp = 6;
@@ -1055,7 +1051,7 @@ mod tests {
             op1: MaybeRelocatable::Int(bigint!(10)),
         };
 
-        let mut vm = VirtualMachine::new(bigint!(39), Vec::new(), false);
+        let mut vm = vm!();
         vm.run_context.pc = Relocatable::from((0, 4));
         vm.run_context.ap = 5;
         vm.run_context.fp = 6;
@@ -1245,7 +1241,7 @@ mod tests {
             op1: MaybeRelocatable::Int(bigint!(10)),
         };
 
-        let mut vm = VirtualMachine::new(bigint!(39), Vec::new(), false);
+        let mut vm = vm!();
         vm.run_context.pc = Relocatable::from((0, 4));
         vm.run_context.ap = 5;
         vm.run_context.fp = 6;
@@ -1982,7 +1978,7 @@ mod tests {
             fp_update: FpUpdate::Regular,
             opcode: Opcode::NOp,
         };
-        let mut vm = VirtualMachine::new(bigint!(127), Vec::new(), false);
+        let mut vm = vm!();
         //Create program and execution segments
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory);
@@ -2083,7 +2079,7 @@ mod tests {
             opcode: Opcode::NOp,
         };
 
-        let mut vm = VirtualMachine::new(bigint!(127), Vec::new(), false);
+        let mut vm = vm!();
 
         vm.memory = memory!(((1, 0), 145944781867024385_i64));
 
@@ -2580,7 +2576,7 @@ mod tests {
 
     #[test]
     fn deduce_memory_cell_bitwise_builtin_valid_and() {
-        let mut vm = VirtualMachine::new(bigint!(17), Vec::new(), false);
+        let mut vm = vm!();
         let builtin = BitwiseBuiltinRunner::new(8);
         vm.builtin_runners
             .push((String::from("bitwise"), Box::new(builtin)));

--- a/tests/bitwise_test.rs
+++ b/tests/bitwise_test.rs
@@ -1,10 +1,13 @@
 use cairo_rs::{
     hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor,
     types::program::Program,
-    vm::{runners::cairo_runner::CairoRunner, trace::trace_entry::RelocatedTraceEntry},
+    vm::{
+        runners::cairo_runner::CairoRunner, trace::trace_entry::RelocatedTraceEntry,
+        vm_core::VirtualMachine,
+    },
 };
+use num_bigint::{BigInt, Sign};
 use std::path::Path;
-
 #[test]
 fn bitwise_integration_test() {
     let program = Program::new(
@@ -13,13 +16,27 @@ fn bitwise_integration_test() {
     )
     .expect("Failed to deserialize program");
     let hint_processor = BuiltinHintProcessor::new_empty();
-    let mut cairo_runner = CairoRunner::new(&program, true, &hint_processor).unwrap();
-    cairo_runner.initialize_segments(None);
-    let end = cairo_runner.initialize_main_entrypoint().unwrap();
+    let mut cairo_runner = CairoRunner::new(&program, &hint_processor).unwrap();
+    let mut vm = VirtualMachine::new(
+        BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+        true,
+    );
+    cairo_runner.initialize_builtins(&mut vm).unwrap();
+    cairo_runner.initialize_segments(&mut vm, None);
+    let end = cairo_runner.initialize_main_entrypoint(&mut vm).unwrap();
 
-    assert!(cairo_runner.initialize_vm() == Ok(()), "Execution failed");
-    assert!(cairo_runner.run_until_pc(end) == Ok(()), "Execution failed");
-    assert!(cairo_runner.relocate() == Ok(()), "Execution failed");
+    assert!(
+        cairo_runner.initialize_vm(&mut vm,) == Ok(()),
+        "Execution failed"
+    );
+    assert!(
+        cairo_runner.run_until_pc(end, &mut vm) == Ok(()),
+        "Execution failed"
+    );
+    assert!(
+        cairo_runner.relocate(&mut vm,) == Ok(()),
+        "Execution failed"
+    );
 
     let python_vm_relocated_trace: Vec<RelocatedTraceEntry> = vec![
         RelocatedTraceEntry {

--- a/tests/cairo_run_test.rs
+++ b/tests/cairo_run_test.rs
@@ -12,6 +12,7 @@ fn cairo_run_test() {
         Path::new("cairo_programs/fibonacci.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -23,6 +24,7 @@ fn cairo_run_array_sum() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/array_sum.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -36,6 +38,7 @@ fn cairo_run_big_struct() {
         Path::new("cairo_programs/big_struct.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -47,6 +50,7 @@ fn cairo_run_call_function_assign_param_by_name() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/call_function_assign_param_by_name.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -60,6 +64,7 @@ fn cairo_run_function_return() {
         Path::new("cairo_programs/function_return.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -71,6 +76,7 @@ fn cairo_run_function_return_if_print() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/function_return_if_print.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -84,6 +90,7 @@ fn cairo_run_function_return_to_variable() {
         Path::new("cairo_programs/function_return_to_variable.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -95,6 +102,7 @@ fn cairo_run_if_and_prime() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/if_and_prime.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -108,6 +116,7 @@ fn cairo_run_if_in_function() {
         Path::new("cairo_programs/if_in_function.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -119,6 +128,7 @@ fn cairo_run_if_list() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/if_list.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -132,6 +142,7 @@ fn cairo_run_jmp() {
         Path::new("cairo_programs/jmp.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -143,6 +154,7 @@ fn cairo_run_jmp_if_condition() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/jmp_if_condition.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -156,6 +168,7 @@ fn cairo_run_pointers() {
         Path::new("cairo_programs/pointers.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -167,6 +180,7 @@ fn cairo_run_print() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/print.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -180,6 +194,7 @@ fn cairo_run_return() {
         Path::new("cairo_programs/return.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -191,6 +206,7 @@ fn cairo_run_reversed_register_instructions() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/reversed_register_instructions.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -204,6 +220,7 @@ fn cairo_run_simple_print() {
         Path::new("cairo_programs/simple_print.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -215,6 +232,7 @@ fn cairo_run_test_addition_if() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/test_addition_if.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -228,6 +246,7 @@ fn cairo_run_test_reverse_if() {
         Path::new("cairo_programs/test_reverse_if.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -239,6 +258,7 @@ fn cairo_run_test_subtraction_if() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/test_subtraction_if.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -252,6 +272,7 @@ fn cairo_run_use_imported_module() {
         Path::new("cairo_programs/use_imported_module.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -263,6 +284,7 @@ fn cairo_run_bitwise_output() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/bitwise_output.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -276,6 +298,7 @@ fn cairo_run_bitwise_recursion() {
         Path::new("cairo_programs/bitwise_recursion.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -287,6 +310,7 @@ fn cairo_run_integration() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/integration.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -300,6 +324,7 @@ fn cairo_run_integration_with_alloc_locals() {
         Path::new("cairo_programs/integration_with_alloc_locals.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -311,6 +336,7 @@ fn cairo_run_compare_arrays() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/compare_arrays.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -324,6 +350,7 @@ fn cairo_run_compare_greater_array() {
         Path::new("cairo_programs/compare_greater_array.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -335,6 +362,7 @@ fn cairo_run_compare_lesser_array() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/compare_lesser_array.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -348,6 +376,7 @@ fn cairo_run_assert_le_felt_hint() {
         Path::new("cairo_programs/assert_le_felt_hint.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -359,6 +388,7 @@ fn cairo_run_assert_250_bit_element_array() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/assert_250_bit_element_array.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -372,6 +402,7 @@ fn cairo_abs_value() {
         Path::new("cairo_programs/abs_value_array.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -383,6 +414,7 @@ fn cairo_run_compare_different_arrays() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/compare_different_arrays.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -396,6 +428,7 @@ fn cairo_run_assert_nn() {
         Path::new("cairo_programs/assert_nn.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -407,6 +440,7 @@ fn cairo_run_sqrt() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/sqrt.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -420,6 +454,7 @@ fn cairo_run_assert_not_zero() {
         Path::new("cairo_programs/assert_not_zero.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -431,6 +466,7 @@ fn cairo_run_split_int() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/split_int.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -444,6 +480,7 @@ fn cairo_run_split_int_big() {
         Path::new("cairo_programs/split_int_big.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -455,6 +492,7 @@ fn cairo_run_split_felt() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/split_felt.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -468,6 +506,7 @@ fn cairo_run_math_cmp() {
         Path::new("cairo_programs/math_cmp.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -479,6 +518,7 @@ fn cairo_run_unsigned_div_rem() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/unsigned_div_rem.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -492,6 +532,7 @@ fn cairo_run_signed_div_rem() {
         Path::new("cairo_programs/signed_div_rem.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -503,6 +544,7 @@ fn cairo_run_assert_lt_felt() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/assert_lt_felt.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -516,6 +558,7 @@ fn cairo_run_memcpy() {
         Path::new("cairo_programs/memcpy_test.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -527,6 +570,7 @@ fn cairo_run_memset() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/memset.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -540,6 +584,7 @@ fn cairo_run_pow() {
         Path::new("cairo_programs/pow.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -551,6 +596,7 @@ fn cairo_run_dict() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/dict.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -564,6 +610,7 @@ fn cairo_run_dict_update() {
         Path::new("cairo_programs/dict_update.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -575,6 +622,7 @@ fn cairo_run_uint256() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/uint256.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -588,6 +636,7 @@ fn cairo_run_find_element() {
         Path::new("cairo_programs/find_element.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -599,6 +648,7 @@ fn cairo_run_search_sorted_lower() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/search_sorted_lower.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -612,6 +662,7 @@ fn cairo_run_usort() {
         Path::new("cairo_programs/usort.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -623,6 +674,7 @@ fn cairo_run_usort_bad() {
     let err = cairo_run::cairo_run(
         Path::new("cairo_programs/bad_programs/bad_usort.json"),
         "main",
+        false,
         false,
         &hint_processor,
     );
@@ -640,6 +692,7 @@ fn cairo_run_dict_write_bad() {
         Path::new("cairo_programs/bad_programs/bad_dict_new.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .is_err());
@@ -647,6 +700,7 @@ fn cairo_run_dict_write_bad() {
     let err = cairo_run::cairo_run(
         Path::new("cairo_programs/bad_programs/bad_dict_new.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -664,12 +718,14 @@ fn cairo_run_dict_update_bad() {
         Path::new("cairo_programs/bad_programs/bad_dict_update.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .is_err());
     let err = cairo_run::cairo_run(
         Path::new("cairo_programs/bad_programs/bad_dict_update.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -687,6 +743,7 @@ fn cairo_run_squash_dict() {
         Path::new("cairo_programs/squash_dict.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -698,6 +755,7 @@ fn cairo_run_dict_squash() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/dict_squash.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -711,6 +769,7 @@ fn cairo_run_set_add() {
         Path::new("cairo_programs/set_add.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -722,6 +781,7 @@ fn cairo_run_secp() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/secp.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -735,6 +795,7 @@ fn cairo_run_signature() {
         Path::new("cairo_programs/signature.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -746,6 +807,7 @@ fn cairo_run_secp_ec() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/secp_ec.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -759,6 +821,7 @@ fn cairo_run_blake2s_hello_world_hash() {
         Path::new("cairo_programs/blake2s_hello_world_hash.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -771,6 +834,7 @@ fn cairo_run_finalize_blake2s() {
         Path::new("cairo_programs/finalize_blake2s.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -781,6 +845,7 @@ fn cairo_run_unsafe_keccak() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/unsafe_keccak.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -794,6 +859,7 @@ fn cairo_run_blake2s_felts() {
         Path::new("cairo_programs/blake2s_felts.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -805,6 +871,7 @@ fn cairo_run_unsafe_keccak_finalize() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/unsafe_keccak_finalize.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -818,6 +885,7 @@ fn cairo_run_keccak_add_uint256() {
         Path::new("cairo_programs/keccak_add_uint256.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -829,6 +897,7 @@ fn cairo_run_private_keccak() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/_keccak.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -842,6 +911,7 @@ fn cairo_run_keccak_copy_inputs() {
         Path::new("cairo_programs/keccak_copy_inputs.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -853,6 +923,7 @@ fn cairo_run_finalize_keccak() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/cairo_finalize_keccak.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -866,6 +937,7 @@ fn cairo_run_operations_with_data() {
         Path::new("cairo_programs/operations_with_data_structures.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -877,6 +949,7 @@ fn cairo_run_sha256() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/sha256.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -890,6 +963,7 @@ fn cairo_run_math_cmp_and_pow_integration() {
         Path::new("cairo_programs/math_cmp_and_pow_integration_tests.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -901,6 +975,7 @@ fn cairo_run_uint256_integration() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/uint256_integration_tests.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -914,6 +989,7 @@ fn cairo_run_set_integration() {
         Path::new("cairo_programs/set_integration_tests.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -925,6 +1001,7 @@ fn cairo_run_memory_module_integration() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/memory_integration_tests.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -938,6 +1015,7 @@ fn cairo_run_dict_integration() {
         Path::new("cairo_programs/dict_integration_tests.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -949,6 +1027,7 @@ fn cairo_run_secp_integration() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/secp_integration_tests.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )
@@ -962,6 +1041,7 @@ fn cairo_run_keccak_integration() {
         Path::new("cairo_programs/keccak_integration_tests.json"),
         "main",
         false,
+        false,
         &hint_processor,
     )
     .expect("Couldn't run program");
@@ -973,6 +1053,7 @@ fn cairo_run_blake2s_integration() {
     cairo_run::cairo_run(
         Path::new("cairo_programs/blake2s_integration_tests.json"),
         "main",
+        false,
         false,
         &hint_processor,
     )

--- a/tests/pedersen_test.rs
+++ b/tests/pedersen_test.rs
@@ -2,21 +2,34 @@ use std::path::Path;
 
 use cairo_rs::{
     hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor,
-    types::program::Program, vm::runners::cairo_runner::CairoRunner,
+    types::program::Program,
     vm::trace::trace_entry::RelocatedTraceEntry,
+    vm::{runners::cairo_runner::CairoRunner, vm_core::VirtualMachine},
 };
+use num_bigint::{BigInt, Sign};
 
 #[test]
 fn pedersen_integration_test() {
     let program = Program::new(Path::new("cairo_programs/pedersen_test.json"), "main")
         .expect("Failed to deserialize program");
     let hint_processor = BuiltinHintProcessor::new_empty();
-    let mut cairo_runner = CairoRunner::new(&program, true, &hint_processor).unwrap();
-    cairo_runner.initialize_segments(None);
-    let end = cairo_runner.initialize_main_entrypoint().unwrap();
-    assert!(cairo_runner.initialize_vm() == Ok(()), "Execution failed");
-    assert!(cairo_runner.run_until_pc(end) == Ok(()), "Execution failed");
-    assert!(cairo_runner.relocate() == Ok(()), "Execution failed");
+    let mut cairo_runner = CairoRunner::new(&program, &hint_processor).unwrap();
+    let mut vm = VirtualMachine::new(
+        BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+        true,
+    );
+    cairo_runner.initialize_builtins(&mut vm).unwrap();
+    cairo_runner.initialize_segments(&mut vm, None);
+    let end = cairo_runner.initialize_main_entrypoint(&mut vm).unwrap();
+    assert!(
+        cairo_runner.initialize_vm(&mut vm) == Ok(()),
+        "Execution failed"
+    );
+    assert!(
+        cairo_runner.run_until_pc(end, &mut vm) == Ok(()),
+        "Execution failed"
+    );
+    assert!(cairo_runner.relocate(&mut vm) == Ok(()), "Execution failed");
 
     let python_vm_relocated_trace: Vec<RelocatedTraceEntry> = vec![
         RelocatedTraceEntry {

--- a/tests/struct_test.rs
+++ b/tests/struct_test.rs
@@ -1,4 +1,8 @@
-use cairo_rs::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor;
+use cairo_rs::{
+    hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor,
+    vm::vm_core::VirtualMachine,
+};
+use num_bigint::{BigInt, Sign};
 use std::path::Path;
 
 use cairo_rs::{
@@ -11,13 +15,24 @@ fn struct_integration_test() {
     let program = Program::new(Path::new("cairo_programs/struct.json"), "main")
         .expect("Failed to deserialize program");
     let hint_processor = BuiltinHintProcessor::new_empty();
-    let mut cairo_runner = CairoRunner::new(&program, true, &hint_processor).unwrap();
-    cairo_runner.initialize_segments(None);
-    let end = cairo_runner.initialize_main_entrypoint().unwrap();
+    let mut cairo_runner = CairoRunner::new(&program, &hint_processor).unwrap();
+    let mut vm = VirtualMachine::new(
+        BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+        true,
+    );
+    cairo_runner.initialize_builtins(&mut vm).unwrap();
+    cairo_runner.initialize_segments(&mut vm, None);
+    let end = cairo_runner.initialize_main_entrypoint(&mut vm).unwrap();
 
-    assert!(cairo_runner.initialize_vm() == Ok(()), "Execution failed");
-    assert!(cairo_runner.run_until_pc(end) == Ok(()), "Execution failed");
-    assert!(cairo_runner.relocate() == Ok(()), "Execution failed");
+    assert!(
+        cairo_runner.initialize_vm(&mut vm) == Ok(()),
+        "Execution failed"
+    );
+    assert!(
+        cairo_runner.run_until_pc(end, &mut vm) == Ok(()),
+        "Execution failed"
+    );
+    assert!(cairo_runner.relocate(&mut vm) == Ok(()), "Execution failed");
     let relocated_entry = RelocatedTraceEntry {
         pc: 1,
         ap: 4,


### PR DESCRIPTION
- Remove VM from CairoRunner
- Now all CairoRunner methods receive a mutable reference to VM
- Add method `initialize_builtins` in order to remove the creation of builtin runners from CairoRunner::new()
- VirtualMachine::new() now creates an empty builtin runner vac
- Move write_output call to cairo_run (and therefore now cairo_run also receives the print_output boolean argument)
- Fix tests