### PR TITLE
[Remove VMProxy -7] load_data

### DIFF
--- a/src/hint_processor/builtin_hint_processor/blake2s_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/blake2s_utils.rs
@@ -127,12 +127,7 @@ pub fn finalize_blake2s(
     }
     let data = get_maybe_relocatable_array_from_u32(&full_padding);
     vm_proxy
-        .memory
-        .load_data(
-            vm_proxy.segments,
-            &MaybeRelocatable::RelocatableValue(blake2s_ptr_end),
-            data,
-        )
+        .load_data(&MaybeRelocatable::RelocatableValue(blake2s_ptr_end), data)
         .map_err(VirtualMachineError::MemoryError)?;
     Ok(())
 }
@@ -168,12 +163,7 @@ pub fn blake2s_add_uint256(
     //Insert first batch of data
     let data = get_maybe_relocatable_array_from_bigint(&inner_data);
     vm_proxy
-        .memory
-        .load_data(
-            vm_proxy.segments,
-            &MaybeRelocatable::RelocatableValue(data_ptr.clone()),
-            data,
-        )
+        .load_data(&MaybeRelocatable::RelocatableValue(data_ptr.clone()), data)
         .map_err(VirtualMachineError::MemoryError)?;
     //Build second batch of data
     let mut inner_data = Vec::<BigInt>::new();
@@ -183,9 +173,7 @@ pub fn blake2s_add_uint256(
     //Insert second batch of data
     let data = get_maybe_relocatable_array_from_bigint(&inner_data);
     vm_proxy
-        .memory
         .load_data(
-            vm_proxy.segments,
             &MaybeRelocatable::RelocatableValue(data_ptr).add_usize_mod(4, None),
             data,
         )
@@ -224,12 +212,7 @@ pub fn blake2s_add_uint256_bigend(
     //Insert first batch of data
     let data = get_maybe_relocatable_array_from_bigint(&inner_data);
     vm_proxy
-        .memory
-        .load_data(
-            vm_proxy.segments,
-            &MaybeRelocatable::RelocatableValue(data_ptr.clone()),
-            data,
-        )
+        .load_data(&MaybeRelocatable::RelocatableValue(data_ptr.clone()), data)
         .map_err(VirtualMachineError::MemoryError)?;
     //Build second batch of data
     let mut inner_data = Vec::<BigInt>::new();
@@ -239,9 +222,7 @@ pub fn blake2s_add_uint256_bigend(
     //Insert second batch of data
     let data = get_maybe_relocatable_array_from_bigint(&inner_data);
     vm_proxy
-        .memory
         .load_data(
-            vm_proxy.segments,
             &MaybeRelocatable::RelocatableValue(data_ptr).add_usize_mod(4, None),
             data,
         )

--- a/src/hint_processor/proxies/vm_proxy.rs
+++ b/src/hint_processor/proxies/vm_proxy.rs
@@ -77,4 +77,13 @@ impl VMProxy<'_> {
     ) -> Result<(), VirtualMachineError> {
         self.memory.insert_value(key, val)
     }
+
+    ///Writes data into the memory at address ptr and returns the first address after the data.
+    pub fn load_data(
+        &mut self,
+        ptr: &MaybeRelocatable,
+        data: Vec<MaybeRelocatable>,
+    ) -> Result<MaybeRelocatable, MemoryError> {
+        self.memory.load_data(self.segments, ptr, data)
+    }
 }

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -688,7 +688,6 @@ impl VirtualMachine {
         ptr: &MaybeRelocatable,
         data: Vec<MaybeRelocatable>,
     ) -> Result<MaybeRelocatable, MemoryError> {
-        // self.memory.load_data(self.segments, ptr, data)
         self.segments.load_data(&mut self.memory, ptr, data)
     }
 }

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -681,6 +681,16 @@ impl VirtualMachine {
     ) -> Result<(), VirtualMachineError> {
         self.memory.insert_value(key, val)
     }
+
+    ///Writes data into the memory at address ptr and returns the first address after the data.
+    pub fn load_data(
+        &mut self,
+        ptr: &MaybeRelocatable,
+        data: Vec<MaybeRelocatable>,
+    ) -> Result<MaybeRelocatable, MemoryError> {
+        // self.memory.load_data(self.segments, ptr, data)
+        self.segments.load_data(&mut self.memory, ptr, data)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Merge after #450
# [Remove VMProxy -7] load_data

## Description
Add method to VirtualMachine and VMProxy:
* load_data(

Replace `vm_proxy.memory.load_data` with `vm_proxy.load_data` in [blake2s_utils.rs](https://github.com/lambdaclass/cairo-rs/compare/remove-vm-proxy-6...remove-vm-proxy-7?expand=1#diff-24f06c895d664409895fc9583d3c842571612c549c8bc554454a2b6874ca4cd8)

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
