### PR TITLE
Replace add segments

### DIFF
--- a/src/hint_processor/builtin_hint_processor/dict_hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/dict_hint_utils.rs
@@ -58,12 +58,10 @@ pub fn dict_new(
         copy_initial_dict(exec_scopes_proxy).ok_or(VirtualMachineError::NoInitialDict)?;
     //Check if there is a dict manager in scope, create it if there isnt one
     let base = if let Ok(dict_manager) = exec_scopes_proxy.get_dict_manager() {
-        dict_manager
-            .borrow_mut()
-            .new_dict(vm_proxy.segments, &mut vm_proxy.memory, initial_dict)?
+        dict_manager.borrow_mut().new_dict(vm_proxy, initial_dict)?
     } else {
         let mut dict_manager = DictManager::new();
-        let base = dict_manager.new_dict(vm_proxy.segments, &mut vm_proxy.memory, initial_dict)?;
+        let base = dict_manager.new_dict(vm_proxy, initial_dict)?;
         exec_scopes_proxy.insert_value("dict_manager", Rc::new(RefCell::new(dict_manager)));
         base
     };

--- a/src/hint_processor/builtin_hint_processor/dict_hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/dict_hint_utils.rs
@@ -91,20 +91,12 @@ pub fn default_dict_new(
     let initial_dict = copy_initial_dict(exec_scopes_proxy);
     //Check if there is a dict manager in scope, create it if there isnt one
     let base = if let Ok(dict_manager) = exec_scopes_proxy.get_dict_manager() {
-        dict_manager.borrow_mut().new_default_dict(
-            vm_proxy.segments,
-            &mut vm_proxy.memory,
-            &default_value,
-            initial_dict,
-        )?
+        dict_manager
+            .borrow_mut()
+            .new_default_dict(vm_proxy, &default_value, initial_dict)?
     } else {
         let mut dict_manager = DictManager::new();
-        let base = dict_manager.new_default_dict(
-            vm_proxy.segments,
-            &mut vm_proxy.memory,
-            &default_value,
-            initial_dict,
-        )?;
+        let base = dict_manager.new_default_dict(vm_proxy, &default_value, initial_dict)?;
         exec_scopes_proxy.insert_value("dict_manager", Rc::new(RefCell::new(dict_manager)));
         base
     };

--- a/src/hint_processor/builtin_hint_processor/dict_manager.rs
+++ b/src/hint_processor/builtin_hint_processor/dict_manager.rs
@@ -252,7 +252,7 @@ mod tests {
             dict_manager.trackers.get(&0),
             Some(&DictTracker::new_empty(&relocatable!(0, 0)))
         );
-        assert_eq!(vm_proxy.get_num_segments(), 1);
+        assert_eq!(vm.segments.num_segments, 1);
     }
 
     #[test]
@@ -271,7 +271,7 @@ mod tests {
                 None
             ))
         );
-        assert_eq!(vm_proxy.get_num_segments(), 1);
+        assert_eq!(vm.segments.num_segments, 1);
     }
 
     #[test]
@@ -291,7 +291,7 @@ mod tests {
                 initial_dict
             ))
         );
-        assert_eq!(vm_proxy.get_num_segments(), 1);
+        assert_eq!(vm.segments.num_segments, 1);
     }
 
     #[test]
@@ -313,7 +313,7 @@ mod tests {
                 Some(initial_dict)
             ))
         );
-        assert_eq!(vm_proxy.get_num_segments(), 1);
+        assert_eq!(vm.segments.num_segments, 1);
     }
 
     #[test]

--- a/src/hint_processor/builtin_hint_processor/dict_manager.rs
+++ b/src/hint_processor/builtin_hint_processor/dict_manager.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use num_bigint::BigInt;
 
 use crate::{
-    hint_processor::proxies::memory_proxy::MemoryProxy,
+    hint_processor::proxies::{memory_proxy::MemoryProxy, vm_proxy::VMProxy},
     types::relocatable::{MaybeRelocatable, Relocatable},
     vm::{
         errors::vm_errors::VirtualMachineError, vm_memory::memory_segments::MemorySegmentManager,
@@ -72,11 +72,10 @@ impl DictManager {
     //For now, no initial dict will be processed (Assumes initial_dict = None)
     pub fn new_dict(
         &mut self,
-        segments: &mut MemorySegmentManager,
-        memory: &mut MemoryProxy,
+        vm_proxy: &mut VMProxy,
         initial_dict: HashMap<BigInt, BigInt>,
     ) -> Result<MaybeRelocatable, VirtualMachineError> {
-        let base = memory.add_segment(segments);
+        let base = vm_proxy.add_memory_segment();
         if self.trackers.contains_key(&base.segment_index) {
             return Err(VirtualMachineError::CantCreateDictionaryOnTakenSegment(
                 base.segment_index,
@@ -209,9 +208,14 @@ impl DictTracker {
 mod tests {
     use super::*;
     use crate::{
-        bigint, hint_processor::proxies::memory_proxy::get_memory_proxy, relocatable,
-        vm::vm_memory::memory::Memory,
+        bigint,
+        hint_processor::proxies::{memory_proxy::get_memory_proxy, vm_proxy::get_vm_proxy},
+        relocatable,
+        utils::test_utils::*,
+        vm::{vm_core::VirtualMachine, vm_memory::memory::Memory},
     };
+
+    use num_bigint::Sign;
 
     #[test]
     fn create_dict_manager() {
@@ -244,18 +248,17 @@ mod tests {
 
     #[test]
     fn dict_manager_new_dict_empty() {
+        let mut vm = vm!();
+        let mut vm_proxy = get_vm_proxy(&mut vm);
         let mut dict_manager = DictManager::new();
-        let mut segments = MemorySegmentManager::new();
-        let mut memory = Memory::new();
-        let mem_proxy = &mut get_memory_proxy(&mut memory);
-        let base = dict_manager.new_dict(&mut segments, mem_proxy, HashMap::new());
+        let base = dict_manager.new_dict(&mut vm_proxy, HashMap::new());
         assert_eq!(base, Ok(MaybeRelocatable::from((0, 0))));
         assert!(dict_manager.trackers.contains_key(&0));
         assert_eq!(
             dict_manager.trackers.get(&0),
             Some(&DictTracker::new_empty(&relocatable!(0, 0)))
         );
-        assert_eq!(segments.num_segments, 1);
+        assert_eq!(vm_proxy.segments.num_segments, 1);
     }
 
     #[test]
@@ -281,12 +284,11 @@ mod tests {
     #[test]
     fn dict_manager_new_dict_with_initial_dict() {
         let mut dict_manager = DictManager::new();
-        let mut segments = MemorySegmentManager::new();
-        let mut memory = Memory::new();
+        let mut vm = vm!();
+        let mut vm_proxy = get_vm_proxy(&mut vm);
         let mut initial_dict = HashMap::<BigInt, BigInt>::new();
         initial_dict.insert(bigint!(5), bigint!(5));
-        let mem_proxy = &mut get_memory_proxy(&mut memory);
-        let base = dict_manager.new_dict(&mut segments, mem_proxy, initial_dict.clone());
+        let base = dict_manager.new_dict(&mut vm_proxy, initial_dict.clone());
         assert_eq!(base, Ok(MaybeRelocatable::from((0, 0))));
         assert!(dict_manager.trackers.contains_key(&0));
         assert_eq!(
@@ -296,7 +298,7 @@ mod tests {
                 initial_dict
             ))
         );
-        assert_eq!(segments.num_segments, 1);
+        assert_eq!(vm_proxy.segments.num_segments, 1);
     }
 
     #[test]
@@ -332,11 +334,10 @@ mod tests {
         dict_manager
             .trackers
             .insert(0, DictTracker::new_empty(&relocatable!(0, 0)));
-        let mut segments = MemorySegmentManager::new();
-        let mut memory = Memory::new();
-        let mem_proxy = &mut get_memory_proxy(&mut memory);
+        let mut vm = vm!();
+        let mut vm_proxy = get_vm_proxy(&mut vm);
         assert_eq!(
-            dict_manager.new_dict(&mut segments, mem_proxy, HashMap::new()),
+            dict_manager.new_dict(&mut vm_proxy, HashMap::new()),
             Err(VirtualMachineError::CantCreateDictionaryOnTakenSegment(0))
         );
     }
@@ -348,11 +349,10 @@ mod tests {
             0,
             DictTracker::new_default_dict(&relocatable!(0, 0), &bigint!(6), None),
         );
-        let mut segments = MemorySegmentManager::new();
-        let mut memory = Memory::new();
-        let mem_proxy = &mut get_memory_proxy(&mut memory);
+        let mut vm = vm!();
+        let mut vm_proxy = get_vm_proxy(&mut vm);
         assert_eq!(
-            dict_manager.new_dict(&mut segments, mem_proxy, HashMap::new()),
+            dict_manager.new_dict(&mut vm_proxy, HashMap::new()),
             Err(VirtualMachineError::CantCreateDictionaryOnTakenSegment(0))
         );
     }

--- a/src/hint_processor/builtin_hint_processor/dict_manager.rs
+++ b/src/hint_processor/builtin_hint_processor/dict_manager.rs
@@ -252,7 +252,7 @@ mod tests {
             dict_manager.trackers.get(&0),
             Some(&DictTracker::new_empty(&relocatable!(0, 0)))
         );
-        assert_eq!(vm_proxy.segments.num_segments, 1);
+        assert_eq!(vm_proxy.get_num_segments(), 1);
     }
 
     #[test]
@@ -271,7 +271,7 @@ mod tests {
                 None
             ))
         );
-        assert_eq!(vm_proxy.segments.num_segments, 1);
+        assert_eq!(vm_proxy.get_num_segments(), 1);
     }
 
     #[test]
@@ -291,7 +291,7 @@ mod tests {
                 initial_dict
             ))
         );
-        assert_eq!(vm_proxy.segments.num_segments, 1);
+        assert_eq!(vm_proxy.get_num_segments(), 1);
     }
 
     #[test]
@@ -313,7 +313,7 @@ mod tests {
                 Some(initial_dict)
             ))
         );
-        assert_eq!(vm_proxy.segments.num_segments, 1);
+        assert_eq!(vm_proxy.get_num_segments(), 1);
     }
 
     #[test]

--- a/src/hint_processor/builtin_hint_processor/usort.rs
+++ b/src/hint_processor/builtin_hint_processor/usort.rs
@@ -66,8 +66,8 @@ pub fn usort_body(
         multiplicities.push(positions_dict[k].len());
     }
     exec_scopes_proxy.insert_value("positions_dict", positions_dict);
-    let output_base = vm_proxy.memory.add_segment(vm_proxy.segments);
-    let multiplicities_base = vm_proxy.memory.add_segment(vm_proxy.segments);
+    let output_base = vm_proxy.add_memory_segment();
+    let multiplicities_base = vm_proxy.add_memory_segment();
     let output_len = output.len();
 
     for (i, sorted_element) in output.into_iter().enumerate() {

--- a/src/hint_processor/proxies/vm_proxy.rs
+++ b/src/hint_processor/proxies/vm_proxy.rs
@@ -37,10 +37,6 @@ impl VMProxy<'_> {
         self.memory.add_segment(self.segments)
     }
 
-    pub fn get_num_segments(&mut self) -> usize {
-        self.segments.num_segments
-    }
-
     pub fn get_ap(&self) -> Relocatable {
         self.run_context.get_ap()
     }

--- a/src/hint_processor/proxies/vm_proxy.rs
+++ b/src/hint_processor/proxies/vm_proxy.rs
@@ -34,4 +34,8 @@ impl VMProxy<'_> {
     pub fn add_memory_segment(&mut self) -> Relocatable {
         self.memory.add_segment(self.segments)
     }
+
+    pub fn get_num_segments(&mut self) -> usize {
+        self.segments.num_segments
+    }
 }

--- a/src/hint_processor/proxies/vm_proxy.rs
+++ b/src/hint_processor/proxies/vm_proxy.rs
@@ -40,7 +40,7 @@ impl VMProxy<'_> {
     pub fn get_num_segments(&mut self) -> usize {
         self.segments.num_segments
     }
-    
+
     pub fn get_ap(&self) -> Relocatable {
         self.run_context.get_ap()
     }


### PR DESCRIPTION
# TITLE

## Description

Replace memory.add_segment in hints to use VMProxy methods

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
