### PR TITLE
[Remove VMProxy -3] get_prime()

### DIFF
--- a/src/hint_processor/proxies/vm_proxy.rs
+++ b/src/hint_processor/proxies/vm_proxy.rs
@@ -42,4 +42,8 @@ impl VMProxy<'_> {
     pub fn get_fp(&self) -> Relocatable {
         self.run_context.get_fp()
     }
+
+    pub fn get_prime(&self) -> &BigInt {
+        self.prime
+    }
 }

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -638,6 +638,10 @@ impl VirtualMachine {
     pub fn get_fp(&self) -> Relocatable {
         self.run_context.get_fp()
     }
+
+    pub fn get_prime(&self) -> &BigInt {
+        &self.prime
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# [Remove VMProxy -3] get_prime()

## Description
Add method to VirtualMachine and VMProxy:
* get_prime()

Use the `vm_proxy.get_prime()` method in `src/hint_processor/builtin_hint_processor/math_utils.rs`


Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
