### PR TITLE
Use vm_proxy's method get_integer

### DIFF
--- a/src/hint_processor/builtin_hint_processor/find_element_hint.rs
+++ b/src/hint_processor/builtin_hint_processor/find_element_hint.rs
@@ -37,7 +37,6 @@ pub fn find_element(
     if let Some(find_element_index_value) = find_element_index {
         let find_element_index_usize = bigint_to_usize(&find_element_index_value)?;
         let found_key = vm_proxy
-            .memory
             .get_integer(&(array_start + (elm_size * find_element_index_usize)))
             .map_err(|_| VirtualMachineError::KeyNotFound)?;
 
@@ -76,7 +75,6 @@ pub fn find_element(
 
         for i in 0..n_elms_iter {
             let iter_key = vm_proxy
-                .memory
                 .get_integer(&(array_start.clone() + (elm_size * i as usize)))
                 .map_err(|_| VirtualMachineError::KeyNotFound)?;
 

--- a/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
@@ -281,7 +281,6 @@ pub fn squash_dict(
     for i in 0..n_accesses_usize {
         let key_addr = &address + DICT_ACCESS_SIZE * i;
         let key = vm_proxy
-            .memory
             .get_integer(&key_addr)
             .map_err(|_| VirtualMachineError::ExpectedInteger(MaybeRelocatable::from(key_addr)))?;
         access_indices


### PR DESCRIPTION
# TITLE

## Description

Replaces memory.get_integer for vm_proxy.get_integer

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
