### PR TITLE
[Remove VMProxy -8] write_arg & get_range

### DIFF
--- a/src/hint_processor/builtin_hint_processor/cairo_keccak/keccak_hints.rs
+++ b/src/hint_processor/builtin_hint_processor/cairo_keccak/keccak_hints.rs
@@ -121,7 +121,6 @@ pub fn block_permutation(
     let keccak_ptr = get_ptr_from_var_name("keccak_ptr", vm_proxy, ids_data, ap_tracking)?;
 
     let values = vm_proxy
-        .memory
         .get_range(
             &MaybeRelocatable::RelocatableValue(keccak_ptr.sub(KECCAK_STATE_SIZE_FELTS)?),
             KECCAK_STATE_SIZE_FELTS,

--- a/src/hint_processor/builtin_hint_processor/cairo_keccak/keccak_hints.rs
+++ b/src/hint_processor/builtin_hint_processor/cairo_keccak/keccak_hints.rs
@@ -40,23 +40,11 @@ pub fn keccak_write_args(
     let high_args = [high & bigint!(u64::MAX), high >> 64];
 
     vm_proxy
-        .memory
-        .write_arg(
-            vm_proxy.segments,
-            &inputs_ptr,
-            &low_args.to_vec(),
-            Some(vm_proxy.prime),
-        )
+        .write_arg(&inputs_ptr, &low_args.to_vec())
         .map_err(VirtualMachineError::MemoryError)?;
 
     vm_proxy
-        .memory
-        .write_arg(
-            vm_proxy.segments,
-            &inputs_ptr.add(2)?,
-            &high_args.to_vec(),
-            Some(vm_proxy.prime),
-        )
+        .write_arg(&inputs_ptr.add(2)?, &high_args.to_vec())
         .map_err(VirtualMachineError::MemoryError)?;
 
     Ok(())
@@ -149,13 +137,7 @@ pub fn block_permutation(
     let bigint_values = u64_array_to_bigint_vec(&u64_values);
 
     vm_proxy
-        .memory
-        .write_arg(
-            vm_proxy.segments,
-            &keccak_ptr,
-            &bigint_values,
-            Some(vm_proxy.prime),
-        )
+        .write_arg(&keccak_ptr, &bigint_values)
         .map_err(VirtualMachineError::MemoryError)?;
 
     Ok(())
@@ -205,13 +187,7 @@ pub fn cairo_keccak_finalize(
     let keccak_ptr_end = get_ptr_from_var_name("keccak_ptr_end", vm_proxy, ids_data, ap_tracking)?;
 
     vm_proxy
-        .memory
-        .write_arg(
-            vm_proxy.segments,
-            &keccak_ptr_end,
-            &padding,
-            Some(vm_proxy.prime),
-        )
+        .write_arg(&keccak_ptr_end, &padding)
         .map_err(VirtualMachineError::MemoryError)?;
 
     Ok(())

--- a/src/hint_processor/builtin_hint_processor/keccak_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/keccak_utils.rs
@@ -157,7 +157,6 @@ pub fn unsafe_keccak_finalize(
 
     let mut keccak_input = Vec::new();
     let range = vm_proxy
-        .memory
         .get_range(&maybe_rel_start_ptr, n_elems)
         .map_err(VirtualMachineError::MemoryError)?;
 

--- a/src/hint_processor/builtin_hint_processor/set.rs
+++ b/src/hint_processor/builtin_hint_processor/set.rs
@@ -28,7 +28,6 @@ pub fn set_add(
         return Err(VirtualMachineError::ValueNotPositive(bigint!(elm_size)));
     }
     let elm = vm_proxy
-        .memory
         .get_range(&MaybeRelocatable::from(elm_ptr), elm_size)
         .map_err(VirtualMachineError::MemoryError)?;
 
@@ -43,7 +42,6 @@ pub fn set_add(
 
     for i in (0..range_limit).step_by(elm_size) {
         let set_iter = vm_proxy
-            .memory
             .get_range(
                 &MaybeRelocatable::from(set_ptr.clone() + i as usize),
                 elm_size,

--- a/src/hint_processor/proxies/vm_proxy.rs
+++ b/src/hint_processor/proxies/vm_proxy.rs
@@ -1,3 +1,5 @@
+use std::any::Any;
+
 use num_bigint::BigInt;
 
 use crate::{
@@ -85,5 +87,16 @@ impl VMProxy<'_> {
         data: Vec<MaybeRelocatable>,
     ) -> Result<MaybeRelocatable, MemoryError> {
         self.memory.load_data(self.segments, ptr, data)
+    }
+
+    //// Writes args into the memory at address ptr and returns the first address after the data.
+    /// Perfroms modulo on each element
+    pub fn write_arg(
+        &mut self,
+        ptr: &Relocatable,
+        arg: &dyn Any,
+    ) -> Result<MaybeRelocatable, MemoryError> {
+        self.memory
+            .write_arg(self.segments, ptr, arg, Some(self.prime))
     }
 }

--- a/src/hint_processor/proxies/vm_proxy.rs
+++ b/src/hint_processor/proxies/vm_proxy.rs
@@ -99,4 +99,13 @@ impl VMProxy<'_> {
         self.memory
             .write_arg(self.segments, ptr, arg, Some(self.prime))
     }
+
+    ///Gets n elements from memory starting from addr (n being size)
+    pub fn get_range(
+        &self,
+        addr: &MaybeRelocatable,
+        size: usize,
+    ) -> Result<Vec<Option<&MaybeRelocatable>>, MemoryError> {
+        self.memory.get_range(addr, size)
+    }
 }

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -690,6 +690,17 @@ impl VirtualMachine {
     ) -> Result<MaybeRelocatable, MemoryError> {
         self.segments.load_data(&mut self.memory, ptr, data)
     }
+
+    //// Writes args into the memory at address ptr and returns the first address after the data.
+    /// Perfroms modulo on each element
+    pub fn write_arg(
+        &mut self,
+        ptr: &Relocatable,
+        arg: &dyn Any,
+    ) -> Result<MaybeRelocatable, MemoryError> {
+        self.segments
+            .write_arg(&mut self.memory, ptr, arg, Some(&self.prime))
+    }
 }
 
 #[cfg(test)]

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -701,6 +701,15 @@ impl VirtualMachine {
         self.segments
             .write_arg(&mut self.memory, ptr, arg, Some(&self.prime))
     }
+
+    ///Gets n elements from memory starting from addr (n being size)
+    pub fn get_range(
+        &self,
+        addr: &MaybeRelocatable,
+        size: usize,
+    ) -> Result<Vec<Option<&MaybeRelocatable>>, MemoryError> {
+        self.memory.get_range(addr, size)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# [Remove VMProxy -8] write_arg & get_range

## Description

Add methods to VirtualMachine and VMProxy:
* write_arg
* get_range

Replace `vm_proxy.memory.get_range` with `vm_proxy.get_range`.
Replace `vm_proxy.memory.write_arg` with the `vm_proxy.write_arg` in [keccak_hints.rs](https://github.com/lambdaclass/cairo-rs/compare/remove-vm-proxy-7...remove-vm-proxy-8?expand=1#diff-8baec07683b44ced45f4f5286966858c39758a7c59c21bb476df04546bdc9077)

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
