### PR TITLE
[Remove VMProxy - 10] get_range_check_builtin

### DIFF
--- a/src/hint_processor/builtin_hint_processor/math_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/math_utils.rs
@@ -1,4 +1,3 @@
-use crate::hint_processor::hint_processor_utils::get_range_check_builtin;
 use crate::hint_processor::{hint_processor_definition::HintReference, proxies::vm_proxy::VMProxy};
 use std::{
     collections::HashMap,
@@ -28,7 +27,7 @@ pub fn is_nn(
     ap_tracking: &ApTracking,
 ) -> Result<(), VirtualMachineError> {
     let a = get_integer_from_var_name("a", vm_proxy, ids_data, ap_tracking)?;
-    let range_check_builtin = get_range_check_builtin(vm_proxy.builtin_runners)?;
+    let range_check_builtin = vm_proxy.get_range_check_builtin()?;
     //Main logic (assert a is not negative and within the expected range)
     let value = if a.mod_floor(vm_proxy.get_prime()) >= bigint!(0)
         && a.mod_floor(vm_proxy.get_prime()) < range_check_builtin._bound
@@ -47,7 +46,7 @@ pub fn is_nn_out_of_range(
     ap_tracking: &ApTracking,
 ) -> Result<(), VirtualMachineError> {
     let a = get_integer_from_var_name("a", vm_proxy, ids_data, ap_tracking)?;
-    let range_check_builtin = get_range_check_builtin(vm_proxy.builtin_runners)?;
+    let range_check_builtin = vm_proxy.get_range_check_builtin()?;
     //Main logic (assert a is not negative and within the expected range)
     let value = if (-a - 1usize).mod_floor(vm_proxy.get_prime()) < range_check_builtin._bound {
         bigint!(0)
@@ -71,7 +70,7 @@ pub fn assert_le_felt(
 ) -> Result<(), VirtualMachineError> {
     let a = get_integer_from_var_name("a", vm_proxy, ids_data, ap_tracking)?;
     let b = get_integer_from_var_name("b", vm_proxy, ids_data, ap_tracking)?;
-    let range_check_builtin = get_range_check_builtin(vm_proxy.builtin_runners)?;
+    let range_check_builtin = vm_proxy.get_range_check_builtin()?;
     //Assert a <= b
     if a.mod_floor(vm_proxy.get_prime()) > b.mod_floor(vm_proxy.get_prime()) {
         return Err(VirtualMachineError::NonLeFelt(a.clone(), b.clone()));
@@ -164,7 +163,7 @@ pub fn assert_nn(
     ap_tracking: &ApTracking,
 ) -> Result<(), VirtualMachineError> {
     let a = get_integer_from_var_name("a", vm_proxy, ids_data, ap_tracking)?;
-    let range_check_builtin = get_range_check_builtin(vm_proxy.builtin_runners)?;
+    let range_check_builtin = vm_proxy.get_range_check_builtin()?;
     // assert 0 <= ids.a % PRIME < range_check_builtin.bound
     // as prime > 0, a % prime will always be > 0
     if a.mod_floor(vm_proxy.get_prime()) >= range_check_builtin._bound {
@@ -236,7 +235,7 @@ pub fn is_positive(
     ap_tracking: &ApTracking,
 ) -> Result<(), VirtualMachineError> {
     let value = get_integer_from_var_name("value", vm_proxy, ids_data, ap_tracking)?;
-    let range_check_builtin = get_range_check_builtin(vm_proxy.builtin_runners)?;
+    let range_check_builtin = vm_proxy.get_range_check_builtin()?;
     //Main logic (assert a is positive)
     let int_value = as_int(value, vm_proxy.get_prime());
     if int_value.abs() > range_check_builtin._bound {
@@ -302,7 +301,7 @@ pub fn signed_div_rem(
     let div = get_integer_from_var_name("div", vm_proxy, ids_data, ap_tracking)?;
     let value = get_integer_from_var_name("value", vm_proxy, ids_data, ap_tracking)?;
     let bound = get_integer_from_var_name("bound", vm_proxy, ids_data, ap_tracking)?;
-    let builtin = get_range_check_builtin(vm_proxy.builtin_runners)?;
+    let builtin = vm_proxy.get_range_check_builtin()?;
     // Main logic
     if !div.is_positive() || div > &(vm_proxy.get_prime() / &builtin._bound) {
         return Err(VirtualMachineError::OutOfValidRange(
@@ -344,7 +343,7 @@ pub fn unsigned_div_rem(
 ) -> Result<(), VirtualMachineError> {
     let div = get_integer_from_var_name("div", vm_proxy, ids_data, ap_tracking)?;
     let value = get_integer_from_var_name("value", vm_proxy, ids_data, ap_tracking)?;
-    let builtin = get_range_check_builtin(vm_proxy.builtin_runners)?;
+    let builtin = vm_proxy.get_range_check_builtin()?;
     // Main logic
     if !div.is_positive() || div > &(vm_proxy.get_prime() / &builtin._bound) {
         return Err(VirtualMachineError::OutOfValidRange(

--- a/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
@@ -1,5 +1,4 @@
 use crate::hint_processor::hint_processor_definition::HintReference;
-use crate::hint_processor::hint_processor_utils::get_range_check_builtin;
 use crate::hint_processor::proxies::exec_scopes_proxy::ExecutionScopesProxy;
 use crate::hint_processor::proxies::vm_proxy::VMProxy;
 use num_bigint::BigInt;
@@ -256,7 +255,7 @@ pub fn squash_dict(
     let ptr_diff = get_integer_from_var_name("ptr_diff", vm_proxy, ids_data, ap_tracking)?;
     let n_accesses = get_integer_from_var_name("n_accesses", vm_proxy, ids_data, ap_tracking)?;
     //Get range_check_builtin
-    let range_check_builtin = get_range_check_builtin(vm_proxy.builtin_runners)?;
+    let range_check_builtin = vm_proxy.get_range_check_builtin()?;
     let range_check_bound = range_check_builtin._bound.clone();
     //Main Logic
     if ptr_diff.mod_floor(&bigint!(DICT_ACCESS_SIZE)) != bigint!(0) {

--- a/src/hint_processor/hint_processor_utils.rs
+++ b/src/hint_processor/hint_processor_utils.rs
@@ -7,10 +7,7 @@ use crate::{
         instruction::Register,
         relocatable::{MaybeRelocatable, Relocatable},
     },
-    vm::{
-        errors::vm_errors::VirtualMachineError,
-        runners::builtin_runner::{BuiltinRunner, RangeCheckBuiltinRunner},
-    },
+    vm::errors::vm_errors::VirtualMachineError,
 };
 
 use super::{hint_processor_definition::HintReference, proxies::vm_proxy::VMProxy};
@@ -131,20 +128,4 @@ pub fn bigint_to_usize(bigint: &BigInt) -> Result<usize, VirtualMachineError> {
 ///Tries to convert a BigInt value to u32
 pub fn bigint_to_u32(bigint: &BigInt) -> Result<u32, VirtualMachineError> {
     bigint.to_u32().ok_or(VirtualMachineError::BigintToU32Fail)
-}
-
-///Returns a reference to the RangeCheckBuiltinRunner struct if range_check builtin is present
-pub fn get_range_check_builtin(
-    builtin_runners: &Vec<(String, Box<dyn BuiltinRunner>)>,
-) -> Result<&RangeCheckBuiltinRunner, VirtualMachineError> {
-    for (name, builtin) in builtin_runners {
-        if name == &String::from("range_check") {
-            if let Some(range_check_builtin) =
-                builtin.as_any().downcast_ref::<RangeCheckBuiltinRunner>()
-            {
-                return Ok(range_check_builtin);
-            };
-        }
-    }
-    Err(VirtualMachineError::NoRangeCheckBuiltin)
 }

--- a/src/hint_processor/proxies/vm_proxy.rs
+++ b/src/hint_processor/proxies/vm_proxy.rs
@@ -7,7 +7,7 @@ use crate::{
     vm::{
         context::run_context::RunContext,
         errors::{memory_errors::MemoryError, vm_errors::VirtualMachineError},
-        runners::builtin_runner::BuiltinRunner,
+        runners::builtin_runner::{BuiltinRunner, RangeCheckBuiltinRunner},
         vm_core::VirtualMachine,
         vm_memory::memory_segments::MemorySegmentManager,
     },
@@ -116,5 +116,18 @@ impl VMProxy<'_> {
         size: usize,
     ) -> Result<Vec<&BigInt>, VirtualMachineError> {
         self.memory.get_integer_range(addr, size)
+    }
+
+    pub fn get_range_check_builtin(&self) -> Result<&RangeCheckBuiltinRunner, VirtualMachineError> {
+        for (name, builtin) in self.builtin_runners {
+            if name == &String::from("range_check") {
+                if let Some(range_check_builtin) =
+                    builtin.as_any().downcast_ref::<RangeCheckBuiltinRunner>()
+                {
+                    return Ok(range_check_builtin);
+                };
+            }
+        }
+        Err(VirtualMachineError::NoRangeCheckBuiltin)
     }
 }

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -24,7 +24,7 @@ use num_integer::Integer;
 use num_traits::{ToPrimitive, Zero};
 use std::{any::Any, collections::HashMap};
 
-use super::errors::memory_errors::MemoryError;
+use super::{errors::memory_errors::MemoryError, runners::builtin_runner::RangeCheckBuiltinRunner};
 
 #[derive(PartialEq, Debug)]
 pub struct Operands {
@@ -718,6 +718,19 @@ impl VirtualMachine {
         size: usize,
     ) -> Result<Vec<&BigInt>, VirtualMachineError> {
         self.memory.get_integer_range(addr, size)
+    }
+
+    pub fn get_range_check_builtin(&self) -> Result<&RangeCheckBuiltinRunner, VirtualMachineError> {
+        for (name, builtin) in &self.builtin_runners {
+            if name == &String::from("range_check") {
+                if let Some(range_check_builtin) =
+                    builtin.as_any().downcast_ref::<RangeCheckBuiltinRunner>()
+                {
+                    return Ok(range_check_builtin);
+                };
+            }
+        }
+        Err(VirtualMachineError::NoRangeCheckBuiltin)
     }
 }
 


### PR DESCRIPTION
# [Remove VMProxy - 10] get_range_check_builtin

## Description
* Add method to VirtualMachine and VMProxy:
  * get_range_check_builtin()
* Replace `get_range_check_builtin(vm_proxy.builtin_runners)` with `vm_proxy.get_range_check_builtin()` in [squash_dict_utils.rs](https://github.com/lambdaclass/cairo-rs/compare/remove-vm-proxy-9...remove-vm-proxy-10?expand=1#diff-fca3233c0d072703a87919cd2f6c0d878dc18678c4916617ee42a2b0ee5e7ac2) and [math_utils.rs](https://github.com/lambdaclass/cairo-rs/pull/459/files#diff-7f4d681998fcaf9cfb8201a0886a1cca877d1c54b936f6cf8a7bd53925435ec8)
* Delete unused `fn get_range_check_builtin`
* Make `VMProxy.builtin_runners` a private field

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
