### PR TITLE
[Remove VMProxy - 9] get_integer_range

### DIFF
--- a/src/hint_processor/proxies/vm_proxy.rs
+++ b/src/hint_processor/proxies/vm_proxy.rs
@@ -108,4 +108,13 @@ impl VMProxy<'_> {
     ) -> Result<Vec<Option<&MaybeRelocatable>>, MemoryError> {
         self.memory.get_range(addr, size)
     }
+
+    ///Gets n integer values from memory starting from addr (n being size),
+    pub fn get_integer_range(
+        &self,
+        addr: &Relocatable,
+        size: usize,
+    ) -> Result<Vec<&BigInt>, VirtualMachineError> {
+        self.memory.get_integer_range(addr, size)
+    }
 }

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -710,6 +710,15 @@ impl VirtualMachine {
     ) -> Result<Vec<Option<&MaybeRelocatable>>, MemoryError> {
         self.memory.get_range(addr, size)
     }
+
+    ///Gets n integer values from memory starting from addr (n being size),
+    pub fn get_integer_range(
+        &self,
+        addr: &Relocatable,
+        size: usize,
+    ) -> Result<Vec<&BigInt>, VirtualMachineError> {
+        self.memory.get_integer_range(addr, size)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# [Remove VMProxy - 9] get_integer_range

## Description
Add method to VirtualMachine and VMProxy:
* get_integer_range()

Refactor `fn compute_blake2s_func` to receive `VMProxy` as input

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
