### PR TITLE
Separate step into step_hint and step_instruction

### DIFF
--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -454,7 +454,7 @@ impl VirtualMachine {
         }
     }
 
-    pub fn step(
+    pub fn step_hint(
         &mut self,
         hint_executor: &dyn HintProcessor,
         exec_scopes: &mut ExecutionScopes,
@@ -468,10 +468,24 @@ impl VirtualMachine {
                 hint_executor.execute_hint(&mut vm_proxy, &mut exec_scopes_proxy, hint_data)?
             }
         }
-        self.skip_instruction_execution = false;
+        Ok(())
+    }
+
+    pub fn step_instruction(&mut self) -> Result<(), VirtualMachineError> {
         let instruction = self.decode_current_instruction()?;
         self.run_instruction(instruction)?;
+        self.skip_instruction_execution = false;
         Ok(())
+    }
+
+    pub fn step(
+        &mut self,
+        hint_executor: &dyn HintProcessor,
+        exec_scopes: &mut ExecutionScopes,
+        hint_data_dictionary: &HashMap<usize, Vec<Box<dyn Any>>>,
+    ) -> Result<(), VirtualMachineError> {
+        self.step_hint(hint_executor, exec_scopes, hint_data_dictionary)?;
+        self.step_instruction()
     }
 
     fn compute_op0_deductions(


### PR DESCRIPTION
Separates `step` method into `step_hint ` and `step_instruction`
No changes in the method code itself, just a minor refactor