### PR TITLE
[Remove VMProxy -5] insert_value & get_relocatable

### DIFF
--- a/src/hint_processor/builtin_hint_processor/find_element_hint.rs
+++ b/src/hint_processor/builtin_hint_processor/find_element_hint.rs
@@ -125,7 +125,7 @@ pub fn search_sorted_lower(
         }
     }
 
-    let mut array_iter = vm_proxy.memory.get_relocatable(&rel_array_ptr)?.clone();
+    let mut array_iter = vm_proxy.get_relocatable(&rel_array_ptr)?.clone();
     let n_elms_usize = n_elms.to_usize().ok_or(VirtualMachineError::KeyNotFound)?;
     let elm_size_usize = elm_size
         .to_usize()

--- a/src/hint_processor/builtin_hint_processor/hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/hint_utils.rs
@@ -43,7 +43,7 @@ pub fn get_ptr_from_var_name(
         .get(&String::from(var_name))
         .ok_or(VirtualMachineError::FailedToGetIds)?;
     if hint_reference.dereference {
-        let value = vm_proxy.memory.get_relocatable(&var_addr)?;
+        let value = vm_proxy.get_relocatable(&var_addr)?;
         if let Some(immediate) = &hint_reference.immediate {
             let modified_value = value + bigint_to_usize(immediate)?;
             Ok(modified_value)

--- a/src/hint_processor/builtin_hint_processor/hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/hint_utils.rs
@@ -19,7 +19,7 @@ pub fn insert_value_from_var_name(
     ap_tracking: &ApTracking,
 ) -> Result<(), VirtualMachineError> {
     let var_address = get_relocatable_from_var_name(var_name, vm_proxy, ids_data, ap_tracking)?;
-    vm_proxy.memory.insert_value(&var_address, value)
+    vm_proxy.insert_value(&var_address, value)
 }
 
 //Inserts value into ap

--- a/src/hint_processor/builtin_hint_processor/keccak_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/keccak_utils.rs
@@ -140,7 +140,7 @@ pub fn unsafe_keccak_finalize(
 
     // in the KeccakState struct, the field `end_ptr` is the second one, so this variable should be get from
     // the memory cell contiguous to the one where KeccakState is pointing to.
-    let end_ptr = vm_proxy.memory.get_relocatable(&Relocatable {
+    let end_ptr = vm_proxy.get_relocatable(&Relocatable {
         segment_index: keccak_state_ptr.segment_index,
         offset: keccak_state_ptr.offset + 1,
     })?;

--- a/src/hint_processor/builtin_hint_processor/keccak_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/keccak_utils.rs
@@ -98,8 +98,8 @@ pub fn unsafe_keccak(
     let high = BigInt::from_bytes_be(Sign::Plus, &hashed[..16]);
     let low = BigInt::from_bytes_be(Sign::Plus, &hashed[16..32]);
 
-    vm_proxy.memory.insert_value(&high_addr, &high)?;
-    vm_proxy.memory.insert_value(&low_addr, &low)
+    vm_proxy.insert_value(&high_addr, &high)?;
+    vm_proxy.insert_value(&low_addr, &low)
 }
 
 /*
@@ -189,8 +189,8 @@ pub fn unsafe_keccak_finalize(
     let high = BigInt::from_bytes_be(Sign::Plus, &hashed[..16]);
     let low = BigInt::from_bytes_be(Sign::Plus, &hashed[16..32]);
 
-    vm_proxy.memory.insert_value(&high_addr, &high)?;
-    vm_proxy.memory.insert_value(&low_addr, &low)
+    vm_proxy.insert_value(&high_addr, &high)?;
+    vm_proxy.insert_value(&low_addr, &low)
 }
 
 fn left_pad(bytes_vector: &mut [u8], n_zeros: usize) -> Vec<u8> {

--- a/src/hint_processor/builtin_hint_processor/math_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/math_utils.rs
@@ -224,7 +224,7 @@ pub fn split_int(
     if res > *bound {
         return Err(VirtualMachineError::SplitIntLimbOutOfRange(res));
     }
-    vm_proxy.memory.insert_value(&output, res)
+    vm_proxy.insert_value(&output, res)
 }
 
 //from starkware.cairo.common.math_utils import is_positive

--- a/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
@@ -64,7 +64,7 @@ pub fn squash_dict_inner_first_iteration(
     exec_scopes_proxy.insert_value("current_access_indices", current_access_indices);
     exec_scopes_proxy.insert_value("current_access_index", first_val.clone());
     //Insert current_accesss_index into range_check_ptr
-    vm_proxy.memory.insert_value(&range_check_ptr, first_val)
+    vm_proxy.insert_value(&range_check_ptr, first_val)
 }
 
 // Implements Hint: ids.should_skip_loop = 0 if current_access_indices else 1

--- a/src/hint_processor/builtin_hint_processor/uint256_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/uint256_utils.rs
@@ -122,8 +122,8 @@ pub fn uint256_sqrt(
             &root
         )));
     }
-    vm_proxy.memory.insert_value(&root_addr, root)?;
-    vm_proxy.memory.insert_value(&(root_addr + 1), bigint!(0))
+    vm_proxy.insert_value(&root_addr, root)?;
+    vm_proxy.insert_value(&(root_addr + 1), bigint!(0))
 }
 
 /*
@@ -200,7 +200,7 @@ pub fn uint256_unsigned_div_rem(
     let remainder_high = remainder.shr(128_usize);
 
     //Insert ids.quotient.low
-    vm_proxy.memory.insert_value(&quotient_addr, quotient_low)?;
+    vm_proxy.insert_value(&quotient_addr, quotient_low)?;
     //Insert ids.quotient.high
     vm_proxy
         .memory

--- a/src/hint_processor/hint_processor_utils.rs
+++ b/src/hint_processor/hint_processor_utils.rs
@@ -23,7 +23,7 @@ pub fn insert_value_from_reference(
     ap_tracking: &ApTracking,
 ) -> Result<(), VirtualMachineError> {
     let var_addr = compute_addr_from_reference(hint_reference, vm_proxy, ap_tracking)?;
-    vm_proxy.memory.insert_value(&var_addr, value)
+    vm_proxy.insert_value(&var_addr, value)
 }
 
 ///Returns the Integer value stored in the given ids variable

--- a/src/hint_processor/hint_processor_utils.rs
+++ b/src/hint_processor/hint_processor_utils.rs
@@ -52,7 +52,7 @@ pub fn get_ptr_from_reference(
     let var_addr = compute_addr_from_reference(hint_reference, vm_proxy, ap_tracking)?;
     //Add immediate if present in reference
     if hint_reference.dereference {
-        let value = vm_proxy.memory.get_relocatable(&var_addr)?;
+        let value = vm_proxy.get_relocatable(&var_addr)?;
         if let Some(immediate) = &hint_reference.immediate {
             let modified_value = value + bigint_to_usize(immediate)?;
             Ok(modified_value)

--- a/src/hint_processor/proxies/vm_proxy.rs
+++ b/src/hint_processor/proxies/vm_proxy.rs
@@ -54,6 +54,11 @@ impl VMProxy<'_> {
         self.memory.get_integer(key)
     }
 
+    ///Gets the relocatable value corresponding to the Relocatable address
+    pub fn get_relocatable(&self, key: &Relocatable) -> Result<&Relocatable, VirtualMachineError> {
+        self.memory.get_relocatable(key)
+    }
+
     ///Inserts a value into a memory address given by a Relocatable value
     pub fn insert_value<T: Into<MaybeRelocatable>>(
         &mut self,

--- a/src/hint_processor/proxies/vm_proxy.rs
+++ b/src/hint_processor/proxies/vm_proxy.rs
@@ -1,7 +1,7 @@
 use num_bigint::BigInt;
 
 use crate::{
-    types::relocatable::Relocatable,
+    types::relocatable::{MaybeRelocatable, Relocatable},
     vm::{
         context::run_context::RunContext, errors::vm_errors::VirtualMachineError,
         runners::builtin_runner::BuiltinRunner, vm_core::VirtualMachine,
@@ -52,5 +52,14 @@ impl VMProxy<'_> {
     ///Gets the integer value corresponding to the Relocatable address
     pub fn get_integer(&self, key: &Relocatable) -> Result<&BigInt, VirtualMachineError> {
         self.memory.get_integer(key)
+    }
+
+    ///Inserts a value into a memory address given by a Relocatable value
+    pub fn insert_value<T: Into<MaybeRelocatable>>(
+        &mut self,
+        key: &Relocatable,
+        val: T,
+    ) -> Result<(), VirtualMachineError> {
+        self.memory.insert_value(key, val)
     }
 }

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -658,6 +658,11 @@ impl VirtualMachine {
         self.memory.get_integer(key)
     }
 
+    ///Gets the relocatable value corresponding to the Relocatable address
+    pub fn get_relocatable(&self, key: &Relocatable) -> Result<&Relocatable, VirtualMachineError> {
+        self.memory.get_relocatable(key)
+    }
+
     ///Inserts a value into a memory address given by a Relocatable value
     pub fn insert_value<T: Into<MaybeRelocatable>>(
         &mut self,

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -657,6 +657,15 @@ impl VirtualMachine {
     pub fn get_integer(&self, key: &Relocatable) -> Result<&BigInt, VirtualMachineError> {
         self.memory.get_integer(key)
     }
+
+    ///Inserts a value into a memory address given by a Relocatable value
+    pub fn insert_value<T: Into<MaybeRelocatable>>(
+        &mut self,
+        key: &Relocatable,
+        val: T,
+    ) -> Result<(), VirtualMachineError> {
+        self.memory.insert_value(key, val)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# [Remove VMProxy -5] insert_value & get_relocatable

## Description
Add methods to VirtualMachine and VMProxy:
* insert_value(
* get_relocatable(

Replace `vm_proxy.memory.insert_value` with `vm_proxy.insert_value`

Replace `vm_proxy.memory.get_relocatable` with `vm_proxy.get_relocatable`

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
