### PR TITLE
[Remove VMProxy - 4] get_integer()

### DIFF
--- a/src/hint_processor/builtin_hint_processor/blake2s_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/blake2s_utils.rs
@@ -152,8 +152,8 @@ pub fn blake2s_add_uint256(
     let data_ptr = get_ptr_from_var_name("data", vm_proxy, ids_data, ap_tracking)?;
     let low_addr = get_relocatable_from_var_name("low", vm_proxy, ids_data, ap_tracking)?;
     let high_addr = get_relocatable_from_var_name("high", vm_proxy, ids_data, ap_tracking)?;
-    let low = vm_proxy.memory.get_integer(&low_addr)?.clone();
-    let high = vm_proxy.memory.get_integer(&high_addr)?.clone();
+    let low = vm_proxy.get_integer(&low_addr)?.clone();
+    let high = vm_proxy.get_integer(&high_addr)?.clone();
     //Main logic
     //Declare constant
     const MASK: u32 = u32::MAX;
@@ -208,8 +208,8 @@ pub fn blake2s_add_uint256_bigend(
     let data_ptr = get_ptr_from_var_name("data", vm_proxy, ids_data, ap_tracking)?;
     let low_addr = get_relocatable_from_var_name("low", vm_proxy, ids_data, ap_tracking)?;
     let high_addr = get_relocatable_from_var_name("high", vm_proxy, ids_data, ap_tracking)?;
-    let low = vm_proxy.memory.get_integer(&low_addr)?.clone();
-    let high = vm_proxy.memory.get_integer(&high_addr)?.clone();
+    let low = vm_proxy.get_integer(&low_addr)?.clone();
+    let high = vm_proxy.get_integer(&high_addr)?.clone();
     //Main logic
     //Declare constant
     const MASK: u32 = u32::MAX as u32;

--- a/src/hint_processor/builtin_hint_processor/find_element_hint.rs
+++ b/src/hint_processor/builtin_hint_processor/find_element_hint.rs
@@ -132,7 +132,7 @@ pub fn search_sorted_lower(
         .ok_or(VirtualMachineError::KeyNotFound)?;
 
     for i in 0..n_elms_usize {
-        let value = vm_proxy.memory.get_integer(&array_iter)?;
+        let value = vm_proxy.get_integer(&array_iter)?;
         if value >= key {
             return insert_value_from_var_name(
                 "index",

--- a/src/hint_processor/builtin_hint_processor/hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/hint_utils.rs
@@ -96,8 +96,6 @@ pub fn get_integer_from_var_name<'a>(
     ids_data: &'a HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<&'a BigInt, VirtualMachineError> {
-    // let relocatable = get_relocatable_from_var_name(var_name, vm_proxy, ids_data, ap_tracking)?;
-    // vm_proxy.get_integer(&relocatable)
     let reference = get_reference_from_var_name(var_name, ids_data)?;
     get_integer_from_reference(vm_proxy, reference, ap_tracking)
 }

--- a/src/hint_processor/builtin_hint_processor/hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/hint_utils.rs
@@ -97,7 +97,7 @@ pub fn get_integer_from_var_name<'a>(
     ap_tracking: &ApTracking,
 ) -> Result<&'a BigInt, VirtualMachineError> {
     // let relocatable = get_relocatable_from_var_name(var_name, vm_proxy, ids_data, ap_tracking)?;
-    // vm_proxy.memory.get_integer(&relocatable)
+    // vm_proxy.get_integer(&relocatable)
     let reference = get_reference_from_var_name(var_name, ids_data)?;
     get_integer_from_reference(vm_proxy, reference, ap_tracking)
 }

--- a/src/hint_processor/builtin_hint_processor/keccak_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/keccak_utils.rs
@@ -74,7 +74,7 @@ pub fn unsafe_keccak(
             offset: data.offset + word_i,
         };
 
-        let word = vm_proxy.memory.get_integer(&word_addr)?;
+        let word = vm_proxy.get_integer(&word_addr)?;
         let n_bytes = cmp::min(16, u64_length - byte_i);
 
         if word.is_negative() || word >= &bigint!(1).shl(8 * (n_bytes as u32)) {

--- a/src/hint_processor/builtin_hint_processor/pow_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/pow_utils.rs
@@ -21,7 +21,7 @@ pub fn pow(
 ) -> Result<(), VirtualMachineError> {
     let prev_locs_addr =
         get_relocatable_from_var_name("prev_locs", vm_proxy, ids_data, ap_tracking)?;
-    let prev_locs_exp = vm_proxy.memory.get_integer(&(&prev_locs_addr + 4))?;
+    let prev_locs_exp = vm_proxy.get_integer(&(&prev_locs_addr + 4))?;
     let locs_bit = prev_locs_exp.mod_floor(vm_proxy.prime) & bigint!(1);
     insert_value_from_var_name("locs", locs_bit, vm_proxy, ids_data, ap_tracking)?;
     Ok(())

--- a/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
@@ -45,8 +45,8 @@ pub fn bigint_to_uint256(
     ap_tracking: &ApTracking,
 ) -> Result<(), VirtualMachineError> {
     let x_struct = get_relocatable_from_var_name("x", vm_proxy, ids_data, ap_tracking)?;
-    let d0 = vm_proxy.memory.get_integer(&x_struct)?;
-    let d1 = vm_proxy.memory.get_integer(&(&x_struct + 1))?;
+    let d0 = vm_proxy.get_integer(&x_struct)?;
+    let d1 = vm_proxy.get_integer(&(&x_struct + 1))?;
     let low = (d0 + d1 * &*BASE_86) & bigint!(u128::MAX);
     insert_value_from_var_name("low", low, vm_proxy, ids_data, ap_tracking)
 }

--- a/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
@@ -62,12 +62,12 @@ pub fn compute_doubling_slope(
     let point_reloc = get_relocatable_from_var_name("point", vm_proxy, ids_data, ap_tracking)?;
 
     let (x_d0, x_d1, x_d2, y_d0, y_d1, y_d2) = (
-        vm_proxy.memory.get_integer(&point_reloc)?,
-        vm_proxy.memory.get_integer(&(&point_reloc + 1))?,
-        vm_proxy.memory.get_integer(&(&point_reloc + 2))?,
-        vm_proxy.memory.get_integer(&(&point_reloc + 3))?,
-        vm_proxy.memory.get_integer(&(&point_reloc + 4))?,
-        vm_proxy.memory.get_integer(&(&point_reloc + 5))?,
+        vm_proxy.get_integer(&point_reloc)?,
+        vm_proxy.get_integer(&(&point_reloc + 1))?,
+        vm_proxy.get_integer(&(&point_reloc + 2))?,
+        vm_proxy.get_integer(&(&point_reloc + 3))?,
+        vm_proxy.get_integer(&(&point_reloc + 4))?,
+        vm_proxy.get_integer(&(&point_reloc + 5))?,
     );
 
     let value = ec_double_slope(
@@ -107,24 +107,24 @@ pub fn compute_slope(
     let point0_reloc = get_relocatable_from_var_name("point0", vm_proxy, ids_data, ap_tracking)?;
 
     let (point0_x_d0, point0_x_d1, point0_x_d2, point0_y_d0, point0_y_d1, point0_y_d2) = (
-        vm_proxy.memory.get_integer(&point0_reloc)?,
-        vm_proxy.memory.get_integer(&(&point0_reloc + 1))?,
-        vm_proxy.memory.get_integer(&(&point0_reloc + 2))?,
-        vm_proxy.memory.get_integer(&(&point0_reloc + 3))?,
-        vm_proxy.memory.get_integer(&(&point0_reloc + 4))?,
-        vm_proxy.memory.get_integer(&(&point0_reloc + 5))?,
+        vm_proxy.get_integer(&point0_reloc)?,
+        vm_proxy.get_integer(&(&point0_reloc + 1))?,
+        vm_proxy.get_integer(&(&point0_reloc + 2))?,
+        vm_proxy.get_integer(&(&point0_reloc + 3))?,
+        vm_proxy.get_integer(&(&point0_reloc + 4))?,
+        vm_proxy.get_integer(&(&point0_reloc + 5))?,
     );
 
     //ids.point1
     let point1_reloc = get_relocatable_from_var_name("point1", vm_proxy, ids_data, ap_tracking)?;
 
     let (point1_x_d0, point1_x_d1, point1_x_d2, point1_y_d0, point1_y_d1, point1_y_d2) = (
-        vm_proxy.memory.get_integer(&point1_reloc)?,
-        vm_proxy.memory.get_integer(&(&point1_reloc + 1))?,
-        vm_proxy.memory.get_integer(&(&point1_reloc + 2))?,
-        vm_proxy.memory.get_integer(&(&point1_reloc + 3))?,
-        vm_proxy.memory.get_integer(&(&point1_reloc + 4))?,
-        vm_proxy.memory.get_integer(&(&point1_reloc + 5))?,
+        vm_proxy.get_integer(&point1_reloc)?,
+        vm_proxy.get_integer(&(&point1_reloc + 1))?,
+        vm_proxy.get_integer(&(&point1_reloc + 2))?,
+        vm_proxy.get_integer(&(&point1_reloc + 3))?,
+        vm_proxy.get_integer(&(&point1_reloc + 4))?,
+        vm_proxy.get_integer(&(&point1_reloc + 5))?,
     );
 
     let value = line_slope(
@@ -165,21 +165,21 @@ pub fn ec_double_assign_new_x(
     let slope_reloc = get_relocatable_from_var_name("slope", vm_proxy, ids_data, ap_tracking)?;
 
     let (slope_d0, slope_d1, slope_d2) = (
-        vm_proxy.memory.get_integer(&slope_reloc)?,
-        vm_proxy.memory.get_integer(&(&slope_reloc + 1))?,
-        vm_proxy.memory.get_integer(&(&slope_reloc + 2))?,
+        vm_proxy.get_integer(&slope_reloc)?,
+        vm_proxy.get_integer(&(&slope_reloc + 1))?,
+        vm_proxy.get_integer(&(&slope_reloc + 2))?,
     );
 
     //ids.point
     let point_reloc = get_relocatable_from_var_name("point", vm_proxy, ids_data, ap_tracking)?;
 
     let (x_d0, x_d1, x_d2, y_d0, y_d1, y_d2) = (
-        vm_proxy.memory.get_integer(&point_reloc)?,
-        vm_proxy.memory.get_integer(&(&point_reloc + 1))?,
-        vm_proxy.memory.get_integer(&(&point_reloc + 2))?,
-        vm_proxy.memory.get_integer(&(&point_reloc + 3))?,
-        vm_proxy.memory.get_integer(&(&point_reloc + 4))?,
-        vm_proxy.memory.get_integer(&(&point_reloc + 5))?,
+        vm_proxy.get_integer(&point_reloc)?,
+        vm_proxy.get_integer(&(&point_reloc + 1))?,
+        vm_proxy.get_integer(&(&point_reloc + 2))?,
+        vm_proxy.get_integer(&(&point_reloc + 3))?,
+        vm_proxy.get_integer(&(&point_reloc + 4))?,
+        vm_proxy.get_integer(&(&point_reloc + 5))?,
     );
 
     let slope = pack(slope_d0, slope_d1, slope_d2, vm_proxy.prime);
@@ -241,30 +241,30 @@ pub fn fast_ec_add_assign_new_x(
     let slope_reloc = get_relocatable_from_var_name("slope", vm_proxy, ids_data, ap_tracking)?;
 
     let (slope_d0, slope_d1, slope_d2) = (
-        vm_proxy.memory.get_integer(&slope_reloc)?,
-        vm_proxy.memory.get_integer(&(&slope_reloc + 1))?,
-        vm_proxy.memory.get_integer(&(&slope_reloc + 2))?,
+        vm_proxy.get_integer(&slope_reloc)?,
+        vm_proxy.get_integer(&(&slope_reloc + 1))?,
+        vm_proxy.get_integer(&(&slope_reloc + 2))?,
     );
 
     //ids.point0
     let point0_reloc = get_relocatable_from_var_name("point0", vm_proxy, ids_data, ap_tracking)?;
 
     let (point0_x_d0, point0_x_d1, point0_x_d2, point0_y_d0, point0_y_d1, point0_y_d2) = (
-        vm_proxy.memory.get_integer(&point0_reloc)?,
-        vm_proxy.memory.get_integer(&(&point0_reloc + 1))?,
-        vm_proxy.memory.get_integer(&(&point0_reloc + 2))?,
-        vm_proxy.memory.get_integer(&(&point0_reloc + 3))?,
-        vm_proxy.memory.get_integer(&(&point0_reloc + 4))?,
-        vm_proxy.memory.get_integer(&(&point0_reloc + 5))?,
+        vm_proxy.get_integer(&point0_reloc)?,
+        vm_proxy.get_integer(&(&point0_reloc + 1))?,
+        vm_proxy.get_integer(&(&point0_reloc + 2))?,
+        vm_proxy.get_integer(&(&point0_reloc + 3))?,
+        vm_proxy.get_integer(&(&point0_reloc + 4))?,
+        vm_proxy.get_integer(&(&point0_reloc + 5))?,
     );
 
     //ids.point1.x
     let point1_reloc = get_relocatable_from_var_name("point1", vm_proxy, ids_data, ap_tracking)?;
 
     let (point1_x_d0, point1_x_d1, point1_x_d2) = (
-        vm_proxy.memory.get_integer(&point1_reloc)?,
-        vm_proxy.memory.get_integer(&(&point1_reloc + 1))?,
-        vm_proxy.memory.get_integer(&(&point1_reloc + 2))?,
+        vm_proxy.get_integer(&point1_reloc)?,
+        vm_proxy.get_integer(&(&point1_reloc + 1))?,
+        vm_proxy.get_integer(&(&point1_reloc + 2))?,
     );
 
     let slope = pack(slope_d0, slope_d1, slope_d2, vm_proxy.prime);

--- a/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
@@ -74,9 +74,9 @@ pub fn pack_from_var_name(
 ) -> Result<BigInt, VirtualMachineError> {
     let to_pack = get_relocatable_from_var_name(name, vm_proxy, ids_data, ap_tracking)?;
 
-    let d0 = vm_proxy.memory.get_integer(&to_pack)?;
-    let d1 = vm_proxy.memory.get_integer(&(&to_pack + 1))?;
-    let d2 = vm_proxy.memory.get_integer(&(&to_pack + 2))?;
+    let d0 = vm_proxy.get_integer(&to_pack)?;
+    let d1 = vm_proxy.get_integer(&(&to_pack + 1))?;
+    let d2 = vm_proxy.get_integer(&(&to_pack + 2))?;
 
     Ok(pack(d0, d1, d2, vm_proxy.prime))
 }
@@ -85,9 +85,9 @@ pub fn pack_from_relocatable(
     rel: Relocatable,
     vm_proxy: &VMProxy,
 ) -> Result<BigInt, VirtualMachineError> {
-    let d0 = vm_proxy.memory.get_integer(&rel)?;
-    let d1 = vm_proxy.memory.get_integer(&(&rel + 1))?;
-    let d2 = vm_proxy.memory.get_integer(&(&rel + 2))?;
+    let d0 = vm_proxy.get_integer(&rel)?;
+    let d1 = vm_proxy.get_integer(&(&rel + 1))?;
+    let d2 = vm_proxy.get_integer(&(&rel + 2))?;
 
     Ok(pack(d0, d1, d2, vm_proxy.prime))
 }

--- a/src/hint_processor/builtin_hint_processor/sha256_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/sha256_utils.rs
@@ -52,7 +52,7 @@ pub fn sha256_main(
     let mut message: Vec<u8> = Vec::with_capacity(4 * SHA256_INPUT_CHUNK_SIZE_FELTS);
 
     for i in 0..SHA256_INPUT_CHUNK_SIZE_FELTS {
-        let input_element = vm_proxy.memory.get_integer(&(&input_ptr + i))?;
+        let input_element = vm_proxy.get_integer(&(&input_ptr + i))?;
         let bytes = bigint_to_u32(input_element)?.to_be_bytes();
         message.extend(bytes);
     }

--- a/src/hint_processor/builtin_hint_processor/uint256_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/uint256_utils.rs
@@ -35,10 +35,10 @@ pub fn uint256_add(
 
     let a_relocatable = get_relocatable_from_var_name("a", vm_proxy, ids_data, ap_tracking)?;
     let b_relocatable = get_relocatable_from_var_name("b", vm_proxy, ids_data, ap_tracking)?;
-    let a_low = vm_proxy.memory.get_integer(&a_relocatable)?;
-    let a_high = vm_proxy.memory.get_integer(&(a_relocatable + 1))?;
-    let b_low = vm_proxy.memory.get_integer(&b_relocatable)?;
-    let b_high = vm_proxy.memory.get_integer(&(b_relocatable + 1))?;
+    let a_low = vm_proxy.get_integer(&a_relocatable)?;
+    let a_high = vm_proxy.get_integer(&(a_relocatable + 1))?;
+    let b_low = vm_proxy.get_integer(&b_relocatable)?;
+    let b_high = vm_proxy.get_integer(&(b_relocatable + 1))?;
 
     //Main logic
     //sum_low = ids.a.low + ids.b.low
@@ -103,8 +103,8 @@ pub fn uint256_sqrt(
 ) -> Result<(), VirtualMachineError> {
     let n_addr = get_relocatable_from_var_name("n", vm_proxy, ids_data, ap_tracking)?;
     let root_addr = get_relocatable_from_var_name("root", vm_proxy, ids_data, ap_tracking)?;
-    let n_low = vm_proxy.memory.get_integer(&n_addr)?;
-    let n_high = vm_proxy.memory.get_integer(&(n_addr + 1))?;
+    let n_low = vm_proxy.get_integer(&n_addr)?;
+    let n_high = vm_proxy.get_integer(&(n_addr + 1))?;
 
     //Main logic
     //from starkware.python.math_utils import isqrt
@@ -136,7 +136,7 @@ pub fn uint256_signed_nn(
     ap_tracking: &ApTracking,
 ) -> Result<(), VirtualMachineError> {
     let a_addr = get_relocatable_from_var_name("a", vm_proxy, ids_data, ap_tracking)?;
-    let a_high = vm_proxy.memory.get_integer(&(a_addr + 1))?;
+    let a_high = vm_proxy.get_integer(&(a_addr + 1))?;
     //Main logic
     //memory[ap] = 1 if 0 <= (ids.a.high % PRIME) < 2 ** 127 else 0
     let result: BigInt =
@@ -172,10 +172,10 @@ pub fn uint256_unsigned_div_rem(
     let remainder_addr =
         get_relocatable_from_var_name("remainder", vm_proxy, ids_data, ap_tracking)?;
 
-    let a_low = vm_proxy.memory.get_integer(&a_addr)?;
-    let a_high = vm_proxy.memory.get_integer(&(a_addr + 1))?;
-    let div_low = vm_proxy.memory.get_integer(&div_addr)?;
-    let div_high = vm_proxy.memory.get_integer(&(div_addr + 1))?;
+    let a_low = vm_proxy.get_integer(&a_addr)?;
+    let a_high = vm_proxy.get_integer(&(a_addr + 1))?;
+    let div_low = vm_proxy.get_integer(&div_addr)?;
+    let div_high = vm_proxy.get_integer(&(div_addr + 1))?;
 
     //Main logic
     //a = (ids.a.high << 128) + ids.a.low

--- a/src/hint_processor/builtin_hint_processor/usort.rs
+++ b/src/hint_processor/builtin_hint_processor/usort.rs
@@ -51,7 +51,7 @@ pub fn usort_body(
     let mut positions_dict: HashMap<BigInt, Vec<u64>> = HashMap::new();
     let mut output: Vec<BigInt> = Vec::new();
     for i in 0..input_len_u64 {
-        let val = vm_proxy.memory.get_integer(&(&input_ptr + i as usize))?;
+        let val = vm_proxy.get_integer(&(&input_ptr + i as usize))?;
         if let Err(output_index) = output.binary_search(val) {
             output.insert(output_index, val.clone());
         }

--- a/src/hint_processor/hint_processor_utils.rs
+++ b/src/hint_processor/hint_processor_utils.rs
@@ -40,7 +40,7 @@ pub fn get_integer_from_reference<'a>(
     }
 
     let var_addr = compute_addr_from_reference(hint_reference, vm_proxy, ap_tracking)?;
-    vm_proxy.memory.get_integer(&var_addr)
+    vm_proxy.get_integer(&var_addr)
 }
 
 ///Returns the Relocatable value stored in the given ids variable

--- a/src/hint_processor/proxies/vm_proxy.rs
+++ b/src/hint_processor/proxies/vm_proxy.rs
@@ -3,8 +3,9 @@ use num_bigint::BigInt;
 use crate::{
     types::relocatable::Relocatable,
     vm::{
-        context::run_context::RunContext, runners::builtin_runner::BuiltinRunner,
-        vm_core::VirtualMachine, vm_memory::memory_segments::MemorySegmentManager,
+        context::run_context::RunContext, errors::vm_errors::VirtualMachineError,
+        runners::builtin_runner::BuiltinRunner, vm_core::VirtualMachine,
+        vm_memory::memory_segments::MemorySegmentManager,
     },
 };
 
@@ -31,6 +32,7 @@ pub fn get_vm_proxy(vm: &mut VirtualMachine) -> VMProxy {
 }
 
 impl VMProxy<'_> {
+    ///Adds a new segment and to the VM.memory returns its starting location as a RelocatableValue.
     pub fn add_memory_segment(&mut self) -> Relocatable {
         self.memory.add_segment(self.segments)
     }
@@ -45,5 +47,10 @@ impl VMProxy<'_> {
 
     pub fn get_prime(&self) -> &BigInt {
         self.prime
+    }
+
+    ///Gets the integer value corresponding to the Relocatable address
+    pub fn get_integer(&self, key: &Relocatable) -> Result<&BigInt, VirtualMachineError> {
+        self.memory.get_integer(key)
     }
 }

--- a/src/hint_processor/proxies/vm_proxy.rs
+++ b/src/hint_processor/proxies/vm_proxy.rs
@@ -32,7 +32,7 @@ pub fn get_vm_proxy(vm: &mut VirtualMachine) -> VMProxy {
 }
 
 impl VMProxy<'_> {
-    ///Adds a new segment and to the VM.memory returns its starting location as a RelocatableValue.
+    ///Adds a new segment and to the VMProxy.memory returns its starting location as a RelocatableValue.
     pub fn add_memory_segment(&mut self) -> Relocatable {
         self.memory.add_segment(self.segments)
     }

--- a/src/vm/hints/secp/ec_utils.rs
+++ b/src/vm/hints/secp/ec_utils.rs
@@ -59,12 +59,12 @@ pub fn compute_doubling_slope(
     let point_reloc = get_relocatable_from_var_name("point", ids, vm_proxy, hint_ap_tracking)?;
 
     let (x_d0, x_d1, x_d2, y_d0, y_d1, y_d2) = (
-        vm_proxy.memory.get_integer(&point_reloc)?,
-        vm_proxy.memory.get_integer(&(&point_reloc + 1))?,
-        vm_proxy.memory.get_integer(&(&point_reloc + 2))?,
-        vm_proxy.memory.get_integer(&(&point_reloc + 3))?,
-        vm_proxy.memory.get_integer(&(&point_reloc + 4))?,
-        vm_proxy.memory.get_integer(&(&point_reloc + 5))?,
+        vm_proxy.get_integer(&point_reloc)?,
+        vm_proxy.get_integer(&(&point_reloc + 1))?,
+        vm_proxy.get_integer(&(&point_reloc + 2))?,
+        vm_proxy.get_integer(&(&point_reloc + 3))?,
+        vm_proxy.get_integer(&(&point_reloc + 4))?,
+        vm_proxy.get_integer(&(&point_reloc + 5))?,
     );
 
     let value = ec_double_slope(
@@ -104,24 +104,24 @@ pub fn compute_slope(
     let point0_reloc = get_relocatable_from_var_name("point0", ids, vm_proxy, hint_ap_tracking)?;
 
     let (point0_x_d0, point0_x_d1, point0_x_d2, point0_y_d0, point0_y_d1, point0_y_d2) = (
-        vm_proxy.memory.get_integer(&point0_reloc)?,
-        vm_proxy.memory.get_integer(&(&point0_reloc + 1))?,
-        vm_proxy.memory.get_integer(&(&point0_reloc + 2))?,
-        vm_proxy.memory.get_integer(&(&point0_reloc + 3))?,
-        vm_proxy.memory.get_integer(&(&point0_reloc + 4))?,
-        vm_proxy.memory.get_integer(&(&point0_reloc + 5))?,
+        vm_proxy.get_integer(&point0_reloc)?,
+        vm_proxy.get_integer(&(&point0_reloc + 1))?,
+        vm_proxy.get_integer(&(&point0_reloc + 2))?,
+        vm_proxy.get_integer(&(&point0_reloc + 3))?,
+        vm_proxy.get_integer(&(&point0_reloc + 4))?,
+        vm_proxy.get_integer(&(&point0_reloc + 5))?,
     );
 
     //ids.point1
     let point1_reloc = get_relocatable_from_var_name("point1", ids, vm_proxy, hint_ap_tracking)?;
 
     let (point1_x_d0, point1_x_d1, point1_x_d2, point1_y_d0, point1_y_d1, point1_y_d2) = (
-        vm_proxy.memory.get_integer(&point1_reloc)?,
-        vm_proxy.memory.get_integer(&(&point1_reloc + 1))?,
-        vm_proxy.memory.get_integer(&(&point1_reloc + 2))?,
-        vm_proxy.memory.get_integer(&(&point1_reloc + 3))?,
-        vm_proxy.memory.get_integer(&(&point1_reloc + 4))?,
-        vm_proxy.memory.get_integer(&(&point1_reloc + 5))?,
+        vm_proxy.get_integer(&point1_reloc)?,
+        vm_proxy.get_integer(&(&point1_reloc + 1))?,
+        vm_proxy.get_integer(&(&point1_reloc + 2))?,
+        vm_proxy.get_integer(&(&point1_reloc + 3))?,
+        vm_proxy.get_integer(&(&point1_reloc + 4))?,
+        vm_proxy.get_integer(&(&point1_reloc + 5))?,
     );
 
     let value = line_slope(
@@ -162,21 +162,21 @@ pub fn ec_double_assign_new_x(
     let slope_reloc = get_relocatable_from_var_name("slope", ids, vm_proxy, hint_ap_tracking)?;
 
     let (slope_d0, slope_d1, slope_d2) = (
-        vm_proxy.memory.get_integer(&slope_reloc)?,
-        vm_proxy.memory.get_integer(&(&slope_reloc + 1))?,
-        vm_proxy.memory.get_integer(&(&slope_reloc + 2))?,
+        vm_proxy.get_integer(&slope_reloc)?,
+        vm_proxy.get_integer(&(&slope_reloc + 1))?,
+        vm_proxy.get_integer(&(&slope_reloc + 2))?,
     );
 
     //ids.point
     let point_reloc = get_relocatable_from_var_name("point", ids, vm_proxy, hint_ap_tracking)?;
 
     let (x_d0, x_d1, x_d2, y_d0, y_d1, y_d2) = (
-        vm_proxy.memory.get_integer(&point_reloc)?,
-        vm_proxy.memory.get_integer(&(&point_reloc + 1))?,
-        vm_proxy.memory.get_integer(&(&point_reloc + 2))?,
-        vm_proxy.memory.get_integer(&(&point_reloc + 3))?,
-        vm_proxy.memory.get_integer(&(&point_reloc + 4))?,
-        vm_proxy.memory.get_integer(&(&point_reloc + 5))?,
+        vm_proxy.get_integer(&point_reloc)?,
+        vm_proxy.get_integer(&(&point_reloc + 1))?,
+        vm_proxy.get_integer(&(&point_reloc + 2))?,
+        vm_proxy.get_integer(&(&point_reloc + 3))?,
+        vm_proxy.get_integer(&(&point_reloc + 4))?,
+        vm_proxy.get_integer(&(&point_reloc + 5))?,
     );
 
     let slope = pack(slope_d0, slope_d1, slope_d2, vm_proxy.prime);
@@ -238,30 +238,30 @@ pub fn fast_ec_add_assign_new_x(
     let slope_reloc = get_relocatable_from_var_name("slope", ids, vm_proxy, hint_ap_tracking)?;
 
     let (slope_d0, slope_d1, slope_d2) = (
-        vm_proxy.memory.get_integer(&slope_reloc)?,
-        vm_proxy.memory.get_integer(&(&slope_reloc + 1))?,
-        vm_proxy.memory.get_integer(&(&slope_reloc + 2))?,
+        vm_proxy.get_integer(&slope_reloc)?,
+        vm_proxy.get_integer(&(&slope_reloc + 1))?,
+        vm_proxy.get_integer(&(&slope_reloc + 2))?,
     );
 
     //ids.point0
     let point0_reloc = get_relocatable_from_var_name("point0", ids, vm_proxy, hint_ap_tracking)?;
 
     let (point0_x_d0, point0_x_d1, point0_x_d2, point0_y_d0, point0_y_d1, point0_y_d2) = (
-        vm_proxy.memory.get_integer(&point0_reloc)?,
-        vm_proxy.memory.get_integer(&(&point0_reloc + 1))?,
-        vm_proxy.memory.get_integer(&(&point0_reloc + 2))?,
-        vm_proxy.memory.get_integer(&(&point0_reloc + 3))?,
-        vm_proxy.memory.get_integer(&(&point0_reloc + 4))?,
-        vm_proxy.memory.get_integer(&(&point0_reloc + 5))?,
+        vm_proxy.get_integer(&point0_reloc)?,
+        vm_proxy.get_integer(&(&point0_reloc + 1))?,
+        vm_proxy.get_integer(&(&point0_reloc + 2))?,
+        vm_proxy.get_integer(&(&point0_reloc + 3))?,
+        vm_proxy.get_integer(&(&point0_reloc + 4))?,
+        vm_proxy.get_integer(&(&point0_reloc + 5))?,
     );
 
     //ids.point1.x
     let point1_reloc = get_relocatable_from_var_name("point1", ids, vm_proxy, hint_ap_tracking)?;
 
     let (point1_x_d0, point1_x_d1, point1_x_d2) = (
-        vm_proxy.memory.get_integer(&point1_reloc)?,
-        vm_proxy.memory.get_integer(&(&point1_reloc + 1))?,
-        vm_proxy.memory.get_integer(&(&point1_reloc + 2))?,
+        vm_proxy.get_integer(&point1_reloc)?,
+        vm_proxy.get_integer(&(&point1_reloc + 1))?,
+        vm_proxy.get_integer(&(&point1_reloc + 2))?,
     );
 
     let slope = pack(slope_d0, slope_d1, slope_d2, vm_proxy.prime);

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -636,7 +636,7 @@ impl VirtualMachine {
         }
         Ok(())
     }
-
+    ///Adds a new segment and to the VirtualMachine.memory returns its starting location as a RelocatableValue.
     pub fn add_memory_segment(&mut self) -> Relocatable {
         self.segments.add(&mut self.memory)
     }
@@ -651,6 +651,11 @@ impl VirtualMachine {
 
     pub fn get_prime(&self) -> &BigInt {
         &self.prime
+    }
+
+    ///Gets the integer value corresponding to the Relocatable address
+    pub fn get_integer(&self, key: &Relocatable) -> Result<&BigInt, VirtualMachineError> {
+        self.memory.get_integer(key)
     }
 }
 


### PR DESCRIPTION
# [Remove VMProxy - 4] get_integer()

## Description
Add method to VirtualMachine and VMProxy:
* get_integer()

Replace `vm_proxy.memory.get_integer` with `vm_proxy.get_integer`

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
