### PR TITLE
[Remove VMProxy -6] get_maybe

### DIFF
--- a/src/hint_processor/builtin_hint_processor/math_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/math_utils.rs
@@ -120,7 +120,7 @@ pub fn assert_not_equal(
     let a_addr = get_address_from_var_name("a", vm_proxy, ids_data, ap_tracking)?;
     let b_addr = get_address_from_var_name("b", vm_proxy, ids_data, ap_tracking)?;
     //Check that the ids are in memory
-    match (vm_proxy.memory.get(&a_addr), vm_proxy.memory.get(&b_addr)) {
+    match (vm_proxy.get_maybe(&a_addr), vm_proxy.get_maybe(&b_addr)) {
         (Ok(Some(maybe_rel_a)), Ok(Some(maybe_rel_b))) => match (maybe_rel_a, maybe_rel_b) {
             (MaybeRelocatable::Int(ref a), MaybeRelocatable::Int(ref b)) => {
                 if (a - b).is_multiple_of(vm_proxy.get_prime()) {

--- a/src/hint_processor/proxies/vm_proxy.rs
+++ b/src/hint_processor/proxies/vm_proxy.rs
@@ -3,8 +3,10 @@ use num_bigint::BigInt;
 use crate::{
     types::relocatable::{MaybeRelocatable, Relocatable},
     vm::{
-        context::run_context::RunContext, errors::vm_errors::VirtualMachineError,
-        runners::builtin_runner::BuiltinRunner, vm_core::VirtualMachine,
+        context::run_context::RunContext,
+        errors::{memory_errors::MemoryError, vm_errors::VirtualMachineError},
+        runners::builtin_runner::BuiltinRunner,
+        vm_core::VirtualMachine,
         vm_memory::memory_segments::MemorySegmentManager,
     },
 };
@@ -57,6 +59,14 @@ impl VMProxy<'_> {
     ///Gets the relocatable value corresponding to the Relocatable address
     pub fn get_relocatable(&self, key: &Relocatable) -> Result<&Relocatable, VirtualMachineError> {
         self.memory.get_relocatable(key)
+    }
+
+    ///Gets a MaybeRelocatable value from memory indicated by a generic address
+    pub fn get_maybe<'a, K: 'a>(&self, key: &'a K) -> Result<Option<&MaybeRelocatable>, MemoryError>
+    where
+        Relocatable: TryFrom<&'a K>,
+    {
+        self.memory.get(key)
     }
 
     ///Inserts a value into a memory address given by a Relocatable value

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -24,6 +24,8 @@ use num_integer::Integer;
 use num_traits::{ToPrimitive, Zero};
 use std::{any::Any, collections::HashMap};
 
+use super::errors::memory_errors::MemoryError;
+
 #[derive(PartialEq, Debug)]
 pub struct Operands {
     dst: MaybeRelocatable,
@@ -661,6 +663,14 @@ impl VirtualMachine {
     ///Gets the relocatable value corresponding to the Relocatable address
     pub fn get_relocatable(&self, key: &Relocatable) -> Result<&Relocatable, VirtualMachineError> {
         self.memory.get_relocatable(key)
+    }
+
+    ///Gets a MaybeRelocatable value from memory indicated by a generic address
+    pub fn get_maybe<'a, K: 'a>(&self, key: &'a K) -> Result<Option<&MaybeRelocatable>, MemoryError>
+    where
+        Relocatable: TryFrom<&'a K>,
+    {
+        self.memory.get(key)
     }
 
     ///Inserts a value into a memory address given by a Relocatable value


### PR DESCRIPTION
# [Remove VMProxy -6] get_maybe

Add method to VirtualMachine and VMProxy:

get_maybe(

Replace `vm_proxy.memory.get` with `vm_proxy.get_maybe`

## Description

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
