### PR TITLE
[Remove VMProxy -2] get_ap() & get_fp() 

### DIFF
--- a/src/hint_processor/proxies/vm_proxy.rs
+++ b/src/hint_processor/proxies/vm_proxy.rs
@@ -34,4 +34,12 @@ impl VMProxy<'_> {
     pub fn add_memory_segment(&mut self) -> Relocatable {
         self.memory.add_segment(self.segments)
     }
+
+    pub fn get_ap(&self) -> Relocatable {
+        self.run_context.get_ap()
+    }
+
+    pub fn get_fp(&self) -> Relocatable {
+        self.run_context.get_fp()
+    }
 }

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -630,6 +630,14 @@ impl VirtualMachine {
     pub fn add_memory_segment(&mut self) -> Relocatable {
         self.segments.add(&mut self.memory)
     }
+
+    pub fn get_ap(&self) -> Relocatable {
+        self.run_context.get_ap()
+    }
+
+    pub fn get_fp(&self) -> Relocatable {
+        self.run_context.get_fp()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# [Remove VMProxy -2] get_ap() & get_fp() 

## Description
Add methods to VirtualMachine and VMProxy:
* get_ap()
* get_fp()

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
