### PR TITLE
Integrate parse-hyperlinks and fix out of bounds

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,3 +1,4 @@
 ignore:
   - src/vm/errors
   - src/types/errors
+  - deps

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,8 +704,6 @@ checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
 [[package]]
 name = "parse-hyperlinks"
 version = "0.23.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0181d37c4d5ae35cc8be7cf823c1a933005661da6a08bcb2855aa392c9a54b8e"
 dependencies = [
  "html-escape",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ generic-array = "0.14.6"
 # There is a proposal for extending nom::delimited to use this function:
 # https://github.com/Geal/nom/issues/1253
 keccak = "0.1.2"
-parse-hyperlinks = "0.23.4"
+parse-hyperlinks = { path = "./deps/parse-hyperlinks" }
 
 [dev-dependencies.rusty-hook]
 version = "0.11"

--- a/deps/parse-hyperlinks/Cargo.toml
+++ b/deps/parse-hyperlinks/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "parse-hyperlinks"
+version = "0.23.4"
+authors = ["Jens Getreu <getreu@getreu@web.de>"]
+edition = "2021"
+keywords = ["parser", "markup", "hyperlink", "Markdown", "reStructuredText"]
+license = "MIT/Apache-2.0"
+readme = "README.md"
+repository = "https://gitlab.com/getreu/parse-hyperlinks"
+homepage = "https://gitlab.com/getreu/parse-hyperlinks"
+description = "A Nom parser library for hyperlinks with markup."
+categories = ["command-line-utilities", "parser-implementations"]
+
+[dependencies]
+nom= "7.1.1"
+html-escape = "0.2.11"
+percent-encoding = "2.1.0"
+thiserror = "1.0.31"

--- a/deps/parse-hyperlinks/LICENSE-APACHE
+++ b/deps/parse-hyperlinks/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/deps/parse-hyperlinks/LICENSE-MIT
+++ b/deps/parse-hyperlinks/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/deps/parse-hyperlinks/LICENSE.md
+++ b/deps/parse-hyperlinks/LICENSE.md
@@ -1,0 +1,1 @@
+../LICENSE.md

--- a/deps/parse-hyperlinks/README.md
+++ b/deps/parse-hyperlinks/README.md
@@ -1,0 +1,27 @@
+# Parse hyperlinks
+
+[Parse-hyperlinks](https://crates.io/crates/parse-hyperlinks),
+a parser library written with [Nom](https://crates.io/crates/nom) to
+recognize hyperlinks and link reference definitions in Markdown,
+reStructuredText, Asciidoc and HTML formatted text input.
+
+[![Cargo](https://img.shields.io/crates/v/parse-hyperlinks.svg)](
+https://crates.io/crates/parse-hyperlinks)
+[![Documentation](https://docs.rs/parse-hyperlinks/badge.svg)](
+https://docs.rs/parse-hyperlinks)
+[![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](
+https://gitlab.com/getreu/parse-hyperlinks)
+
+The library implements the
+[CommonMark Specification 0.30](https://spec.commonmark.org/0.30/),
+[reStructuredText Markup Specification](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html)
+(revision 8571, date 2020-10-28), the specifications in
+[Asciidoctor User Manual, chapter 26](https://asciidoctor.org/docs/user-manual/#url) (date 2020-12-03)
+and [HTML 5.2: section 4.5](https://www.w3.org/TR/html52/textlevel-semantics.html#the-a-element).
+
+To illustrate the usage and the
+[API of the library](https://docs.rs/parse-hyperlinks/0.19.6/parse_hyperlinks/index.html),
+[Parse-hyperlinks](https://crates.io/crates/parse-hyperlinks) comes with a
+simple command line application:
+[Atext2html](https://crates.io/crates/atext2html)
+

--- a/deps/parse-hyperlinks/src/iterator.rs
+++ b/deps/parse-hyperlinks/src/iterator.rs
@@ -1,0 +1,929 @@
+//! Module providing an iterator over the hyperlinks found in the input text.  Consult the
+//! documentation of `parser::parse::take_link()` to see a list of supported markup languages. The
+//! iterator resolves link references.
+
+use crate::parser::parse::take_link;
+use crate::parser::Link;
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::mem::swap;
+
+#[derive(Debug, PartialEq)]
+/// A collection of `Link` objects grouped by link type.
+struct HyperlinkCollection<'a> {
+    /// Vector storing all `Link::Text2Dest`, `Link::Text2Label` and `Link::TextLabel2Dest` links.
+    /// The tuple is defined as follows: `(link_first_byte_offset, link_len, Link)`.
+    text2dest_label: Vec<(usize, usize, Link<'a>)>,
+    /// Vector for `Link::Label2Label` links.
+    label2label: Vec<(Cow<'a, str>, Cow<'a, str>)>,
+    /// Vector for `Link::Label2Dest` and `Link::TextLabel2Dest` links.
+    /// The `HashMap`'s key is the `link_label` of the link, the value its
+    /// `(link_destination, link_title)`.
+    label2dest: HashMap<Cow<'a, str>, (Cow<'a, str>, Cow<'a, str>)>,
+}
+
+impl<'a> HyperlinkCollection<'a> {
+    fn new() -> Self {
+        Self {
+            text2dest_label: Vec::new(),
+            label2label: Vec::new(),
+            label2dest: HashMap::new(),
+        }
+    }
+
+    /// Reads through the whole `Self::input` and extracts all hyperlinks and
+    /// stores them in `Self::HyperlinkCollection` according to their category.
+    /// One type is treated specially: `Link::TextLabel2Dest` are cloned and one
+    /// copy is stored in `HyperlinkCollection::Text2Dest` and the other copy is
+    /// stored in `HyperlinkCollection::Label2Dest`.
+    #[inline]
+    fn from(input: &'a str, render_label2dest: bool) -> Self {
+        let mut i = input;
+        let mut hc = HyperlinkCollection::new();
+        let mut anonymous_text2label_counter = 0;
+        let mut anonymous_label2x_counter = 0;
+        // This index refers to `input`.
+        let mut input_idx = 0;
+
+        while let Ok((j, (skipped, res))) = take_link(i) {
+            match res {
+                // `Text2Dest` is stored without modification in `hc.text2dest_label`.
+                l if matches!(l, Link::Text2Dest { .. }) => {
+                    let link_offset = input_idx + skipped.len();
+                    let link_len = i.len() - j.len() - skipped.len();
+                    hc.text2dest_label.push((link_offset, link_len, l));
+                }
+
+                // `Text2label` is stored without modification in `hc.text2dest_label`.
+                Link::Text2Label(text, mut label) => {
+                    if label == "_" {
+                        anonymous_text2label_counter += 1;
+                        label = Cow::Owned(format!("_{}", anonymous_text2label_counter));
+                    }
+                    let link_offset = input_idx + skipped.len();
+                    let link_len = i.len() - j.len() - skipped.len();
+                    hc.text2dest_label
+                        .push((link_offset, link_len, Link::Text2Label(text, label)))
+                }
+                //`TextLabel2Dest` are cloned and stored in `hc.text2dest_label` as `Text2Dest`
+                // and in `hc.label2dest` (repacked in a `HashMap`).
+                Link::TextLabel2Dest(tl, d, t) => {
+                    let link_offset = input_idx + skipped.len();
+                    let link_len = i.len() - j.len() - skipped.len();
+                    hc.text2dest_label.push((
+                        link_offset,
+                        link_len,
+                        Link::Text2Dest(tl.clone(), d.clone(), t.clone()),
+                    ));
+
+                    // Silently ignore when overwriting a key that exists already.
+                    hc.label2dest.insert(tl, (d, t));
+                }
+
+                // `Label2Label` are unpacked and stored in `hc.label2label`.
+                Link::Label2Label(mut from, to) => {
+                    if from == "_" {
+                        anonymous_label2x_counter += 1;
+                        from = Cow::Owned(format!("_{}", anonymous_label2x_counter));
+                    }
+                    hc.label2label.push((from, to));
+                }
+
+                // `Label2Dest` are unpacked and stored as `HashMap` in `hc.label2dest`:
+                Link::Label2Dest(mut l, d, t) => {
+                    if l == "_" {
+                        anonymous_label2x_counter += 1;
+                        l = Cow::Owned(format!("_{}", anonymous_label2x_counter));
+                    }
+                    // Some want to have link reference definitions clickable
+                    // too. Strictly speaking they are not links, this is why
+                    // this is optional.
+                    if render_label2dest {
+                        let link_offset = input_idx + skipped.len();
+                        let link_len = i.len() - j.len() - skipped.len();
+                        hc.text2dest_label.push((
+                            link_offset,
+                            link_len,
+                            Link::Text2Dest(
+                                Cow::from(&input[link_offset..link_offset + link_len]),
+                                d.clone(),
+                                t.clone(),
+                            ),
+                        ));
+                    };
+
+                    // Silently ignore when overwriting a key that exists already.
+                    hc.label2dest.insert(l, (d, t));
+                }
+                _ => unreachable!(),
+            };
+
+            // Prepare next iteration.
+            input_idx += i.len() - j.len();
+            i = j;
+        }
+
+        hc
+    }
+
+    /// Takes one by one, one item from `HyperlinkCollection::label2label` and
+    /// searches the corresponding label in `HyperlinkCollection::label2dest`.
+    /// When found, add a new item to `HyperlinkCollection::label2dest`. Continue
+    /// until `HyperlinkCollection::label2label` is empty or no more corresponding
+    /// items can be associated.
+    #[inline]
+    fn resolve_label2label_references(&mut self) {
+        let mut nb_no_match = 0;
+        let mut idx = 0;
+        while !self.label2label.is_empty() && nb_no_match < self.label2label.len() {
+            let (key_alias, key) = &self.label2label[idx];
+            // This makes sure, that we advance in the loop.
+            if let Some(value) = self.label2dest.get(key) {
+                let found_new_key = key_alias.clone();
+                let found_value = value.clone();
+                // We advance in the loop, because we remove the element `idx` points to.
+                self.label2label.remove(idx);
+                self.label2dest.insert(found_new_key, found_value);
+                // We give up only, after a complete round without match.
+                nb_no_match = 0;
+            } else {
+                // We advance in the loop because we increment `idx`.
+                idx += 1;
+                nb_no_match += 1;
+            };
+            // Make sure, that `idx` always points to some valid index.
+            if idx >= self.label2label.len() {
+                idx = 0;
+            }
+        }
+    }
+
+    /// Takes one by one, one item of type `Link::Text2Label` from
+    /// `HyperlinkCollection::text2text_label` and searches the corresponding
+    /// label in `HyperlinkCollection::label2dest`. The associated
+    /// `Link::Text2Label` and `Link::Label2Dest` are resolved into a new
+    /// `Link::Text2Dest` object. Then the item form the fist list is replaced by
+    /// this new object. After this operation the
+    /// `HyperlinkCollection::text2text_label` list contains only
+    /// `Link::Text2Dest` objects (and some unresolvable `Link::Text2Label`
+    /// objects).
+    #[inline]
+    fn resolve_text2label_references(&mut self) {
+        let mut idx = 0;
+        while idx < self.text2dest_label.len() {
+            // If we can not resolve the label, we just skip it.
+            if let (input_offset, len, Link::Text2Label(text, label)) = &self.text2dest_label[idx] {
+                if let Some((dest, title)) = &self.label2dest.get(&*label) {
+                    let new_link = if text == "" {
+                        (
+                            *input_offset,
+                            *len,
+                            Link::Text2Dest(dest.clone(), dest.clone(), title.clone()),
+                        )
+                    } else {
+                        (
+                            *input_offset,
+                            *len,
+                            Link::Text2Dest(text.clone(), dest.clone(), title.clone()),
+                        )
+                    };
+                    self.text2dest_label[idx] = new_link;
+                };
+            };
+            // We advance in the loop because we increment `idx`.
+            idx += 1;
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+/// The interator's state.
+enum Status<'a> {
+    /// Initial state. Iterator is not started.
+    Init,
+    /// So far only `Text2Dest` links are coming, no links need to be resolved.
+    DirectSearch(&'a str),
+    /// As soon as the first reference appears, the remaining text is read and
+    /// all links are resolved. The tuple describes a resolved link. The first
+    /// integer index points to the first byte of the link in `self.input`, the
+    /// second interger is the lenght of the link in `input` bytes. Then follows
+    /// the `Link`.
+    ResolvedLinks(Vec<(usize, usize, Link<'a>)>),
+    /// All links have been returned. From now on only `None` are returned.
+    End,
+}
+
+#[derive(Debug, PartialEq)]
+/// Iterator over all the hyperlinks in the `input` text.
+/// This struct holds the iterator's state and an advancing pointer into the `input` text.
+/// The iterator's `next()` method returns a tuple with 2 tuples inside:
+/// `Some(((input_split)(link_content)))`.
+///
+/// Each tuple has the following parts:
+/// * `input_split = (skipped_characters, consumed_characters, remaining_characters)`
+/// * `link_content = (link_text, link_destination, link_title)`
+///
+/// # Input split
+///
+/// ```
+/// use parse_hyperlinks::iterator::Hyperlink;
+/// use std::borrow::Cow;
+///
+/// let i = "abc[text0](dest0)efg[text1](dest1)hij";
+///
+/// let mut iter = Hyperlink::new(i, false);
+/// assert_eq!(iter.next().unwrap().0, ("abc", "[text0](dest0)", "efg[text1](dest1)hij"));
+/// assert_eq!(iter.next().unwrap().0, ("efg", "[text1](dest1)", "hij"));
+/// assert_eq!(iter.next(), None);
+/// ```
+/// # Link content
+/// ## Markdown
+/// ```
+/// use parse_hyperlinks::iterator::Hyperlink;
+/// use std::borrow::Cow;
+///
+/// let i = r#"abc[text0](dest0 "title0")abc
+/// abc[text1][label1]abc
+/// abc[text2](dest2 "title2")
+/// [text3]: dest3 "title3"
+/// [label1]: dest1 "title1"
+/// abc[text3]abc
+/// "#;
+///
+/// let mut iter = Hyperlink::new(i, false);
+/// assert_eq!(iter.next().unwrap().1, (Cow::from("text0"), Cow::from("dest0"), Cow::from("title0")));
+/// assert_eq!(iter.next().unwrap().1, (Cow::from("text1"), Cow::from("dest1"), Cow::from("title1")));
+/// assert_eq!(iter.next().unwrap().1, (Cow::from("text2"), Cow::from("dest2"), Cow::from("title2")));
+/// assert_eq!(iter.next().unwrap().1, (Cow::from("text3"), Cow::from("dest3"), Cow::from("title3")));
+/// assert_eq!(iter.next(), None);
+/// ```
+///
+/// ## reStructuredText
+///
+/// ```
+/// use parse_hyperlinks::iterator::Hyperlink;
+/// use std::borrow::Cow;
+///
+/// let i = r#"
+/// abc `text1 <label1_>`_abc
+/// abc text2_ abc
+/// abc text3__ abc
+/// abc text_label4_ abc
+/// abc text5__ abc
+/// .. _label1: dest1
+/// .. _text2: dest2
+/// .. __: dest3
+/// __ dest5
+/// "#;
+///
+/// let mut iter = Hyperlink::new(i, false);
+/// assert_eq!(iter.next().unwrap().1, (Cow::from("text1"), Cow::from("dest1"), Cow::from("")));
+/// assert_eq!(iter.next().unwrap().1, (Cow::from("text2"), Cow::from("dest2"), Cow::from("")));
+/// assert_eq!(iter.next().unwrap().1, (Cow::from("text3"), Cow::from("dest3"), Cow::from("")));
+/// assert_eq!(iter.next().unwrap().1, (Cow::from("text5"), Cow::from("dest5"), Cow::from("")));
+/// assert_eq!(iter.next(), None);
+///
+/// ```
+/// ## Asciidoc
+///
+/// ```
+/// use parse_hyperlinks::iterator::Hyperlink;
+/// use std::borrow::Cow;
+///
+/// let i = r#"abc
+/// abc https://dest0[text0]abc
+/// abc link:https://dest1[text1]abc
+/// abc {label2}[text2]abc
+/// abc {label3}abc
+/// :label2: https://dest2
+/// :label3: https://dest3
+/// "#;
+///
+/// let mut iter = Hyperlink::new(i, false);
+/// assert_eq!(iter.next().unwrap().1, (Cow::from("text0"), Cow::from("https://dest0"), Cow::from("")));
+/// assert_eq!(iter.next().unwrap().1, (Cow::from("text1"), Cow::from("https://dest1"), Cow::from("")));
+/// assert_eq!(iter.next().unwrap().1, (Cow::from("text2"), Cow::from("https://dest2"), Cow::from("")));
+/// assert_eq!(iter.next().unwrap().1, (Cow::from("https://dest3"), Cow::from("https://dest3"), Cow::from("")));
+/// assert_eq!(iter.next(), None);
+/// ```
+///
+/// # HTML
+///
+/// ```
+/// use parse_hyperlinks::iterator::Hyperlink;
+/// use std::borrow::Cow;
+///
+/// let i = r#"abc<a href="dest1" title="title1">text1</a>abc
+/// abc<a href="dest2" title="title2">text2</a>abc
+/// "#;
+///
+/// let mut iter = Hyperlink::new(i, false);
+/// assert_eq!(iter.next().unwrap().1, (Cow::from("text1"), Cow::from("dest1"), Cow::from("title1")));
+/// assert_eq!(iter.next().unwrap().1, (Cow::from("text2"), Cow::from("dest2"), Cow::from("title2")));
+/// assert_eq!(iter.next(), None);
+/// ```
+pub struct Hyperlink<'a> {
+    /// The remaining text input.
+    input: &'a str,
+    /// Status of the `Hyperlink` state machine.
+    status: Status<'a>,
+    /// Index where the last output started.
+    last_output_offset: usize,
+    /// Length of the last output.
+    last_output_len: usize,
+    /// By default, `Label2Dest` link reference definitions are not rendered. If
+    /// `render_label` is true, then `Label2Dest` is rendered like an inline
+    /// link: with the full link reference definition's source as _link text_ and
+    /// the definition's destination as _link destination_.
+    render_label: bool,
+}
+
+/// Constructor for the `Hyperlink` struct.
+impl<'a> Hyperlink<'a> {
+    /// Constructor for the iterator. `input` is the text with hyperlinks to be
+    /// extracted.
+    ///
+    /// # Optional rendering of Label2Dest link reference definitions
+    ///
+    /// By default `Label2Dest` link reference definitions are not rendered:
+    ///
+    /// ```
+    /// use parse_hyperlinks::iterator::Hyperlink;
+    /// use std::borrow::Cow;
+    ///
+    /// let i = r#"abc[text1][label1]abc
+    /// [label1]: dest1 "title1"
+    /// "#;
+    ///
+    /// let mut iter = Hyperlink::new(i, false);
+    /// assert_eq!(iter.next().unwrap().1, (Cow::from("text1"), Cow::from("dest1"), Cow::from("title1")));
+    /// assert_eq!(iter.next(), None);
+    /// ```
+    ///
+    /// If the internal variable `render_label` is true, then `Label2Dest` link
+    /// reference definitions are rendered like inline links: the full
+    /// `Label2Dest` link reference definition's source will appear as _link
+    /// text_ and its destination as _link destination_. To enable this feature,
+    /// construct `Hyperlink` with the second positional parameter set to `true`,
+    /// e.g. `Hyperlink::new(i, true)`.
+    ///
+    /// ```
+    /// use parse_hyperlinks::iterator::Hyperlink;
+    /// use std::borrow::Cow;
+    ///
+    /// let i = r#"abc[text1][label1]abc
+    /// [label1]: dest1 "title1"
+    /// "#;
+    ///
+    /// let mut iter = Hyperlink::new(i, true);
+    /// assert_eq!(iter.next().unwrap().1, (Cow::from("text1"), Cow::from("dest1"), Cow::from("title1")));
+    /// assert_eq!(iter.next().unwrap().1, (Cow::from("[label1]: dest1 \"title1\""), Cow::from("dest1"), Cow::from("title1")));
+    /// assert_eq!(iter.next(), None);
+    /// ```
+    ///
+    #[inline]
+    pub fn new(input: &'a str, render_label: bool) -> Self {
+        Self {
+            input,
+            status: Status::Init,
+            last_output_offset: 0,
+            last_output_len: 0,
+            render_label,
+        }
+    }
+}
+
+/// Iterator over the hyperlinks (with markup) in the `input`-text.
+/// The iterator's `next()` method returns a tuple with 2 tuples inside:
+/// * `Some(((input_split)(link_content)))`
+///
+/// Each tuple has the following parts:
+/// * `input_split = (skipped_characters, consumed_characters, remaining_characters)`
+/// * `link_content = (link_text, link_destination, link_title)`
+///
+impl<'a> Iterator for Hyperlink<'a> {
+    #[allow(clippy::type_complexity)]
+    type Item = (
+        (&'a str, &'a str, &'a str),
+        (Cow<'a, str>, Cow<'a, str>, Cow<'a, str>),
+    );
+    /// The iterator operates in 2 modes:
+    /// 1. `Status::DirectSearch`: This is the starting state. So far
+    ///    the iterator has only encountered inline links so far.
+    ///    Nothing needs to be resolved and the next method can
+    ///    output the link immediately.
+    ///    The `next()` method outputs directly the result from the parser
+    ///    `parser::take_link()`.
+    /// 2. `Status::ResolvedLinks`: as soon as the iterator encounters
+    ///    some reference link, e.g. `Text2label`, `Label2Dest` or
+    ///    `Label2Label` link, it switches into `Status::ResolvedLinks` mode.
+    ///    The transition happens as follows:
+    ///    1. The `next()` method consumes all the remaining `input` and
+    ///       calls the `populate_collection()`,
+    ///       `resolve_label2label_references()` and
+    ///       `resolve_text2label_references()` methods.
+    ///       From now on,
+    ///    2. the `next()` method outputs and deletes
+    ///       `HyperlinkCollection::Dest2Text_label[0]`.
+    ///       Not resolved `Text2Label` are ignored.
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut output = None;
+        let mut status = Status::Init;
+        swap(&mut status, &mut self.status);
+
+        // Advance state machine.
+        let mut again = true;
+        while again {
+            status = match status {
+                // Advance state machine and match one more time.
+                Status::Init => Status::DirectSearch(self.input),
+
+                Status::DirectSearch(input) => {
+                    // We stay in direct mode.
+                    if let Ok((remaining_input, (skipped, Link::Text2Dest(te, de, ti)))) =
+                        take_link(input)
+                    {
+                        let consumed = &input[skipped.len()..input.len() - remaining_input.len()];
+                        // Assing output.
+                        output = Some(((skipped, consumed, remaining_input), (te, de, ti)));
+                        debug_assert_eq!(input, {
+                            let mut s = "".to_string();
+                            s.push_str(skipped);
+                            s.push_str(consumed);
+                            s.push_str(remaining_input);
+                            s
+                        });
+                        // Same state, we leave the loop.
+                        again = false;
+                        Status::DirectSearch(remaining_input)
+                    } else {
+                        // We switch to resolving mode.
+                        self.input = input;
+                        let mut hc = HyperlinkCollection::from(input, self.render_label);
+                        hc.resolve_label2label_references();
+                        hc.resolve_text2label_references();
+                        let mut resolved_links = Vec::new();
+                        swap(&mut hc.text2dest_label, &mut resolved_links);
+
+                        // Advance state machine and match one more time.
+                        Status::ResolvedLinks(resolved_links)
+                    }
+                }
+
+                Status::ResolvedLinks(mut resolved_links) => {
+                    while !resolved_links.is_empty() {
+                        if let (input_offset, len, Link::Text2Dest(te, de, ti)) =
+                            resolved_links.remove(0)
+                        {
+                            let skipped = &self.input
+                                [(self.last_output_offset + self.last_output_len)..input_offset];
+                            let consumed = &self.input[input_offset..input_offset + len];
+                            let remaining_input = &self.input[input_offset + len..];
+                            // Assign output.
+                            output = Some(((skipped, consumed, remaining_input), (te, de, ti)));
+                            debug_assert_eq!(self.input, {
+                                let mut s = (&self.input
+                                    [..self.last_output_offset + self.last_output_len])
+                                    .to_string();
+                                s.push_str(skipped);
+                                s.push_str(consumed);
+                                s.push_str(remaining_input);
+                                s
+                            });
+                            self.last_output_offset = input_offset;
+                            self.last_output_len = len;
+                            break;
+                        };
+                    }
+                    again = false;
+                    if output.is_some() {
+                        Status::ResolvedLinks(resolved_links)
+                    } else {
+                        Status::End
+                    }
+                }
+
+                Status::End => {
+                    again = false;
+                    output = None;
+                    Status::End
+                }
+            }
+        }
+        swap(&mut status, &mut self.status);
+        output
+    }
+}
+
+/// Recognizes hyperlinks in all supported markup languages
+/// and returns the first hyperlink found as tuple:
+/// `Some((link_text, link_destination, link_title))`.
+///
+/// Returns `None` if no hyperlink is found.
+/// This function resolves _link references_.
+/// ```
+/// use parse_hyperlinks::iterator::first_hyperlink;
+/// use std::borrow::Cow;
+///
+/// let i = r#"abc[t][u]abc
+///            [u]: v "w"
+///            abc"#;
+///
+/// let r = first_hyperlink(i);
+/// assert_eq!(r, Some((Cow::from("t"), Cow::from("v"), Cow::from("w"))));
+/// ```
+pub fn first_hyperlink(i: &str) -> Option<(Cow<str>, Cow<str>, Cow<str>)> {
+    if let Some((_, (text, dest, title))) = Hyperlink::new(i, false).next() {
+        Some((text, dest, title))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_populate_collection() {
+        let i = r#"[md label1]: md_destination1 "md title1"
+abc [md text2](md_destination2 "md title2")[md text3]: abc[md text4]: abc
+   [md label5]: md_destination5 "md title5"
+abc `rst text1 <rst_destination1>`__abc
+abc `rst text2 <rst_label2_>`_ .. _norst: no .. _norst: no
+.. _rst label3: rst_destination3
+  .. _rst label4: rst_d
+     estination4
+__ rst_label5_
+__ rst_label6_
+abc `rst text5`__abc
+abc `rst text6`__abc
+abc `rst text_label7 <rst_destination7>`_abc
+"#;
+
+        let hc = HyperlinkCollection::from(i, false);
+
+        let expected = r#"[
+    (
+        45,
+        39,
+        Text2Dest(
+            "md text2",
+            "md_destination2",
+            "md title2",
+        ),
+    ),
+    (
+        84,
+        10,
+        Text2Label(
+            "md text3",
+            "md text3",
+        ),
+    ),
+    (
+        99,
+        10,
+        Text2Label(
+            "md text4",
+            "md text4",
+        ),
+    ),
+    (
+        163,
+        32,
+        Text2Dest(
+            "rst text1",
+            "rst_destination1",
+            "",
+        ),
+    ),
+    (
+        203,
+        54,
+        Text2Label(
+            "rst text2",
+            "rst_label2",
+        ),
+    ),
+    (
+        366,
+        13,
+        Text2Label(
+            "rst text5",
+            "_1",
+        ),
+    ),
+    (
+        387,
+        13,
+        Text2Label(
+            "rst text6",
+            "_2",
+        ),
+    ),
+    (
+        408,
+        37,
+        Text2Dest(
+            "rst text_label7",
+            "rst_destination7",
+            "",
+        ),
+    ),
+]"#;
+        let res = format!("{:#?}", hc.text2dest_label);
+        //eprintln!("{}", res);
+        assert_eq!(hc.text2dest_label.len(), 8);
+        assert_eq!(res, expected);
+
+        let expected = r#"[
+    (
+        "_1",
+        "rst_label5",
+    ),
+    (
+        "_2",
+        "rst_label6",
+    ),
+]"#;
+
+        let res = format!("{:#?}", hc.label2label);
+        assert_eq!(hc.label2label.len(), 2);
+        assert_eq!(res, expected);
+
+        //eprintln!("{:#?}", c.label2dest);
+        assert_eq!(hc.label2dest.len(), 5);
+        assert_eq!(
+            *hc.label2dest.get("md label1").unwrap(),
+            (Cow::from("md_destination1"), Cow::from("md title1"))
+        );
+        assert_eq!(
+            *hc.label2dest.get("md label5").unwrap(),
+            (Cow::from("md_destination5"), Cow::from("md title5"))
+        );
+        assert_eq!(
+            *hc.label2dest.get("rst label3").unwrap(),
+            (Cow::from("rst_destination3"), Cow::from(""))
+        );
+        assert_eq!(
+            *hc.label2dest.get("rst label4").unwrap(),
+            (Cow::from("rst_destination4"), Cow::from(""))
+        );
+        assert_eq!(
+            *hc.label2dest.get("rst text_label7").unwrap(),
+            (Cow::from("rst_destination7"), Cow::from(""))
+        );
+    }
+
+    #[test]
+    fn test_resolve_label2label_references() {
+        let i = r#"label2_
+.. _label2: rst_destination2
+  .. _label5: label4_
+  .. _label1: nolabel_
+  .. _label4: label3_
+  .. _label3: label2_
+"#;
+
+        let mut hc = HyperlinkCollection::from(i, false);
+        hc.resolve_label2label_references();
+        //eprintln!("{:#?}", hc);
+        assert_eq!(hc.label2label.len(), 1);
+        assert_eq!(
+            hc.label2label[0],
+            (Cow::from("label1"), Cow::from("nolabel"))
+        );
+
+        assert_eq!(hc.label2dest.len(), 4);
+        assert_eq!(
+            *hc.label2dest.get("label2").unwrap(),
+            (Cow::from("rst_destination2"), Cow::from(""))
+        );
+        assert_eq!(
+            *hc.label2dest.get("label3").unwrap(),
+            (Cow::from("rst_destination2"), Cow::from(""))
+        );
+        assert_eq!(
+            *hc.label2dest.get("label4").unwrap(),
+            (Cow::from("rst_destination2"), Cow::from(""))
+        );
+        assert_eq!(
+            *hc.label2dest.get("label5").unwrap(),
+            (Cow::from("rst_destination2"), Cow::from(""))
+        );
+    }
+
+    #[test]
+    fn test_resolve_text2label_references() {
+        let i = r#"abc[text1][label1]abc
+        abc [text2](destination2 "title2")
+          [label3]: destination3 "title3"
+          [label1]: destination1 "title1"
+           .. _label4: label3_
+        abc[label3]abc[label5]abc
+        label4_
+        "#;
+
+        let mut hc = HyperlinkCollection::from(i, false);
+        //eprintln!("{:#?}", hc);
+        hc.resolve_label2label_references();
+        //eprintln!("{:#?}", hc);
+        hc.resolve_text2label_references();
+        //eprintln!("{:#?}", hc);
+
+        let expected = vec![
+            (
+                3,
+                15,
+                Link::Text2Dest(
+                    Cow::from("text1"),
+                    Cow::from("destination1"),
+                    Cow::from("title1"),
+                ),
+            ),
+            (
+                34,
+                30,
+                Link::Text2Dest(
+                    Cow::from("text2"),
+                    Cow::from("destination2"),
+                    Cow::from("title2"),
+                ),
+            ),
+            (
+                191,
+                8,
+                Link::Text2Dest(
+                    Cow::from("label3"),
+                    Cow::from("destination3"),
+                    Cow::from("title3"),
+                ),
+            ),
+            (
+                202,
+                8,
+                Link::Text2Label(Cow::from("label5"), Cow::from("label5")),
+            ),
+            (
+                222,
+                7,
+                Link::Text2Dest(
+                    Cow::from("label4"),
+                    Cow::from("destination3"),
+                    Cow::from("title3"),
+                ),
+            ),
+        ];
+        assert_eq!(hc.text2dest_label, expected);
+    }
+
+    #[test]
+    fn test_resolve_text2label_references2() {
+        let i = r#"
+abc `text1 <label1_>`_abc
+abc text_label2_ abc
+abc text3__ abc
+abc text_label4_ abc
+abc text5__ abc
+  .. _label1: destination1
+  .. _text_label2: destination2
+  .. __: destination3
+  __ destination5
+        "#;
+
+        let mut hc = HyperlinkCollection::from(i, false);
+        //eprintln!("{:#?}", hc);
+        hc.resolve_label2label_references();
+        //eprintln!("{:#?}", hc);
+        hc.resolve_text2label_references();
+        //eprintln!("{:#?}", hc);
+
+        let expected = vec![
+            (
+                5,
+                18,
+                Link::Text2Dest(Cow::from("text1"), Cow::from("destination1"), Cow::from("")),
+            ),
+            (
+                31,
+                12,
+                Link::Text2Dest(
+                    Cow::from("text_label2"),
+                    Cow::from("destination2"),
+                    Cow::from(""),
+                ),
+            ),
+            (
+                52,
+                7,
+                Link::Text2Dest(Cow::from("text3"), Cow::from("destination3"), Cow::from("")),
+            ),
+            (
+                68,
+                12,
+                Link::Text2Label(Cow::from("text_label4"), Cow::from("text_label4")),
+            ),
+            (
+                89,
+                7,
+                Link::Text2Dest(Cow::from("text5"), Cow::from("destination5"), Cow::from("")),
+            ),
+        ];
+        assert_eq!(hc.text2dest_label, expected);
+    }
+
+    #[test]
+    fn test_resolve_text2label_references3() {
+        let i = r#"
+abc[my homepage]abc
+abc
+
+[my homepage]: https://getreu.net
+abc"#;
+
+        let mut hc = HyperlinkCollection::from(i, false);
+        eprintln!("{:#?}", hc);
+        hc.resolve_label2label_references();
+        //eprintln!("{:#?}", hc);
+        hc.resolve_text2label_references();
+        //eprintln!("{:#?}", hc);
+
+        let expected = vec![(
+            4,
+            13,
+            Link::Text2Dest(
+                Cow::from("my homepage"),
+                Cow::from("https://getreu.net"),
+                Cow::from(""),
+            ),
+        )];
+        assert_eq!(hc.text2dest_label, expected);
+    }
+
+    #[test]
+    fn test_next() {
+        let i = r#"abc[text0](destination0)abc
+abc[text1][label1]abc
+abc [text2](destination2 "title2")
+  [label3]: destination3 "title3"
+  [label1]: destination1 "title1"
+   .. _label4: label3_
+abc[label3]abc[label5]abc
+label4_
+        "#;
+
+        let mut iter = Hyperlink::new(i, false);
+
+        let expected = (Cow::from("text0"), Cow::from("destination0"), Cow::from(""));
+        let item = iter.next().unwrap();
+        //eprintln!("item: {:#?}", item);
+        assert_eq!(item.1, expected);
+
+        let expected = (
+            Cow::from("text1"),
+            Cow::from("destination1"),
+            Cow::from("title1"),
+        );
+        let item = iter.next().unwrap();
+        //eprintln!("item: {:#?}", item);
+        assert_eq!(item.1, expected);
+
+        let expected = (
+            Cow::from("text2"),
+            Cow::from("destination2"),
+            Cow::from("title2"),
+        );
+        let item = iter.next().unwrap();
+        //eprintln!("item: {:#?}", item);
+        assert_eq!(item.1, expected);
+
+        let expected = (
+            Cow::from("label3"),
+            Cow::from("destination3"),
+            Cow::from("title3"),
+        );
+        let item = iter.next().unwrap();
+        //eprintln!("item: {:#?}", item);
+        assert_eq!(item.1, expected);
+
+        let expected = (
+            Cow::from("label4"),
+            Cow::from("destination3"),
+            Cow::from("title3"),
+        );
+        let item = iter.next().unwrap();
+        //eprintln!("item: {:#?}", item);
+        assert_eq!(item.1, expected);
+
+        let expected = None;
+        let item = iter.next();
+        //eprintln!("item: {:#?}", item);
+        assert_eq!(item, expected);
+
+        let expected = None;
+        let item = iter.next();
+        //eprintln!("item: {:#?}", item);
+        assert_eq!(item, expected);
+    }
+}

--- a/deps/parse-hyperlinks/src/lib.rs
+++ b/deps/parse-hyperlinks/src/lib.rs
@@ -1,0 +1,131 @@
+//! Library and application for parsing hyperlinks and link reference
+//! definitions in Markdown, reStructuredText, Asciidoc and HTML format. The
+//! library implements the
+//! [CommonMark Specification 0.30](https://spec.commonmark.org/0.30/),
+//! [reStructuredText Markup Specification](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html)
+//! (revision 8571, date 2020-10-28),
+//! [Asciidoctor User Manual, chapter 26](https://asciidoctor.org/docs/user-manual/#url) (date 2020-12-03),
+//! the
+//! [HTML 5.2: section 4.5.](https://www.w3.org/TR/html52/textlevel-semantics.html#the-a-element)
+//! specification
+//! and the [Wikitext v1.0.0](https://www.mediawiki.org/wiki/Specs/wikitext/1.0.0)
+//! specification.
+#![allow(dead_code)]
+
+pub mod iterator;
+pub mod parser;
+pub mod renderer;
+
+use nom::error::Error;
+use nom::error::ErrorKind;
+use nom::error::ParseError;
+use nom::Err;
+use nom::IResult;
+
+/// A parser similar to `nom::bytes::complete::take_until()`, except that this
+/// one does not stop at balanced opening and closing tags. It is designed to
+/// work inside the `nom::sequence::delimited()` parser.
+///
+/// # Basic usage
+/// ```
+/// use nom::bytes::complete::tag;
+/// use nom::sequence::delimited;
+/// use parse_hyperlinks::take_until_unbalanced;
+///
+/// let mut parser = delimited(tag("<"), take_until_unbalanced('<', '>'), tag(">"));
+/// assert_eq!(parser("<<inside>inside>abc"), Ok(("abc", "<inside>inside")));
+/// ```
+/// It skips nested brackets until it finds an extra unbalanced closing bracket. Escaped brackets
+/// like `\<` and `\>` are not considered as brackets and are not counted. This function is
+/// very similar to `nom::bytes::complete::take_until(">")`, except it also takes nested brackets.
+pub fn take_until_unbalanced(
+    opening_bracket: char,
+    closing_bracket: char,
+) -> impl Fn(&str) -> IResult<&str, &str> {
+    move |i: &str| {
+        let mut index = 0;
+        let mut bracket_counter = 0;
+        while let Some(n) = &i[index..].find(&[opening_bracket, closing_bracket, '\\'][..]) {
+            index += n;
+            let mut it = i[index..].chars();
+            match it.next().unwrap_or_default() {
+                c if c == '\\' => {
+                    // Skip the escape char `\`.
+                    index += '\\'.len_utf8();
+                    // Skip also the following char.
+                    let c = it.next().unwrap_or_default();
+                    index += c.len_utf8();
+                }
+                c if c == opening_bracket => {
+                    bracket_counter += 1;
+                    index += opening_bracket.len_utf8();
+                }
+                c if c == closing_bracket => {
+                    // Closing bracket.
+                    bracket_counter -= 1;
+                    index += closing_bracket.len_utf8();
+                }
+                // Can not happen.
+                _ => unreachable!(),
+            };
+            // We found the unmatched closing bracket.
+            if bracket_counter == -1 {
+                // We do not consume it.
+                index -= closing_bracket.len_utf8();
+                return Ok((&i[index..], &i[0..index]));
+            };
+        }
+
+        if bracket_counter == 0 {
+            Ok(("", i))
+        } else {
+            Err(Err::Error(Error::from_error_kind(i, ErrorKind::TakeUntil)))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nom::error::ErrorKind;
+
+    #[test]
+    fn test_take_until_unmatched() {
+        assert_eq!(take_until_unbalanced('(', ')')("abc"), Ok(("", "abc")));
+        assert_eq!(
+            take_until_unbalanced('(', ')')("url)abc"),
+            Ok((")abc", "url"))
+        );
+        assert_eq!(
+            take_until_unbalanced('(', ')')("u()rl)abc"),
+            Ok((")abc", "u()rl"))
+        );
+        assert_eq!(
+            take_until_unbalanced('(', ')')("u(())rl)abc"),
+            Ok((")abc", "u(())rl"))
+        );
+        assert_eq!(
+            take_until_unbalanced('(', ')')("u(())r()l)abc"),
+            Ok((")abc", "u(())r()l"))
+        );
+        assert_eq!(
+            take_until_unbalanced('(', ')')("u(())r()labc"),
+            Ok(("", "u(())r()labc"))
+        );
+        assert_eq!(
+            take_until_unbalanced('(', ')')(r#"u\((\))r()labc"#),
+            Ok(("", r#"u\((\))r()labc"#))
+        );
+        assert_eq!(
+            take_until_unbalanced('(', ')')("u(())r(labc"),
+            Err(nom::Err::Error(nom::error::Error::new(
+                "u(())r(labc",
+                ErrorKind::TakeUntil
+            )))
+        );
+        assert_eq!(
+            take_until_unbalanced('€', 'ü')("€uü€€üürlüabc"),
+            Ok(("üabc", "€uü€€üürl"))
+        );
+    }
+}

--- a/deps/parse-hyperlinks/src/lib.rs
+++ b/deps/parse-hyperlinks/src/lib.rs
@@ -53,7 +53,9 @@ pub fn take_until_unbalanced(
                     // Skip the escape char `\`.
                     index += '\\'.len_utf8();
                     // Skip also the following char.
-                    let c = it.next().unwrap_or_default();
+                    let c = it.next().ok_or_else(|| {
+                        Err::Error(Error::from_error_kind(i, ErrorKind::TakeUntil))
+                    })?;
                     index += c.len_utf8();
                 }
                 c if c == opening_bracket => {

--- a/deps/parse-hyperlinks/src/parser/asciidoc.rs
+++ b/deps/parse-hyperlinks/src/parser/asciidoc.rs
@@ -1,0 +1,765 @@
+//! This module implements parsers for Asciidoc hyperlinks.
+#![allow(dead_code)]
+#![allow(clippy::type_complexity)]
+
+use crate::parser::parse::LABEL_LEN_MAX;
+use crate::parser::Link;
+use nom::branch::alt;
+use nom::bytes::complete::tag;
+use nom::bytes::complete::tag_no_case;
+use nom::character::complete::char;
+use nom::character::complete::space0;
+use nom::combinator::peek;
+use nom::error::ErrorKind;
+use percent_encoding::percent_decode_str;
+use std::borrow::Cow;
+
+/// Wrapper around `adoc_text2dest()` that packs the result in
+/// `Link::Text2Dest`.
+pub fn adoc_text2dest_link(i: &str) -> nom::IResult<&str, Link> {
+    let (i, (te, de, ti)) = adoc_text2dest(i)?;
+    Ok((i, Link::Text2Dest(te, de, ti)))
+}
+
+/// Parses an Asciidoc _inline link_.
+///
+/// This parser expects to start at the first letter of `http://`,
+/// `https://`, `link:http://` or `link:https://` (preceded by optional
+/// whitespaces) to succeed.
+///
+/// When it starts at the letter `h` or `l`, the caller must guarantee, that:
+/// * the parser is at the beginning of the input _or_
+/// * the preceding byte is a newline `\n` _or_
+/// * the preceding bytes are whitespaces _or_
+/// * the preceding bytes are whitespaces or newline, followed by one of `[(<`
+///
+/// When ist starts at a whitespace no further guarantee is required.
+///
+/// `link_title` is always the empty `Cow::Borrowed("")`.
+/// ```
+/// use parse_hyperlinks::parser::Link;
+/// use parse_hyperlinks::parser::asciidoc::adoc_text2dest;
+/// use std::borrow::Cow;
+///
+/// assert_eq!(
+///   adoc_text2dest("https://destination[name]abc"),
+///   Ok(("abc", (Cow::from("name"), Cow::from("https://destination"), Cow::from(""))))
+/// );
+/// assert_eq!(
+///   adoc_text2dest("https://destination[]abc"),
+///   Ok(("abc", (Cow::from("https://destination"), Cow::from("https://destination"), Cow::from(""))))
+/// );
+/// assert_eq!(
+///   adoc_text2dest("https://destination abc"),
+///   Ok((" abc", (Cow::from("https://destination"), Cow::from("https://destination"), Cow::from(""))))
+/// );
+/// ```
+pub fn adoc_text2dest(i: &str) -> nom::IResult<&str, (Cow<str>, Cow<str>, Cow<str>)> {
+    let (i, (link_destination, link_text)) = nom::sequence::preceded(
+        space0,
+        nom::sequence::pair(
+            adoc_inline_link_destination,
+            nom::combinator::opt(adoc_link_text),
+        ),
+    )(i)?;
+
+    let link_text = if let Some(lt) = link_text {
+        if lt.is_empty() {
+            link_destination.clone()
+        } else {
+            lt
+        }
+    } else {
+        link_destination.clone()
+    };
+
+    Ok((i, (link_text, link_destination, Cow::Borrowed(""))))
+}
+
+/// Wrapper around `adoc_label2dest()` that packs the result in
+/// `Link::Label2Dest`.
+pub fn adoc_label2dest_link(i: &str) -> nom::IResult<&str, Link> {
+    let (i, (te, de, ti)) = adoc_label2dest(i)?;
+    Ok((i, Link::Label2Dest(te, de, ti)))
+}
+
+/// Parses an Asciidoc _link reference definition_.
+///
+/// This parser expects to start at the first letter of `:`,
+/// ` `, or `\t` to succeed.
+///
+/// The caller must guarantee, that:
+/// * the parser is at the beginning of the input _or_
+/// * the preceding byte is a newline `\n`.
+///
+/// `link_label` is always of type `Cow::Borrowed(&str)`.
+/// `link_title` is always the empty `Cow::Borrowed("")`.
+/// ```
+/// use parse_hyperlinks::parser::Link;
+/// use parse_hyperlinks::parser::asciidoc::adoc_label2dest;
+/// use std::borrow::Cow;
+///
+/// assert_eq!(
+///   adoc_label2dest(":label: https://destination\nabc"),
+///   Ok(("\nabc", (Cow::from("label"), Cow::from("https://destination"), Cow::from(""))))
+/// );
+/// ```
+pub fn adoc_label2dest(i: &str) -> nom::IResult<&str, (Cow<str>, Cow<str>, Cow<str>)> {
+    let (i, (link_label, link_destination)) = nom::sequence::preceded(
+        space0,
+        nom::sequence::pair(
+            adoc_parse_colon_reference,
+            nom::sequence::delimited(
+                nom::character::complete::space1,
+                adoc_link_reference_definition_destination,
+                nom::character::complete::space0,
+            ),
+        ),
+    )(i)?;
+
+    if !i.is_empty() {
+        let _ = peek::<&str, _, nom::error::Error<_>, _>(nom::character::complete::newline)(i)?;
+    };
+
+    Ok((
+        i,
+        (
+            Cow::Borrowed(link_label),
+            link_destination,
+            Cow::Borrowed(""),
+        ),
+    ))
+}
+
+/// Wrapper around `adoc_text2label()` that packs the result in
+/// `Link::Text2Label`.
+pub fn adoc_text2label_link(i: &str) -> nom::IResult<&str, Link> {
+    let (i, (te, la)) = adoc_text2label(i)?;
+    Ok((i, Link::Text2Label(te, la)))
+}
+
+/// Parse a Asciidoc _reference link_.
+///
+/// There are three kinds of reference links `Text2Label`: full, collapsed, and
+/// shortcut.
+/// 1. A full reference link `{label}[text]` consists of a link label immediately
+/// followed by a link text. The label matches a link reference definition
+/// elsewhere in the document.
+/// 2. A collapsed reference link `{label}[]` consists of a link label that matches
+///    a link reference definition elsewhere in the document, followed by the string
+///    `[]`. In this case, the function returns an empty _link text_ `""`,
+///    indicating, that the empty string must be replaced later by the link
+///    destination `link_dest` of the matching _link reference definition_
+///    (`Label2Dest`).
+/// 3. A shortcut reference link consists of a link label that matches a link
+///    reference definition elsewhere in the document and is not followed by `[]` or
+///    a link text `[link text]`. This is a shortcut of case 2. above.
+///
+/// This parser expects to start at the beginning of the link `[` to succeed.
+/// It should always run at last position after all other parsers.
+/// ```rust
+/// use parse_hyperlinks::parser::Link;
+/// use parse_hyperlinks::parser::asciidoc::adoc_text2label;
+/// use std::borrow::Cow;
+///
+/// assert_eq!(
+///   adoc_text2label("{link-label}[link text]abc"),
+///   Ok(("abc", (Cow::from("link text"), Cow::from("link-label"))))
+/// );
+/// assert_eq!(
+///   adoc_text2label("{link-label}[]abc"),
+///   Ok(("abc", (Cow::from(""), Cow::from("link-label"))))
+/// );
+/// assert_eq!(
+///   adoc_text2label("{link-label}abc"),
+///   Ok(("abc", (Cow::from(""), Cow::from("link-label"))))
+/// );
+/// ```
+pub fn adoc_text2label(i: &str) -> nom::IResult<&str, (Cow<str>, Cow<str>)> {
+    let (i, (link_label, link_text)) = alt((
+        nom::sequence::pair(adoc_parse_curly_bracket_reference, adoc_link_text),
+        nom::combinator::map(adoc_parse_curly_bracket_reference, |s| (s, Cow::from(""))),
+    ))(i)?;
+
+    // Check that there is no `[` or `{` following. Do not consume.
+    if !i.is_empty() {
+        let _ = nom::character::complete::none_of("[{")(i)?;
+    }
+
+    Ok((i, (link_text, link_label)))
+}
+
+/// Parses the link label. To succeed the first letter must be `[` and the
+/// last letter `]`. A sequence of whitespaces including newlines, will be
+/// replaced by one space. There must be not contain more than one newline
+/// per sequence. The string can contain the `\]` which is replaced by `]`.
+fn adoc_link_text(i: &str) -> nom::IResult<&str, Cow<str>> {
+    nom::sequence::delimited(char('['), remove_newline_take_till(']'), char(']'))(i)
+}
+
+/// Takes all characters until the character `<pat>`. The escaped character
+/// `\<pat>` is taken as normal character. Then parser replaces the escaped character
+/// `\<pat>` with `<pat>`. A sequence of whitespaces including one newline, is
+/// replaced by one space ` `. Each sequence must not contain more than one
+/// newline.
+fn remove_newline_take_till<'a>(
+    pat: char,
+) -> impl Fn(&'a str) -> nom::IResult<&'a str, Cow<'a, str>> {
+    move |i: &str| {
+        let mut res = Cow::Borrowed("");
+        let mut j = i;
+        while !j.is_empty() {
+            // `till()` always succeeds. There are two situations, when it does not
+            // advance the parser:
+            // 1. Input is the empty string `""`.
+            // 2. The first character satisfy the condition of `take_till()`.
+            //
+            // Case 1.: Can not happen because of the `while` just before.
+            // Case 2.: Even if the parser does not advance here, the code below
+            // starting with `if let Ok...` it will advance the parser at least
+            // one character.
+            let (k, s1) =
+                nom::bytes::complete::take_till(|c| c == pat || c == '\n' || c == '\\')(j)?;
+
+            // Store the result.
+            res = match res {
+                Cow::Borrowed("") => Cow::Borrowed(s1),
+                Cow::Borrowed(res_str) => {
+                    let mut strg = res_str.to_string();
+                    strg.push_str(s1);
+                    Cow::Owned(strg)
+                }
+                Cow::Owned(mut strg) => {
+                    strg.push_str(s1);
+                    Cow::Owned(strg)
+                }
+            };
+
+            // If there is a character left, inspect. Then either quit or advance at least one character.
+            // Therefor no endless is loop possible.
+            if let (_, Some(c)) =
+                nom::combinator::opt(nom::combinator::peek(nom::character::complete::anychar))(k)?
+            {
+                let m = match c {
+                    // We completed our mission and found `pat`.
+                    // This is the only Ok exit from the while loop.
+                    c if c == pat => return Ok((k, res)),
+                    // We stopped at an escaped character.
+                    c if c == '\\' => {
+                        // Consume the escape `\`.
+                        let (l, _) = char('\\')(k)?;
+                        // `pat` is the only valid escaped character (not even `\\` is special in
+                        // Asciidoc).
+                        // If `<pat>` is found, `c=='<pat>'`, otherwise `c=='\\'`
+                        let (l, c) = alt((char(pat), nom::combinator::success('\\')))(l)?;
+
+                        // and append the escaped character to `res`.
+                        let mut strg = res.to_string();
+                        strg.push(c);
+                        // Store the result.
+                        res = Cow::Owned(strg);
+                        // Advance `k`.
+                        l
+                    }
+                    // We stopped at a newline.
+                    c if c == '\n' => {
+                        // Now consume the `\n`.
+                        let (l, _) = char('\n')(k)?;
+                        let (l, _) = space0(l)?;
+                        // Return error if there is one more `\n`. BTW, `not()` never consumes.
+                        let _ = nom::combinator::not(char('\n'))(l)?;
+
+                        // and append one space ` ` character to `res`.
+                        let mut strg = res.to_string();
+                        strg.push(' ');
+                        // Store the result.
+                        res = Cow::Owned(strg);
+                        // Advance `k`.
+                        l
+                    }
+                    _ => unreachable!(),
+                };
+                j = m;
+            } else {
+                // We are here because `k == ""`. We quit the while loop.
+                j = k;
+            }
+        }
+
+        // If we are here, `j` is empty `""`.
+        Ok(("", res))
+    }
+}
+
+/// Parses an link reference definition destination.
+/// The parser takes URLs until `[`, whitespace or newline.
+/// The parser succeeds, if one of the variants:
+/// `adoc_parse_http_link_destination()` or
+/// `adoc_parse_escaped_link_destination()` succeeds and returns its result.
+fn adoc_link_reference_definition_destination(i: &str) -> nom::IResult<&str, Cow<str>> {
+    alt((
+        adoc_parse_http_link_destination,
+        adoc_parse_escaped_link_destination,
+    ))(i)
+}
+
+/// Parses an inline link destination.
+/// The parser succeeds, if one of the variants:
+/// `adoc_parse_http_link_destination()`, `adoc_parse_literal_link_destination()`
+/// or `adoc_parse_escaped_link_destination()` succeeds and returns its result.
+fn adoc_inline_link_destination(i: &str) -> nom::IResult<&str, Cow<str>> {
+    alt((
+        adoc_parse_http_link_destination,
+        adoc_parse_literal_link_destination,
+        adoc_parse_escaped_link_destination,
+    ))(i)
+}
+
+/// Parses a link destination in URL form starting with `http://` or `https://`
+/// and ending with `[`. The latter is peeked, but no consumed.
+fn adoc_parse_http_link_destination(i: &str) -> nom::IResult<&str, Cow<str>> {
+    let (j, s) = nom::sequence::preceded(
+        peek(alt((tag_no_case("http://"), (tag_no_case("https://"))))),
+        nom::bytes::complete::take_till1(|c| c == '[' || c == ' ' || c == '\t' || c == '\n'),
+    )(i)?;
+    Ok((j, Cow::Borrowed(s)))
+}
+
+/// A parser that decodes percent encoded URLS.
+/// Fails when the percent codes can not be mapped to valid UTF8.
+/// ```text
+/// use std::borrow::Cow;
+///
+/// let res = percent_decode("https://getreu.net/?q=%5Ba%20b%5D").unwrap();
+/// assert_eq!(res, ("", Cow::Owned("https://getreu.net/?q=[a b]".to_string())));
+///```
+fn percent_decode(i: &str) -> nom::IResult<&str, Cow<str>> {
+    let decoded = percent_decode_str(i)
+        .decode_utf8()
+        .map_err(|_| nom::Err::Error(nom::error::Error::new(i, ErrorKind::EscapedTransform)))?;
+    Ok(("", decoded))
+}
+
+/// Parses a link destination starting with `link:http://` or `link:https://` ending
+/// with `]`, whitespace or newline. The later is peeked, but not consumed. The URL can contain percent
+/// encoded characters, which are decoded.
+fn adoc_parse_escaped_link_destination(i: &str) -> nom::IResult<&str, Cow<str>> {
+    nom::combinator::map_parser(
+        nom::sequence::preceded(
+            nom::sequence::pair(
+                tag("link:"),
+                peek(alt((tag_no_case("http://"), (tag_no_case("https://"))))),
+            ),
+            nom::bytes::complete::take_till1(|c| {
+                c == '[' || c == ' ' || c == '\t' || c == '\r' || c == '\n'
+            }),
+        ),
+        percent_decode,
+    )(i)
+}
+
+/// Parses a link destination starting with `link:+++` ending with `++`. Everything in
+/// between is taken as it is without any transformation.
+fn adoc_parse_literal_link_destination(i: &str) -> nom::IResult<&str, Cow<str>> {
+    let (j, s) = nom::sequence::preceded(
+        tag("link:"),
+        nom::sequence::delimited(tag("++"), nom::bytes::complete::take_until("++"), tag("++")),
+    )(i)?;
+    Ok((j, Cow::Borrowed(s)))
+}
+
+/// Parses the _link text_ (`label`) of `Label2Text` link.
+///
+/// The parser expects to start at the opening `{` to succeed.
+/// The result is always a borrowed reference.
+fn adoc_parse_curly_bracket_reference(i: &str) -> nom::IResult<&str, Cow<str>> {
+    nom::combinator::map(
+        nom::combinator::verify(
+            nom::sequence::delimited(
+                char('{'),
+                nom::bytes::complete::take_till1(|c| {
+                    c == '}' || c == ' ' || c == '\t' || c == '\r'
+                }),
+                char('}'),
+            ),
+            |s: &str| s.len() <= LABEL_LEN_MAX,
+        ),
+        Cow::Borrowed,
+    )(i)
+}
+
+/// Parses the label of a link reference definition.
+///
+/// The parser expects to start at the first colon `:` or at some whitespace to
+/// succeed.
+/// The caller must guaranty, that the byte before was a newline. The parser
+/// consumes all whitespace before the first colon and after the second.
+fn adoc_parse_colon_reference(i: &str) -> nom::IResult<&str, &str> {
+    nom::combinator::verify(
+        nom::sequence::delimited(
+            char(':'),
+            nom::bytes::complete::take_till1(|c| c == ':' || c == ' ' || c == '\t' || c == '\r'),
+            char(':'),
+        ),
+        |s: &str| s.len() <= LABEL_LEN_MAX,
+    )(i)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nom::error::ErrorKind;
+    use std::matches;
+
+    #[test]
+    fn test_adoc_text2dest() {
+        assert_eq!(
+            adoc_text2dest("http://getreu.net[]"),
+            Ok((
+                "",
+                (
+                    Cow::from("http://getreu.net"),
+                    Cow::from("http://getreu.net"),
+                    Cow::from("")
+                )
+            ))
+        );
+
+        assert_eq!(
+            adoc_text2dest("http://getreu.net[]abc"),
+            Ok((
+                "abc",
+                (
+                    Cow::from("http://getreu.net"),
+                    Cow::from("http://getreu.net"),
+                    Cow::from("")
+                )
+            ))
+        );
+
+        assert_eq!(
+            adoc_text2dest("  \t  http://getreu.net[My blog]abc"),
+            Ok((
+                "abc",
+                (
+                    Cow::from("My blog"),
+                    Cow::from("http://getreu.net"),
+                    Cow::from("")
+                )
+            ))
+        );
+
+        assert_eq!(
+            adoc_text2dest(r#"http://getreu.net[My blog[1\]]abc"#),
+            Ok((
+                "abc",
+                (
+                    Cow::from("My blog[1]"),
+                    Cow::from("http://getreu.net"),
+                    Cow::from("")
+                )
+            ))
+        );
+
+        assert_eq!(
+            adoc_text2dest("http://getreu.net[My\n    blog]abc"),
+            Ok((
+                "abc",
+                (
+                    Cow::from("My blog"),
+                    Cow::from("http://getreu.net"),
+                    Cow::from("")
+                )
+            ))
+        );
+
+        assert_eq!(
+            adoc_text2dest("link:http://getreu.net[My blog]abc"),
+            Ok((
+                "abc",
+                (
+                    Cow::from("My blog"),
+                    Cow::from("http://getreu.net"),
+                    Cow::from("")
+                )
+            ))
+        );
+
+        assert_eq!(
+            adoc_text2dest("link:https://getreu.net/?q=%5Ba%20b%5D[My blog]abc"),
+            Ok((
+                "abc",
+                (
+                    Cow::from("My blog"),
+                    Cow::from("https://getreu.net/?q=[a b]"),
+                    Cow::from("")
+                )
+            ))
+        );
+
+        assert_eq!(
+            adoc_text2dest("link:++https://getreu.net/?q=[a b]++[My blog]abc"),
+            Ok((
+                "abc",
+                (
+                    Cow::from("My blog"),
+                    Cow::from("https://getreu.net/?q=[a b]"),
+                    Cow::from("")
+                )
+            ))
+        );
+    }
+
+    #[test]
+    fn test_adoc_label2dest() {
+        assert_eq!(
+            adoc_label2dest(":label: http://getreu.net\n"),
+            Ok((
+                "\n",
+                (
+                    Cow::from("label"),
+                    Cow::from("http://getreu.net"),
+                    Cow::from("")
+                )
+            ))
+        );
+
+        assert_eq!(
+            adoc_label2dest("  :label: \thttp://getreu.net \t "),
+            Ok((
+                "",
+                (
+                    Cow::from("label"),
+                    Cow::from("http://getreu.net"),
+                    Cow::from("")
+                )
+            ))
+        );
+
+        assert_eq!(
+            adoc_label2dest("  :label: \thttp://getreu.net \t abc").unwrap_err(),
+            nom::Err::Error(nom::error::Error::new("abc", ErrorKind::Char))
+        );
+    }
+
+    #[test]
+    fn test_adoc_link_text() {
+        assert_eq!(adoc_link_text("[text]abc"), Ok(("abc", Cow::from("text"))));
+
+        assert_eq!(
+            adoc_link_text("[te\nxt]abc"),
+            Ok(("abc", Cow::from("te xt")))
+        );
+
+        assert_eq!(
+            adoc_link_text("[te\n\nxt]abc"),
+            Err(nom::Err::Error(nom::error::Error::new(
+                "\nxt]abc",
+                ErrorKind::Not
+            )))
+        );
+
+        assert_eq!(
+            adoc_link_text(r#"[text[i\]]abc"#),
+            Ok(("abc", Cow::from(r#"text[i]"#.to_string())))
+        );
+
+        assert_eq!(
+            adoc_link_text("[textabc"),
+            Err(nom::Err::Error(nom::error::Error::new("", ErrorKind::Char)))
+        );
+    }
+
+    #[test]
+    fn test_remove_newline_take_till() {
+        let res = remove_newline_take_till(']')("").unwrap();
+        assert_eq!(res, ("", Cow::from("")));
+        assert!(matches!(res.1, Cow::Borrowed { .. }));
+
+        let res = remove_newline_take_till(']')("text text]abc").unwrap();
+        assert_eq!(res, ("]abc", Cow::from("text text")));
+        assert!(matches!(res.1, Cow::Borrowed { .. }));
+
+        let res = remove_newline_take_till(']')("text text").unwrap();
+        assert_eq!(res, ("", Cow::from("text text")));
+        assert!(matches!(res.1, Cow::Borrowed { .. }));
+
+        let res = remove_newline_take_till(']')(r#"te\]xt]abc"#).unwrap();
+        assert_eq!(res, ("]abc", Cow::from("te]xt")));
+        assert!(matches!(res.1, Cow::Owned { .. }));
+
+        let res = remove_newline_take_till(']')(r#"text\]]abc"#).unwrap();
+        assert_eq!(res, ("]abc", Cow::from("text]")));
+        assert!(matches!(res.1, Cow::Owned { .. }));
+
+        let res = remove_newline_take_till(']')(r#"te\xt]abc"#).unwrap();
+        assert_eq!(res, ("]abc", Cow::from(r#"te\xt"#)));
+        assert!(matches!(res.1, Cow::Owned { .. }));
+
+        let res = remove_newline_take_till(']')("text\n   text]abc").unwrap();
+        assert_eq!(res, ("]abc", Cow::from("text text")));
+        assert!(matches!(res.1, Cow::Owned { .. }));
+
+        let res = remove_newline_take_till(']')("text\n   text]abc").unwrap();
+        assert_eq!(res, ("]abc", Cow::from("text text")));
+        assert!(matches!(res.1, Cow::Owned { .. }));
+
+        assert_eq!(
+            remove_newline_take_till(']')("text\n\ntext]abc").unwrap_err(),
+            nom::Err::Error(nom::error::Error::new("\ntext]abc", ErrorKind::Not))
+        );
+
+        assert_eq!(
+            remove_newline_take_till(']')("text\n  \n  text]abc").unwrap_err(),
+            nom::Err::Error(nom::error::Error::new("\n  text]abc", ErrorKind::Not))
+        );
+    }
+
+    #[test]
+    fn test_adoc_parse_http_link_destination() {
+        let res = adoc_parse_http_link_destination("http://destination/").unwrap();
+        assert_eq!(res, ("", Cow::from("http://destination/")));
+        assert!(matches!(res.1, Cow::Borrowed { .. }));
+
+        let res = adoc_parse_http_link_destination("http://destination/\nabc").unwrap();
+        assert_eq!(res, ("\nabc", Cow::from("http://destination/")));
+        assert!(matches!(res.1, Cow::Borrowed { .. }));
+
+        let res = adoc_parse_http_link_destination("http://destination/ abc").unwrap();
+        assert_eq!(res, (" abc", Cow::from("http://destination/")));
+        assert!(matches!(res.1, Cow::Borrowed { .. }));
+
+        let res = adoc_parse_http_link_destination("http://destination/[abc").unwrap();
+        assert_eq!(res, ("[abc", Cow::from("http://destination/")));
+        assert!(matches!(res.1, Cow::Borrowed { .. }));
+
+        let res = adoc_parse_http_link_destination("https://destination/[abc").unwrap();
+        assert_eq!(res, ("[abc", Cow::from("https://destination/")));
+        assert!(matches!(res.1, Cow::Borrowed { .. }));
+
+        assert_eq!(
+            adoc_parse_http_link_destination("http:/destination/[abc").unwrap_err(),
+            nom::Err::Error(nom::error::Error::new(
+                "http:/destination/[abc",
+                ErrorKind::Tag
+            ))
+        );
+    }
+
+    #[test]
+    fn test_adoc_parse_escaped_link_destination() {
+        let res = adoc_parse_escaped_link_destination("link:http://destination/").unwrap();
+        assert_eq!(res, ("", Cow::from("http://destination/")));
+        assert!(matches!(res.1, Cow::Borrowed { .. }));
+
+        let res = adoc_parse_escaped_link_destination("link:http://destination/[abc").unwrap();
+        assert_eq!(res, ("[abc", Cow::from("http://destination/")));
+        assert!(matches!(res.1, Cow::Borrowed { .. }));
+
+        let res = adoc_parse_escaped_link_destination("link:http://destination/ abc").unwrap();
+        assert_eq!(res, (" abc", Cow::from("http://destination/")));
+        assert!(matches!(res.1, Cow::Borrowed { .. }));
+
+        let res = adoc_parse_escaped_link_destination("link:http://destination/\nabc").unwrap();
+        assert_eq!(res, ("\nabc", Cow::from("http://destination/")));
+        assert!(matches!(res.1, Cow::Borrowed { .. }));
+
+        assert_eq!(
+            adoc_parse_escaped_link_destination("link:httpX:/destination/[abc").unwrap_err(),
+            nom::Err::Error(nom::error::Error::new(
+                "httpX:/destination/[abc",
+                ErrorKind::Tag
+            ))
+        );
+
+        let res = adoc_parse_escaped_link_destination("link:https://getreu.net/?q=%5Ba%20b%5D[abc")
+            .unwrap();
+        assert_eq!(res, ("[abc", Cow::from("https://getreu.net/?q=[a b]")));
+        assert!(matches!(res.1, Cow::Owned { .. }));
+
+        assert_eq!(
+            adoc_parse_escaped_link_destination("link:https://getreu.net/?q=%FF%FF[abc")
+                .unwrap_err(),
+            nom::Err::Error(nom::error::Error::new(
+                "https://getreu.net/?q=%FF%FF",
+                ErrorKind::EscapedTransform
+            ))
+        );
+    }
+
+    #[test]
+    fn test_adoc_parse_literal_link_destination() {
+        let res = adoc_parse_literal_link_destination("link:++https://getreu.net/?q=[a b]++[abc")
+            .unwrap();
+        assert_eq!(res, ("[abc", Cow::from("https://getreu.net/?q=[a b]")));
+
+        assert_eq!(
+            adoc_parse_literal_link_destination("link:++https://getreu.net/?q=[a b]+[abc")
+                .unwrap_err(),
+            nom::Err::Error(nom::error::Error::new(
+                "https://getreu.net/?q=[a b]+[abc",
+                ErrorKind::TakeUntil
+            ))
+        );
+    }
+
+    #[test]
+    fn test_adoc_text2label() {
+        let res = adoc_text2label("{label}[link text]abc").unwrap();
+        assert_eq!(res, ("abc", (Cow::from("link text"), Cow::from("label"))));
+
+        let res = adoc_text2label("{label}[]abc").unwrap();
+        assert_eq!(res, ("abc", (Cow::from(""), Cow::from("label"))));
+
+        let res = adoc_text2label("{label}abc").unwrap();
+        assert_eq!(res, ("abc", (Cow::from(""), Cow::from("label"))));
+
+        let res = adoc_text2label("{label}").unwrap();
+        assert_eq!(res, ("", (Cow::from(""), Cow::from("label"))));
+
+        let res = adoc_text2label("{label} [link text]abc").unwrap();
+        assert_eq!(
+            res,
+            (" [link text]abc", (Cow::from(""), Cow::from("label")))
+        );
+
+        assert_eq!(
+            adoc_text2label("{label}[abc").unwrap_err(),
+            nom::Err::Error(nom::error::Error::new("[abc", ErrorKind::NoneOf))
+        );
+    }
+
+    #[test]
+    fn test_adoc_parse_curly_bracket_reference() {
+        let res = adoc_parse_curly_bracket_reference("{label}").unwrap();
+        assert_eq!(res, ("", Cow::from("label")));
+
+        let res = adoc_parse_curly_bracket_reference("{label}[link text]").unwrap();
+        assert_eq!(res, ("[link text]", Cow::from("label")));
+
+        assert_eq!(
+            adoc_parse_curly_bracket_reference("").unwrap_err(),
+            nom::Err::Error(nom::error::Error::new("", ErrorKind::Char))
+        );
+
+        assert_eq!(
+            adoc_parse_curly_bracket_reference("{label }").unwrap_err(),
+            nom::Err::Error(nom::error::Error::new(" }", ErrorKind::Char))
+        );
+        assert_eq!(
+            adoc_parse_curly_bracket_reference("").unwrap_err(),
+            nom::Err::Error(nom::error::Error::new("", ErrorKind::Char))
+        );
+    }
+
+    #[test]
+    fn test_adoc_parse_colon_reference() {
+        let res = adoc_parse_colon_reference(":label:abc").unwrap();
+        assert_eq!(res, ("abc", "label"));
+
+        assert_eq!(
+            adoc_parse_colon_reference(":label abc").unwrap_err(),
+            nom::Err::Error(nom::error::Error::new(" abc", ErrorKind::Char))
+        );
+    }
+}

--- a/deps/parse-hyperlinks/src/parser/html.rs
+++ b/deps/parse-hyperlinks/src/parser/html.rs
@@ -1,0 +1,335 @@
+//! This module implements parsers for HTML hyperlinks.
+#![allow(dead_code)]
+#![allow(clippy::type_complexity)]
+
+use crate::parser::Link;
+use html_escape::decode_html_entities;
+use nom::branch::alt;
+use nom::bytes::complete::is_not;
+use nom::bytes::complete::tag;
+use nom::character::complete::alphanumeric1;
+use nom::error::Error;
+use nom::error::ErrorKind;
+use std::borrow::Cow;
+
+/// Wrapper around `html_text2dest()` that packs the result in
+/// `Link::Text2Dest`.
+pub fn html_text2dest_link(i: &str) -> nom::IResult<&str, Link> {
+    let (i, (te, de, ti)) = html_text2dest(i)?;
+    Ok((i, Link::Text2Dest(te, de, ti)))
+}
+
+/// Parse an HTML _inline hyperlink_.
+///
+/// It returns either `Ok((i, (link_text, link_destination, link_title)))` or some error.
+///
+/// The parser expects to start at the link start (`<`) to succeed.
+/// ```
+/// use parse_hyperlinks::parser::Link;
+/// use parse_hyperlinks::parser::html::html_text2dest;
+/// use std::borrow::Cow;
+///
+/// assert_eq!(
+///   html_text2dest(r#"<a href="destination" title="title">name</a>abc"#),
+///   Ok(("abc", (Cow::from("name"), Cow::from("destination"), Cow::from("title"))))
+/// );
+/// ```
+pub fn html_text2dest(i: &str) -> nom::IResult<&str, (Cow<str>, Cow<str>, Cow<str>)> {
+    let (i, ((link_destination, link_title), link_text)) = nom::sequence::terminated(
+        nom::sequence::pair(
+            tag_a_opening,
+            alt((
+                nom::bytes::complete::take_until("</a>"),
+                nom::bytes::complete::take_until("</A>"),
+            )),
+        ),
+        // HTML is case insensitive. XHTML, that is being XML is case sensitive.
+        // Here we deal with HTML.
+        alt((tag("</a>"), tag("</A>"))),
+    )(i)?;
+    let link_text = decode_html_entities(link_text);
+    Ok((i, (link_text, link_destination, link_title)))
+}
+
+/// Parses a `<a ...>` opening tag and returns
+/// either `Ok((i, (link_destination, link_title)))` or some error.
+fn tag_a_opening(i: &str) -> nom::IResult<&str, (Cow<str>, Cow<str>)> {
+    nom::sequence::delimited(
+        // HTML is case insensitive. XHTML, that is being XML is case sensitive.
+        // Here we deal with HTML.
+        alt((tag("<a "), tag("<A "))),
+        nom::combinator::map_parser(is_not(">"), parse_attributes),
+        tag(">"),
+    )(i)
+}
+
+/// Parses attributes and returns `Ok((name, value))`.
+/// Boolean attributes are ignored, but silently consumed.
+fn attribute(i: &str) -> nom::IResult<&str, (&str, Cow<str>)> {
+    alt((
+        nom::sequence::pair(
+            nom::combinator::verify(alphanumeric1, |s: &str| {
+                nom::character::is_alphabetic(s.as_bytes()[0])
+            }),
+            alt((
+                nom::combinator::value(Cow::from(""), tag(r#"="""#)),
+                nom::combinator::value(Cow::from(""), tag(r#"=''"#)),
+                nom::combinator::map(
+                    nom::sequence::delimited(tag("=\""), is_not("\""), tag("\"")),
+                    |s: &str| decode_html_entities(s),
+                ),
+                nom::combinator::map(
+                    nom::sequence::delimited(tag("='"), is_not("'"), tag("'")),
+                    |s: &str| decode_html_entities(s),
+                ),
+                nom::combinator::map(nom::sequence::preceded(tag("="), is_not(" ")), |s: &str| {
+                    decode_html_entities(s)
+                }),
+            )),
+        ),
+        // Consume boolean attributes.
+        nom::combinator::value(
+            ("", Cow::from("")),
+            nom::combinator::verify(alphanumeric1, |s: &str| {
+                nom::character::is_alphabetic(s.as_bytes()[0])
+            }),
+        ),
+    ))(i)
+}
+
+/// Parses a whitespace separated list of attributes and returns a vector of (name, value).
+pub fn attribute_list<'a>(i: &'a str) -> nom::IResult<&'a str, Vec<(&'a str, Cow<str>)>> {
+    let i = i.trim();
+    nom::multi::separated_list1(nom::character::complete::multispace1, attribute)(i)
+}
+
+/// Extracts the `href` and `title` attributes and returns
+/// `Ok((link_destination, link_title))`. `link_title` can be empty,
+/// `link_destination` not.
+fn parse_attributes(i: &str) -> nom::IResult<&str, (Cow<str>, Cow<str>)> {
+    let (i, attributes) = attribute_list(i)?;
+    let mut href = Cow::Borrowed("");
+    let mut title = Cow::Borrowed("");
+
+    for (name, value) in attributes {
+        if name == "href" {
+            // Make sure `href` is empty, it can appear only
+            // once.
+            if !(&*href).is_empty() {
+                return Err(nom::Err::Error(Error::new(name, ErrorKind::ManyMN)));
+            }
+            href = value;
+        } else if name == "title" {
+            // Make sure `title` is empty, it can appear only
+            // once.
+            if !(&*title).is_empty() {
+                return Err(nom::Err::Error(Error::new(name, ErrorKind::ManyMN)));
+            }
+            title = value;
+        }
+    }
+
+    // Assure that `href` is not empty.
+    if (&*href).is_empty() {
+        return Err(nom::Err::Error(Error::new(i, ErrorKind::Eof)));
+    };
+
+    Ok((i, (href, title)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_html_text2dest() {
+        let expected = (
+            "abc",
+            (
+                Cow::from("W3Schools"),
+                Cow::from("https://www.w3schools.com/"),
+                Cow::from("W3S"),
+            ),
+        );
+        assert_eq!(
+            html_text2dest(r#"<a title="W3S" href="https://www.w3schools.com/">W3Schools</a>abc"#)
+                .unwrap(),
+            expected
+        );
+        assert_eq!(
+            html_text2dest(r#"<A title="W3S" href="https://www.w3schools.com/">W3Schools</A>abc"#)
+                .unwrap(),
+            expected
+        );
+
+        let expected = ("abc", (Cow::from("<n>"), Cow::from("h"), Cow::from("t")));
+        assert_eq!(
+            html_text2dest(r#"<a title="t" href="h">&lt;n&gt;</a>abc"#).unwrap(),
+            expected
+        );
+
+        let expected = ("abc", (Cow::from("name"), Cow::from("url"), Cow::from("")));
+        assert_eq!(
+            html_text2dest(r#"<a href="url" title="" >name</a>abc"#).unwrap(),
+            expected
+        );
+
+        let expected = (
+            "abc",
+            (Cow::from("na</me"), Cow::from("url"), Cow::from("")),
+        );
+        assert_eq!(
+            html_text2dest(r#"<a href="url" title="" >na</me</A>abc"#).unwrap(),
+            expected
+        );
+
+        let expected = nom::Err::Error(nom::error::Error::new(
+            r#"<a href="url" title="" >name</a abc"#,
+            nom::error::ErrorKind::AlphaNumeric,
+        ));
+        assert_eq!(
+            parse_attributes(r#"<a href="url" title="" >name</a abc"#).unwrap_err(),
+            expected
+        );
+
+        let expected = (
+            "abc",
+            (
+                Cow::from(
+                    "<img src=\"w3html.gif\" alt=\"W3Schools.com \"width=\"100\" height=\"132\">",
+                ),
+                Cow::from("https://blog.getreu.net"),
+                Cow::from(""),
+            ),
+        );
+        assert_eq!(
+            html_text2dest(
+                "<a href=\"https://blog.getreu.net\">\
+                              <img src=\"w3html.gif\" alt=\"W3Schools.com \"\
+                              width=\"100\" height=\"132\">\
+                              </a>abc"
+            )
+            .unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn test_tag_a_opening() {
+        let expected = (
+            "abc",
+            (Cow::from("http://getreu.net"), Cow::from("My blog")),
+        );
+        assert_eq!(
+            tag_a_opening(r#"<a href="http://getreu.net" title="My blog">abc"#).unwrap(),
+            expected
+        );
+        assert_eq!(
+            tag_a_opening(r#"<A href="http://getreu.net" title="My blog">abc"#).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn test_parse_attributes() {
+        let expected = ("", (Cow::from("http://getreu.net"), Cow::from("My blog")));
+        assert_eq!(
+            parse_attributes(r#"abc href="http://getreu.net" abc title="My blog" abc"#).unwrap(),
+            expected
+        );
+
+        let expected = nom::Err::Error(nom::error::Error::new(
+            "href",
+            nom::error::ErrorKind::ManyMN,
+        ));
+        assert_eq!(
+            parse_attributes(r#" href="http://getreu.net" href="http://blog.getreu.net" "#)
+                .unwrap_err(),
+            expected
+        );
+
+        let expected = nom::Err::Error(nom::error::Error::new(
+            "title",
+            nom::error::ErrorKind::ManyMN,
+        ));
+        assert_eq!(
+            parse_attributes(r#" href="http://getreu.net" title="a" title="b" "#).unwrap_err(),
+            expected
+        );
+
+        let expected = nom::Err::Error(nom::error::Error::new("", nom::error::ErrorKind::Eof));
+        assert_eq!(
+            parse_attributes(r#" title="title" "#).unwrap_err(),
+            expected
+        );
+    }
+
+    #[test]
+    fn test_attribute_list() {
+        let expected = (
+            "",
+            vec![
+                ("", Cow::from("")),
+                ("href", Cow::from("http://getreu.net")),
+                ("", Cow::from("")),
+                ("title", Cow::from("My blog")),
+                ("", Cow::from("")),
+            ],
+        );
+        assert_eq!(
+            attribute_list(r#"abc href="http://getreu.net" abc title="My blog" abc"#).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn test_attribute() {
+        let expected = (" abc", ("href", Cow::from("http://getreu.net")));
+        assert_eq!(
+            attribute(r#"href="http://getreu.net" abc"#).unwrap(),
+            expected
+        );
+        assert_eq!(
+            attribute(r#"href='http://getreu.net' abc"#).unwrap(),
+            expected
+        );
+        // Only allowed when no space in value.
+        assert_eq!(
+            attribute(r#"href=http://getreu.net abc"#).unwrap(),
+            expected
+        );
+
+        let expected = (" abc", ("href", Cow::from("http://getreu.net/<>")));
+        assert_eq!(
+            attribute(r#"href="http://getreu.net/&lt;&gt;" abc"#).unwrap(),
+            expected
+        );
+        assert_eq!(
+            attribute(r#"href='http://getreu.net/&lt;&gt;' abc"#).unwrap(),
+            expected
+        );
+        // Only allowed when no space in value.
+        assert_eq!(
+            attribute(r#"href=http://getreu.net/&lt;&gt; abc"#).unwrap(),
+            expected
+        );
+
+        let expected = (" abc", ("", Cow::from("")));
+        assert_eq!(attribute("bool abc").unwrap(), expected);
+
+        let expected = nom::Err::Error(nom::error::Error::new(
+            "1name",
+            nom::error::ErrorKind::Verify,
+        ));
+        assert_eq!(attribute("1name").unwrap_err(), expected);
+
+        let expected = nom::Err::Error(nom::error::Error::new(
+            r#"1name="http://getreu.net"#,
+            nom::error::ErrorKind::Verify,
+        ));
+        assert_eq!(
+            attribute(r#"1name="http://getreu.net"#).unwrap_err(),
+            expected
+        );
+    }
+}

--- a/deps/parse-hyperlinks/src/parser/markdown.rs
+++ b/deps/parse-hyperlinks/src/parser/markdown.rs
@@ -1,0 +1,805 @@
+//! This module implements parsers for Markdown hyperlinks.
+#![allow(dead_code)]
+#![allow(clippy::type_complexity)]
+
+use crate::parser::parse::LABEL_LEN_MAX;
+use crate::parser::Link;
+use crate::take_until_unbalanced;
+use nom::branch::alt;
+use nom::bytes::complete::tag;
+use nom::character::complete::multispace1;
+use nom::combinator::*;
+use std::borrow::Cow;
+
+/// The following character are escapable in _link text_, _link label_, _link
+/// destination_ and _link title_.
+const ESCAPABLE: &str = r#"\'"()[]{}<>"#;
+
+/// Wrapper around `md_text2dest()` that packs the result in
+/// `Link::Text2Dest`.
+pub fn md_text2dest_link(i: &str) -> nom::IResult<&str, Link> {
+    let (i, (te, de, ti)) = md_text2dest(i)?;
+    Ok((i, Link::Text2Dest(te, de, ti)))
+}
+
+/// Parses a Markdown _inline link_.
+///
+/// This parser expects to start at the beginning of the link `[` to succeed.
+/// ```
+/// use parse_hyperlinks::parser::Link;
+/// use parse_hyperlinks::parser::markdown::md_text2dest;
+/// use std::borrow::Cow;
+///
+/// assert_eq!(
+///   md_text2dest(r#"[text](<destination> "title")abc"#),
+///   Ok(("abc", (Cow::from("text"), Cow::from("destination"), Cow::from("title"))))
+/// );
+/// ```
+pub fn md_text2dest(i: &str) -> nom::IResult<&str, (Cow<str>, Cow<str>, Cow<str>)> {
+    let (i, link_text) = md_link_text(i)?;
+    let (i, (link_destination, link_title)) = md_link_destination_enclosed(i)?;
+    Ok((i, (link_text, link_destination, link_title)))
+}
+
+/// Wrapper around `md_label2dest()` that packs the result in
+/// `Link::Label2Dest`.
+pub fn md_label2dest_link(i: &str) -> nom::IResult<&str, Link> {
+    let (i, (l, d, t)) = md_label2dest(i)?;
+    Ok((i, Link::Label2Dest(l, d, t)))
+}
+
+/// Matches a Markdown _link reference definition_.
+///
+/// The caller must guarantee, that the parser starts at first character of the
+/// input or at the first character of a line. The parser consumes all bytes
+/// until the end of the line.
+/// ```
+/// use parse_hyperlinks::parser::Link;
+/// use parse_hyperlinks::parser::markdown::md_label2dest;
+/// use std::borrow::Cow;
+///
+/// assert_eq!(
+///   md_label2dest("   [label]: <destination> 'title'\nabc"),
+///   Ok(("\nabc", (Cow::from("label"), Cow::from("destination"), Cow::from("title"))))
+/// );
+/// ```
+///
+/// [CommonMark
+/// Spec](https://spec.commonmark.org/0.30/#link-reference-definition)\ A [link
+/// reference
+/// definition](https://spec.commonmark.org/0.30/#link-reference-definition)
+/// consists of a [link label](https://spec.commonmark.org/0.30/#link-label),
+/// optionally preceded by up to three spaces of indentation, followed by a
+/// colon (`:`), optional spaces or tabs (including up to one [line
+/// ending](https://spec.commonmark.org/0.30/#line-ending)), a [link
+/// destination](https://spec.commonmark.org/0.30/#link-destination), optional
+/// spaces or tabs (including up to one [line
+/// ending](https://spec.commonmark.org/0.30/#line-ending)), and an optional
+/// [link title](https://spec.commonmark.org/0.30/#link-title), which if it is
+/// present must be separated from the [link
+/// destination](https://spec.commonmark.org/0.30/#link-destination) by spaces
+/// or tabs. No further character may occur.
+///
+/// A [link reference
+/// definition](https://spec.commonmark.org/0.30/#link-reference-definition)
+/// does not correspond to a structural element of a document. Instead, it
+/// defines a label which can be used in [reference
+/// links](https://spec.commonmark.org/0.30/#reference-link) and reference-style
+/// [images](https://spec.commonmark.org/0.30/#images) elsewhere in the
+/// document. [Link reference
+/// definitions](https://spec.commonmark.org/0.30/#link-reference-definition)
+/// can come either before or after the links that use them.
+pub fn md_label2dest(i: &str) -> nom::IResult<&str, (Cow<str>, Cow<str>, Cow<str>)> {
+    // Consume up to three spaces.
+    let (i, _) = nom::bytes::complete::take_while_m_n(0, 3, |c| c == ' ')(i)?;
+    // Take label.
+    let (i, link_text) = md_link_label(i)?;
+    let (i, _) = nom::character::complete::char(':')(i)?;
+    // Take spaces.
+    let (i, _) = verify(nom::character::complete::multispace1, |s: &str| {
+        !s.contains("\n\n")
+    })(i)?;
+    // Take destination.
+    let (i, link_destination) = md_link_destination(i)?;
+    // Try, but do not fail.
+    let (i, link_title) = alt((
+        // Take link title.
+        md_link_title,
+        nom::combinator::success(Cow::from("")),
+    ))(i)?;
+
+    // Now consume as much whitespace as possible.
+    let (i, _) = nom::character::complete::space0(i)?;
+
+    // Check if there is newline coming. Do not consume.
+    if !i.is_empty() {
+        let _ = nom::character::complete::newline(i)?;
+    }
+
+    Ok((i, (link_text, link_destination, link_title)))
+}
+
+/// Wrapper around `md_text2label()` that packs the result in
+/// `Link::Text2Label`.
+pub fn md_text2label_link(i: &str) -> nom::IResult<&str, Link> {
+    let (i, (t, l)) = md_text2label(i)?;
+    Ok((i, Link::Text2Label(t, l)))
+}
+
+/// Parse a Markdown _reference link_.
+///
+/// There are three kinds of reference links: full, collapsed, and shortcut.
+/// 1. A full reference link consists of a link text immediately followed by a
+///    link label that matches a link reference definition elsewhere in the
+///    document.
+/// 2. A collapsed reference link consists of a link label that matches a link
+///    reference definition elsewhere in the document, followed by the string [].
+///    The contents of the first link label are parsed as inlines, which are used as
+///    the link’s text. The link’s URI and title are provided by the matching
+///    reference link definition. Thus, `[foo][]` is equivalent to `[foo][foo]`.
+/// 3. A shortcut reference link consists of a link label that matches a link
+///    reference definition elsewhere in the document and is not followed by [] or a
+///    link label. The contents of the first link label are parsed as inlines, which
+///    are used as the link’s text. The link’s URI and title are provided by the
+///    matching link reference definition. Thus, `[foo]` is equivalent to `[foo][]`.
+///
+/// This parser expects to start at the beginning of the link `[` to succeed.
+/// It should always run at last position after all other parsers.
+/// ```rust
+/// use parse_hyperlinks::parser::Link;
+/// use parse_hyperlinks::parser::markdown::md_text2label;
+/// use std::borrow::Cow;
+///
+/// assert_eq!(
+///   md_text2label("[link text][link label]abc"),
+///   Ok(("abc", (Cow::from("link text"), Cow::from("link label"))))
+/// );
+/// assert_eq!(
+///   md_text2label("[link text][]abc"),
+///   Ok(("abc", (Cow::from("link text"), Cow::from("link text"))))
+/// );
+/// assert_eq!(
+///   md_text2label("[link text]abc"),
+///   Ok(("abc", (Cow::from("link text"), Cow::from("link text"))))
+/// );
+/// ```
+pub fn md_text2label(i: &str) -> nom::IResult<&str, (Cow<str>, Cow<str>)> {
+    let (i, (link_text, link_label)) = alt((
+        nom::sequence::pair(md_link_text, md_link_label),
+        nom::combinator::map(nom::sequence::terminated(md_link_text, tag("[]")), |s| {
+            (s.clone(), s)
+        }),
+        nom::combinator::map(md_link_text, |s| (s.clone(), s)),
+    ))(i)?;
+
+    // Check that there is no `[` or `(` following. Do not consume.
+    if !i.is_empty() {
+        let _ = nom::character::complete::none_of("[(")(i)?;
+    }
+
+    Ok((i, (link_text, link_label)))
+}
+
+/// Parses _link text_.
+/// Brackets are allowed in the
+/// [link text](https://spec.commonmark.org/0.29/#link-text) only if (a) they are
+/// backslash-escaped or (b) they appear as a matched pair of brackets, with
+/// an open bracket `[`, a sequence of zero or more inlines, and a close
+/// bracket `]`.
+/// [CommonMark Spec](https://spec.commonmark.org/0.29/#link-text)
+fn md_link_text(i: &str) -> nom::IResult<&str, Cow<str>> {
+    nom::combinator::map_parser(
+        nom::sequence::delimited(tag("["), take_until_unbalanced('[', ']'), tag("]")),
+        md_escaped_str_transform,
+    )(i)
+}
+
+/// Parses _link label_.
+/// A link label begins with a left bracket ([) and ends with the first right
+/// bracket (]) that is not backslash-escaped. Between these brackets there must
+/// be at least one non-whitespace character. Unescaped square bracket characters
+/// are not allowed inside the opening and closing square brackets of link
+/// labels. A link label can have at most 999 characters inside the square
+/// brackets (TODO).
+/// [CommonMark Spec](https://spec.commonmark.org/0.29/#link-label)
+fn md_link_label(i: &str) -> nom::IResult<&str, Cow<str>> {
+    nom::combinator::map_parser(
+        nom::combinator::verify(
+            nom::sequence::delimited(
+                tag("["),
+                nom::bytes::complete::escaped(
+                    nom::character::complete::none_of(r#"\[]"#),
+                    '\\',
+                    nom::character::complete::one_of(ESCAPABLE),
+                ),
+                tag("]"),
+            ),
+            |l: &str| l.len() <= LABEL_LEN_MAX,
+        ),
+        md_escaped_str_transform,
+    )(i)
+}
+
+/// This is a wrapper around `md_parse_link_destination()`. It takes its result
+/// and removes the `\` before the escaped characters `ESCAPABLE`.
+fn md_link_destination(i: &str) -> nom::IResult<&str, Cow<str>> {
+    nom::combinator::map_parser(md_parse_link_destination, md_escaped_str_transform)(i)
+}
+
+/// A [link destination](https://spec.commonmark.org/0.30/#link-destination)
+/// consists of either
+///
+/// * a sequence of zero or more characters between an opening `<` and a
+/// closing `>` that contains no line endings or unescaped `<` or `>`
+/// characters, or
+/// * a nonempty sequence of characters that does not start with `<`, does not
+/// include [ASCII control
+/// characters](https://spec.commonmark.org/0.30/#ascii-control-character) or
+/// [space](https://spec.commonmark.org/0.30/#space) character, and includes
+/// parentheses only if (a) they are backslash-escaped or (b) they are part of a
+/// balanced pair of unescaped parentheses. (Implementations may impose limits
+/// on parentheses nesting to avoid performance issues, but at least three
+/// levels of nesting should be supported.)
+fn md_parse_link_destination(i: &str) -> nom::IResult<&str, &str> {
+    alt((
+        nom::sequence::delimited(
+            tag("<"),
+            nom::bytes::complete::escaped(
+                nom::character::complete::none_of(r#"\<>"#),
+                '\\',
+                nom::character::complete::one_of(ESCAPABLE),
+            ),
+            tag(">"),
+        ),
+        map(nom::bytes::complete::tag("<>"), |_| ""),
+        alt((
+            nom::bytes::complete::is_not(" \t\r\n"),
+            nom::combinator::success(""),
+        )),
+    ))(i)
+}
+
+/// Matches `md_link_destination` in parenthesis.
+fn md_link_destination_enclosed(i: &str) -> nom::IResult<&str, (Cow<str>, Cow<str>)> {
+    let (rest, inner) =
+        nom::sequence::delimited(tag("("), take_until_unbalanced('(', ')'), tag(")"))(i)?;
+    let (i, link_destination) = md_link_destination(inner)?;
+    let (_i, link_title) = alt((
+        // Take link title.
+        md_link_title,
+        nom::combinator::success(Cow::from("")),
+    ))(i)?;
+
+    Ok((rest, (link_destination, link_title)))
+}
+
+/// This is a wrapper around `md_parse_link_title()`. It takes its result
+/// and removes the `\` before the escaped characters `ESCAPABLE`.
+fn md_link_title(i: &str) -> nom::IResult<&str, Cow<str>> {
+    nom::combinator::map_parser(md_parse_link_title, md_escaped_str_transform)(i)
+}
+
+/// A link title is always preceded one or more whitespace inluding
+/// one newline.
+/// [CommonMark Spec](https://spec.commonmark.org/0.29/#link-title)
+/// A [link title](https://spec.commonmark.org/0.29/#link-title) consists of either
+///
+///  - a sequence of zero or more characters between straight double-quote
+///    characters (`"`), including a `"` character only if it is
+///    backslash-escaped, or
+///  - a sequence of zero or more characters between straight single-quote
+///    characters (`'`), including a `'` character only if it is
+///    backslash-escaped, or
+///  - a sequence of zero or more characters between matching parentheses
+///    (`(...)`), including a `(` or `)` character only if it is
+///    backslash-escaped.
+///
+///  Although [link titles](https://spec.commonmark.org/0.29/#link-title) may
+///  span multiple lines, they may not contain a [blank
+///  line](https://spec.commonmark.org/0.29/#blank-line).
+fn md_parse_link_title(i: &str) -> nom::IResult<&str, &str> {
+    nom::sequence::preceded(
+        verify(multispace1, |s: &str| !s.contains("\n\n")),
+        verify(
+            alt((
+                nom::sequence::delimited(tag("("), take_until_unbalanced('(', ')'), tag(")")),
+                nom::sequence::delimited(
+                    tag("'"),
+                    nom::bytes::complete::escaped(
+                        nom::character::complete::none_of(r#"\'"#),
+                        '\\',
+                        nom::character::complete::one_of(ESCAPABLE),
+                    ),
+                    tag("'"),
+                ),
+                nom::sequence::delimited(
+                    tag("\""),
+                    nom::bytes::complete::escaped(
+                        nom::character::complete::none_of(r#"\""#),
+                        '\\',
+                        nom::character::complete::one_of(ESCAPABLE),
+                    ),
+                    tag("\""),
+                ),
+            )),
+            |s: &str| !s.contains("\n\n"),
+        ),
+    )(i)
+}
+
+/// Remove the `\` before the escaped characters `ESCAPABLE`.
+fn md_escaped_str_transform(i: &str) -> nom::IResult<&str, Cow<str>> {
+    nom::combinator::map(
+        nom::bytes::complete::escaped_transform(
+            nom::bytes::complete::is_not("\\"),
+            '\\',
+            nom::character::complete::one_of(ESCAPABLE),
+        ),
+        |s| if s == i { Cow::from(i) } else { Cow::from(s) },
+    )(i)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nom::error::ErrorKind;
+
+    #[test]
+    fn test_md_text2dest() {
+        assert_eq!(
+            md_text2dest("[text](url)abc"),
+            Ok(("abc", (Cow::from("text"), Cow::from("url"), Cow::from(""))))
+        );
+        assert_eq!(
+            md_text2dest("[text[i]](url)abc"),
+            Ok((
+                "abc",
+                (Cow::from("text[i]"), Cow::from("url"), Cow::from(""))
+            ))
+        );
+        assert_eq!(
+            md_text2dest("[text[i]](ur(l))abc"),
+            Ok((
+                "abc",
+                (Cow::from("text[i]"), Cow::from("ur(l)"), Cow::from(""))
+            ))
+        );
+        assert_eq!(
+            md_text2dest("[text(url)"),
+            Err(nom::Err::Error(nom::error::Error::new("", ErrorKind::Tag)))
+        );
+        assert_eq!(
+            md_text2dest("[text](<url>)abc"),
+            Ok(("abc", (Cow::from("text"), Cow::from("url"), Cow::from(""))))
+        );
+        assert_eq!(
+            md_text2dest("[text](<url> \"link title\")abc"),
+            Ok((
+                "abc",
+                (Cow::from("text"), Cow::from("url"), Cow::from("link title"))
+            ))
+        );
+        assert_eq!(
+            md_text2dest("[text](url \"link title\")abc"),
+            Ok((
+                "abc",
+                (Cow::from("text"), Cow::from("url"), Cow::from("link title"))
+            ))
+        );
+        // [Example 483](https://spec.commonmark.org/0.30/#example-483)
+        assert_eq!(
+            md_text2dest("[](./target.md)abc"),
+            Ok((
+                "abc",
+                (Cow::from(""), Cow::from("./target.md"), Cow::from(""))
+            ))
+        );
+        // [Example 484](https://spec.commonmark.org/0.30/#example-484)
+        assert_eq!(
+            md_text2dest("[link]()abc"),
+            Ok(("abc", (Cow::from("link"), Cow::from(""), Cow::from(""))))
+        );
+        // [Example 485](https://spec.commonmark.org/0.30/#example-485)
+        assert_eq!(
+            md_text2dest("[link](<>)abc"),
+            Ok(("abc", (Cow::from("link"), Cow::from(""), Cow::from(""))))
+        );
+        // [Example 486](https://spec.commonmark.org/0.30/#example-486)
+        assert_eq!(
+            md_text2dest("[]()abc"),
+            Ok(("abc", (Cow::from(""), Cow::from(""), Cow::from(""))))
+        );
+    }
+
+    #[test]
+    fn test_md_text2label() {
+        assert_eq!(
+            md_text2label("[link text][link label]abc"),
+            Ok(("abc", (Cow::from("link text"), Cow::from("link label"))))
+        );
+        assert_eq!(
+            md_text2label("[link text][]abc"),
+            Ok(("abc", (Cow::from("link text"), Cow::from("link text"))))
+        );
+        assert_eq!(
+            md_text2label("[link text]abc"),
+            Ok(("abc", (Cow::from("link text"), Cow::from("link text"))))
+        );
+        assert_eq!(
+            md_text2label("[]abc"),
+            Ok(("abc", (Cow::from(""), Cow::from(""))))
+        );
+        assert_eq!(
+            md_text2label(""),
+            Err(nom::Err::Error(nom::error::Error::new("", ErrorKind::Tag)))
+        );
+        // Check end of input position.
+        assert_eq!(
+            md_text2label("[text]"),
+            Ok(("", (Cow::from("text"), Cow::from("text"))))
+        );
+        assert_eq!(
+            md_text2label("[text][text]"),
+            Ok(("", (Cow::from("text"), Cow::from("text"))))
+        );
+        assert_eq!(
+            md_text2label("[text][label url"),
+            Err(nom::Err::Error(nom::error::Error::new(
+                "[label url",
+                ErrorKind::NoneOf
+            )))
+        );
+        assert_eq!(
+            md_text2label("[text](url)abc"),
+            Err(nom::Err::Error(nom::error::Error::new(
+                "(url)abc",
+                ErrorKind::NoneOf
+            )))
+        );
+    }
+
+    #[test]
+    fn test_md_label2dest() {
+        assert_eq!(
+            md_label2dest("[text]: url\nabc"),
+            Ok((
+                "\nabc",
+                (Cow::from("text"), Cow::from("url"), Cow::from(""))
+            ))
+        );
+        assert_eq!(
+            md_label2dest("[text]: url  \nabc"),
+            Ok((
+                "\nabc",
+                (Cow::from("text"), Cow::from("url"), Cow::from(""))
+            ))
+        );
+        assert_eq!(
+            md_label2dest("[text]: <url url> \nabc"),
+            Ok((
+                "\nabc",
+                (Cow::from("text"), Cow::from("url url"), Cow::from(""))
+            ))
+        );
+        assert_eq!(
+            md_label2dest("[text]: url \"title\"\nabc"),
+            Ok((
+                "\nabc",
+                (Cow::from("text"), Cow::from("url"), Cow::from("title"))
+            ))
+        );
+        assert_eq!(
+            md_label2dest("[text]: url\n\"title\"\nabc"),
+            Ok((
+                "\nabc",
+                (Cow::from("text"), Cow::from("url"), Cow::from("title"))
+            ))
+        );
+        assert_eq!(
+            md_label2dest("   [text]: url\n\"title\"\nabc"),
+            Ok((
+                "\nabc",
+                (Cow::from("text"), Cow::from("url"), Cow::from("title"))
+            ))
+        );
+        assert_eq!(
+            md_label2dest("abc[text]: url\n\"title\""),
+            Err(nom::Err::Error(nom::error::Error::new(
+                "abc[text]: url\n\"title\"",
+                ErrorKind::Tag
+            )))
+        );
+        assert_eq!(
+            md_label2dest("    [text]: url\n\"title\" abc"),
+            Err(nom::Err::Error(nom::error::Error::new(
+                " [text]: url\n\"title\" abc",
+                ErrorKind::Tag
+            )))
+        );
+        // Nested brackets.
+        assert_eq!(
+            md_label2dest("[text\\[i\\]]: ur(l)url\nabc"),
+            Ok((
+                "\nabc",
+                (Cow::from("text[i]"), Cow::from("ur(l)url"), Cow::from(""))
+            ))
+        );
+        // Nested but balanced not allowed for link labels.
+        assert_eq!(
+            md_label2dest("[text[i]]: ur(l)(url"),
+            Err(nom::Err::Error(nom::error::Error::new(
+                "[i]]: ur(l)(url",
+                ErrorKind::Tag
+            )))
+        );
+        // Whitespace can have one newline.
+        assert_eq!(
+            md_label2dest("[text]: \nurl"),
+            Ok(("", (Cow::from("text"), Cow::from("url"), Cow::from(""))))
+        );
+        // But only one newline is allowed.
+        assert_eq!(
+            md_label2dest("[text]: \n\nurl"),
+            Err(nom::Err::Error(nom::error::Error::new(
+                " \n\nurl",
+                ErrorKind::Verify
+            )))
+        );
+        assert_eq!(
+            md_label2dest("[text: url"),
+            Err(nom::Err::Error(nom::error::Error::new("", ErrorKind::Tag)))
+        );
+        assert_eq!(
+            md_label2dest("[text] url"),
+            Err(nom::Err::Error(nom::error::Error::new(
+                " url",
+                ErrorKind::Char
+            )))
+        );
+        assert_eq!(
+            md_label2dest("[text]: url \"link title\"\nabc"),
+            Ok((
+                "\nabc",
+                (Cow::from("text"), Cow::from("url"), Cow::from("link title"))
+            ))
+        );
+        assert_eq!(
+            md_label2dest("[text]: url \"link\ntitle\"\nabc"),
+            Ok((
+                "\nabc",
+                (
+                    Cow::from("text"),
+                    Cow::from("url"),
+                    Cow::from("link\ntitle")
+                )
+            ))
+        );
+        assert_eq!(
+            md_label2dest("[text]: url \"link\ntitle\"abc"),
+            Err(nom::Err::Error(nom::error::Error::new(
+                "abc",
+                ErrorKind::Char
+            )))
+        );
+        assert_eq!(
+            md_label2dest("[text]:\nurl \"link\ntitle\"\nabc"),
+            Ok((
+                "\nabc",
+                (
+                    Cow::from("text"),
+                    Cow::from("url"),
+                    Cow::from("link\ntitle")
+                )
+            ))
+        );
+        assert_eq!(
+            md_label2dest("[text]: url \"link\n\ntitle\"\nabc"),
+            Err(nom::Err::Error(nom::error::Error::new(
+                "\"link\n\ntitle\"\nabc",
+                ErrorKind::Char
+            )))
+        );
+        assert_eq!(
+            md_label2dest("[text]:\n\nurl \"link title\"\nabc"),
+            Err(nom::Err::Error(nom::error::Error::new(
+                "\n\nurl \"link title\"\nabc",
+                ErrorKind::Verify
+            )))
+        );
+    }
+
+    #[test]
+    fn test_md_link_text() {
+        assert_eq!(
+            md_link_text("[text](url)"),
+            Ok(("(url)", Cow::from("text")))
+        );
+        assert_eq!(
+            md_link_text("[text[i]](url)"),
+            Ok(("(url)", Cow::from("text[i]")))
+        );
+        assert_eq!(
+            md_link_text(r#"[text\[i\]](url)"#),
+            Ok(("(url)", Cow::from("text[i]")))
+        );
+        assert_eq!(
+            md_link_text("[text(url)"),
+            Err(nom::Err::Error(nom::error::Error::new("", ErrorKind::Tag)))
+        );
+    }
+
+    #[test]
+    fn test_md_link_label() {
+        assert_eq!(
+            md_link_label("[text]: url"),
+            Ok((": url", Cow::from("text")))
+        );
+        assert_eq!(
+            md_link_label(r#"[text\[i\]]: url"#),
+            Ok((": url", Cow::from("text[i]")))
+        );
+        assert_eq!(
+            md_link_label("[text: url"),
+            Err(nom::Err::Error(nom::error::Error::new("", ErrorKind::Tag)))
+        );
+        assert_eq!(
+            md_link_label("[t[ext: url"),
+            Err(nom::Err::Error(nom::error::Error::new(
+                "[ext: url",
+                ErrorKind::Tag
+            )))
+        );
+    }
+
+    #[test]
+    fn test_md_link_destination() {
+        assert_eq!(
+            md_link_destination("url  abc"),
+            Ok(("  abc", Cow::from("url")))
+        );
+        assert_eq!(md_link_destination("url"), Ok(("", Cow::from("url"))));
+        assert_eq!(
+            md_link_destination("url\nabc"),
+            Ok(("\nabc", Cow::from("url")))
+        );
+        assert_eq!(
+            md_link_destination("<url>abc"),
+            Ok(("abc", Cow::from("url")))
+        );
+        assert_eq!(
+            md_link_destination(r#"<u\<r\>l>abc"#),
+            Ok(("abc", Cow::from(r#"u<r>l"#)))
+        );
+        assert_eq!(
+            md_link_destination(r#"u\)r\(l abc"#),
+            Ok((" abc", Cow::from(r#"u)r(l"#)))
+        );
+        assert_eq!(
+            md_link_destination(r#"u(r)l abc"#),
+            Ok((" abc", Cow::from(r#"u(r)l"#)))
+        );
+        assert_eq!(
+            md_link_destination("u(r)l\nabc"),
+            Ok(("\nabc", Cow::from(r#"u(r)l"#)))
+        );
+    }
+
+    #[test]
+    fn test_md_parse_link_destination() {
+        assert_eq!(md_parse_link_destination("<url>abc"), Ok(("abc", "url")));
+        assert_eq!(
+            md_parse_link_destination(r#"<u\<r\>l>abc"#),
+            Ok(("abc", r#"u\<r\>l"#))
+        );
+        assert_eq!(md_parse_link_destination("<url> abc"), Ok((" abc", "url")));
+        assert_eq!(
+            md_parse_link_destination("<url>\nabc"),
+            Ok(("\nabc", "url"))
+        );
+        assert_eq!(
+            md_parse_link_destination("<url 2>abc"),
+            Ok(("abc", "url 2"))
+        );
+        assert_eq!(md_parse_link_destination("url abc"), Ok((" abc", "url")));
+        assert_eq!(
+            md_parse_link_destination("<url(1)> abc"),
+            Ok((" abc", "url(1)"))
+        );
+        assert_eq!(
+            md_parse_link_destination(r#"<[1a]\[1b\](2a)\(2b\)\<3b\>{4a}\{4b\}> abc"#),
+            Ok((" abc", r#"[1a]\[1b\](2a)\(2b\)\<3b\>{4a}\{4b\}"#))
+        );
+        assert_eq!(
+            md_parse_link_destination("ur()l abc"),
+            Ok((" abc", "ur()l"))
+        );
+        assert_eq!(
+            md_parse_link_destination("ur()l\nabc"),
+            Ok(("\nabc", "ur()l"))
+        );
+        assert_eq!(md_parse_link_destination("<>abc"), Ok(("abc", "")));
+        assert_eq!(md_parse_link_destination("<>\nabc"), Ok(("\nabc", "")));
+        assert_eq!(md_parse_link_destination("url"), Ok(("", "url")));
+        assert_eq!(md_parse_link_destination(""), Ok(("", "")));
+        assert_eq!(md_parse_link_destination("\nabc"), Ok(("\nabc", "")));
+    }
+
+    #[test]
+    fn test_md_escaped_str_transform() {
+        assert_eq!(md_escaped_str_transform(""), Ok(("", Cow::from(""))));
+        // Different than the link destination version.
+        assert_eq!(md_escaped_str_transform("   "), Ok(("", Cow::from("   "))));
+        assert_eq!(
+            md_escaped_str_transform(r#"abc`:<>abc"#),
+            Ok(("", Cow::from(r#"abc`:<>abc"#)))
+        );
+        assert_eq!(
+            md_escaped_str_transform(r#"\<\>\\"#),
+            Ok(("", Cow::from(r#"<>\"#)))
+        );
+        assert_eq!(
+            md_escaped_str_transform(r#"\(\)\\"#),
+            Ok(("", Cow::from(r#"()\"#)))
+        );
+    }
+
+    #[test]
+    fn test_md_link_title() {
+        assert_eq!(
+            md_link_title(" (title)abc"),
+            Ok(("abc", Cow::from("title")))
+        );
+        assert_eq!(
+            md_link_title(" (ti(t)le)abc"),
+            Ok(("abc", Cow::from("ti(t)le")))
+        );
+        assert_eq!(
+            md_link_title(r#" (ti\(t\)le)abc"#),
+            Ok(("abc", Cow::from("ti(t)le")))
+        );
+        assert_eq!(
+            md_link_title(r#" "1\\23\"4\'56"abc"#),
+            Ok(("abc", Cow::from(r#"1\23"4'56"#)))
+        );
+        assert_eq!(
+            md_link_title(" \"tu\nvwxy\"abc"),
+            Ok(("abc", Cow::from("tu\nvwxy")))
+        );
+        assert_eq!(
+            md_link_title(" 'tu\nv\\\'wxy'abc"),
+            Ok(("abc", Cow::from("tu\nv\'wxy")))
+        );
+        assert_eq!(
+            md_link_title(" (ti\n\ntle)abc"),
+            Err(nom::Err::Error(nom::error::Error::new(
+                "(ti\n\ntle)abc",
+                ErrorKind::Verify
+            )))
+        );
+    }
+
+    #[test]
+    fn test_md_parse_link_title() {
+        assert_eq!(md_parse_link_title(" (title)abc"), Ok(("abc", "title")));
+        assert_eq!(md_parse_link_title(" (ti(t)le)abc"), Ok(("abc", "ti(t)le")));
+        assert_eq!(
+            md_parse_link_title(r#" "1\\23\"4\'56"abc"#),
+            Ok(("abc", r#"1\\23\"4\'56"#))
+        );
+        assert_eq!(
+            md_parse_link_title(" \"tu\nvwxy\"abc"),
+            Ok(("abc", "tu\nvwxy"))
+        );
+        assert_eq!(
+            md_parse_link_title(" 'tu\nv\\\'wxy'abc"),
+            Ok(("abc", "tu\nv\\\'wxy"))
+        );
+        assert_eq!(
+            md_parse_link_title(" (ti\n\ntle)abc"),
+            Err(nom::Err::Error(nom::error::Error::new(
+                "(ti\n\ntle)abc",
+                ErrorKind::Verify
+            )))
+        );
+    }
+}

--- a/deps/parse-hyperlinks/src/parser/mod.rs
+++ b/deps/parse-hyperlinks/src/parser/mod.rs
@@ -1,0 +1,151 @@
+//! This module implements parsers to extract hyperlinks and link reference
+//! definitions from text input.
+
+pub mod asciidoc;
+pub mod html;
+pub mod markdown;
+pub mod parse;
+pub mod restructured_text;
+pub mod wikitext;
+
+use std::borrow::Cow;
+
+/// A link can be an _inline link_, a _reference link_, a _link reference
+/// definition_, a combined _inline link / link reference definition_, a
+/// _reference alias_ or an _inline image_. This is the main return type of this
+/// API.
+///
+/// The _link title_ in Markdown is optional, when not given the string is set
+/// to the empty string `""`.  The back ticks \` in reStructuredText can be
+/// omitted when only one word is enclosed without spaces.
+#[derive(Debug, PartialEq, Clone)]
+#[non_exhaustive]
+pub enum Link<'a> {
+    /// In (stand alone) **inline links** the destination and title are given
+    /// immediately after the link text. When an _inline link_ is rendered, only
+    /// the `link_text` is visible in the continuous text.
+    /// * Markdown example:
+    ///   ```md
+    ///       [link_text](link_dest "link title")
+    ///   ```
+    /// * reStructuredText example:
+    ///   ```rst
+    ///       `link_text <link_dest>`__
+    ///   ```
+    /// *  Asciidoc example:
+    ///    ```adoc
+    ///    http://link_dest[link_text]
+    ///    ```
+    /// *  Wikitext example:
+    ///    ```wm
+    ///    [http://link_dest link_text]
+    ///    ```
+    /// The tuple is defined as follows:
+    /// ```text
+    /// Text2Dest(link_text, link_destination, link_title)
+    /// ```
+    Text2Dest(Cow<'a, str>, Cow<'a, str>, Cow<'a, str>),
+
+    /// In **reference links** the destination and title are defined elsewhere in
+    /// the document in some _link reference definition_. When a _reference link_
+    /// is rendered only `link_text` is visible.
+    /// * Markdown examples:
+    ///   ```md
+    ///   [link_text][link_label]
+    ///
+    ///   [link_text]
+    ///   ```
+    ///   When only _link text_ is given, _link label_ is set to the same string.
+    /// * reStructuredText examples:
+    ///   ```rst
+    ///   `link_text <link_label_>`_
+    ///
+    ///   `link_text`_
+    ///   ```
+    ///   When only _link text_ is given, _link label_ is set to the same string.
+    /// * Asciidoc example:
+    ///   ```adoc
+    ///   {link_label}[link_text]
+    ///   ```
+    ///
+    /// The tuple is defined as follows:
+    /// ```text
+    /// Text2Label(link_text, link_label)
+    /// ```
+    Text2Label(Cow<'a, str>, Cow<'a, str>),
+
+    /// A **link reference definition** refers to a _reference link_ with the
+    /// same _link label_. A _link reference definition_ is not visible
+    /// when the document is rendered.
+    /// _link title_ is optional.
+    /// * Markdown example:
+    ///   ```md
+    ///   [link_label]: link_dest "link title"
+    ///   ```
+    /// * reStructuredText examples:
+    ///   ```rst
+    ///   .. _`link_label`: link_dest
+    ///
+    ///   .. __: link_dest
+    ///
+    ///   __ link_dest
+    ///   ```
+    ///   When `__` is given, the _link label_ is set to `"_"`, which is a marker
+    ///   for an anonymous _link label_.
+    /// * Asciidoc example:
+    ///   ```adoc
+    ///   :link_label: http://link_dest
+    ///   ```
+    ///
+    /// The tuple is defined as follows:
+    /// ```text
+    /// Label2Dest(link_label, link_destination, link_title)
+    /// ```
+    Label2Dest(Cow<'a, str>, Cow<'a, str>, Cow<'a, str>),
+
+    /// This type represents a combined **inline link** and **link reference
+    /// definition**.
+    /// Semantically `TextLabel2Dest` is a shorthand for two links `Text2Dest` and
+    /// `Label2Dest` in one object, where _link text_ and _link label_ are the
+    /// same string. When rendered, _link text_ is visible.
+    ///
+    /// * Consider the following reStructuredText link:
+    ///   ```rst
+    ///   `link_text_label <link_dest>`_
+    ///
+    ///   `a <b>`_
+    ///   ```
+    ///   In this link is `b` the _link destination_ and `a` has a double role: it
+    ///   defines _link text_ of the first link `Text2Dest("a", "b", "")` and _link
+    ///   label_ of the second link `Label2Dest("a", "b", "")`.
+    ///
+    /// The tuple is defined as follows:
+    /// ```text
+    /// Label2Dest(link_text_label, link_destination, link_title)
+    /// ```
+    TextLabel2Dest(Cow<'a, str>, Cow<'a, str>, Cow<'a, str>),
+
+    /// The **reference alias** defines an alternative link label
+    /// `alt_link_label` for an existing `link_label` defined elsewhere in the
+    /// document. At some point, the `link_label` must be resolved to a
+    /// `link_destination` by a _link_reference_definition_. A _reference
+    /// alias_ is not visible when the document is rendered.
+    /// This link type is only available in reStructuredText, e.g.
+    /// ```rst
+    /// .. _`alt_link_label`: `link_label`_
+    /// ```
+    ///
+    /// The tuple is defined as follows:
+    /// ```text
+    /// Label2Label(alt_link_label, link_label)
+    /// ```
+    Label2Label(Cow<'a, str>, Cow<'a, str>),
+
+    /// Inline Image.
+    /// The tuple is defined as follows:
+    /// ```text
+    /// Image(img_alt, img_src)
+    /// ```
+    /// Note: this crate does not contain parsers for this variant.
+    Image(Cow<'a, str>, Cow<'a, str>),
+}

--- a/deps/parse-hyperlinks/src/parser/parse.rs
+++ b/deps/parse-hyperlinks/src/parser/parse.rs
@@ -1,0 +1,619 @@
+//! This module implements parsers to extract hyperlinks and link reference
+//! definitions from text input. The parsers search for Markdown,
+//! ReStructuredText, Asciidoc, Wikitext and HTML formatted links.
+#![allow(dead_code)]
+#![allow(clippy::type_complexity)]
+
+use crate::parser::asciidoc::adoc_label2dest_link;
+use crate::parser::asciidoc::adoc_text2dest_link;
+use crate::parser::asciidoc::adoc_text2label_link;
+use crate::parser::html::html_text2dest_link;
+use crate::parser::markdown::md_label2dest_link;
+use crate::parser::markdown::md_text2dest_link;
+use crate::parser::markdown::md_text2label_link;
+use crate::parser::restructured_text::rst_label2dest_link;
+use crate::parser::restructured_text::rst_label2label_link;
+use crate::parser::restructured_text::rst_text2dest_link;
+use crate::parser::restructured_text::rst_text2label_link;
+use crate::parser::restructured_text::rst_text_label2dest_link;
+use crate::parser::wikitext::wikitext_text2dest_link;
+use crate::parser::Link;
+use nom::branch::alt;
+use nom::bytes::complete::take_till;
+use nom::character::complete::anychar;
+use std::borrow::Cow;
+
+/// Link max label. This limits the damage of a forgotten closing brackets.
+/// [CommonMark Spec](https://spec.commonmark.org/0.30/#link-label)
+pub const LABEL_LEN_MAX: usize = 999;
+
+/// Consumes the input until it finds a Markdown, RestructuredText, Asciidoc or
+/// HTML formatted _inline link_ (`Text2Dest`) or _link reference definition_
+/// (`Label2Dest`).
+///
+/// Returns `Ok((remaining_input, (link_text_or_label, link_destination,
+/// link_title)))`. The parser recognizes only stand alone _inline links_ and
+/// _link reference definitions_, but no _reference links_.
+///
+/// # Limitations:
+/// Link reference labels are never resolved into link text. This limitation only
+/// concerns this parser. Others are not affected.
+///
+/// Very often this limitation has no effect at all. This is the case, when the
+/// _link text_ and the _link label_ are identical:
+///
+/// ```md
+/// abc [link text/label] abc
+///
+/// [link text/label]: /url "title"
+/// ```
+///
+/// But in general, the _link text_ and the _link label_ can be different:
+///
+/// ```md
+/// abc [link text][link label] abc
+///
+/// [link label]: /url "title"
+/// ```
+///
+/// When a link reference definition is found, the parser outputs it's link label
+/// instead of the link text, which is strictly speaking only correct when both
+/// are identical. Note, the same applies to RestructuredText's link reference
+/// definitions too.
+///
+/// Another limitation is that ReStructuredText's anonymous links are not supported.
+///
+///
+/// # Basic usage
+///
+/// ```
+/// use parse_hyperlinks::parser::parse::take_text2dest_label2dest;
+/// use std::borrow::Cow;
+///
+/// let i = r#"[a]: b 'c'
+///            .. _d: e
+///            ---[f](g 'h')---`i <j>`_---
+///            ---<a href="l" title="m">k</a>"#;
+///
+/// let (i, r) = take_text2dest_label2dest(i).unwrap();
+/// assert_eq!(r, (Cow::from("a"), Cow::from("b"), Cow::from("c")));
+/// let (i, r) = take_text2dest_label2dest(i).unwrap();
+/// assert_eq!(r, (Cow::from("d"), Cow::from("e"), Cow::from("")));
+/// let (i, r) = take_text2dest_label2dest(i).unwrap();
+/// assert_eq!(r, (Cow::from("f"), Cow::from("g"), Cow::from("h")));
+/// let (i, r) = take_text2dest_label2dest(i).unwrap();
+/// assert_eq!(r, (Cow::from("i"), Cow::from("j"), Cow::from("")));
+/// let (i, r) = take_text2dest_label2dest(i).unwrap();
+/// assert_eq!(r, (Cow::from("k"), Cow::from("l"), Cow::from("m")));
+/// ```
+/// The parser might silently consume some additional bytes after the actual finding: This happens,
+/// when directly after a finding a `md_link_ref` or `rst_link_ref` appears. These must be ignored,
+/// as they are only allowed at the beginning of a line. The skip has to happen at this moment, as
+/// the next parser does not know if the first byte it gets, is it at the beginning of a line or
+/// not.
+///
+/// Technically, this parser is a wrapper around `take_link()`, that erases the
+/// link type information and ignores all _reference links_. In case the input
+/// text contains _link reference definitions_, this function is be faster than
+/// the `parse_hyperlinks::iterator::Hyperlink` iterator.
+///
+/// Note: This function is depreciated and will be removed in some later release.
+/// Use `take_link()` instead.
+pub fn take_text2dest_label2dest(i: &str) -> nom::IResult<&str, (Cow<str>, Cow<str>, Cow<str>)> {
+    let mut j = i;
+    loop {
+        match take_link(j) {
+            Ok((j, (_, Link::Text2Dest(lte, ld, lti)))) => return Ok((j, (lte, ld, lti))),
+            Ok((j, (_, Link::TextLabel2Dest(lte, ld, lti)))) => return Ok((j, (lte, ld, lti))),
+            Ok((j, (_, Link::Label2Dest(ll, ld, lti)))) => return Ok((j, (ll, ld, lti))),
+            // We ignore `Link::Ref()` and `Link::RefAlias`. Instead we continue parsing.
+            Ok((k, _)) => {
+                j = k;
+                continue;
+            }
+            Err(e) => return Err(e),
+        };
+    }
+}
+
+/// Consumes the input until it finds a Markdown, RestructuredText, Asciidoc or
+/// HTML formatted _inline link_ (`Text2Dest`), _reference link_ (`Text2Label`),
+/// _link reference definition_ (`Label2Dest`) or _reference alias_ (`Label2Label`).
+///
+/// The parser consumes the finding and returns
+/// `Ok((remaining_input, (skipped_input, Link)))` or some error.
+///
+/// # Markdown
+///
+/// ```
+/// use parse_hyperlinks::parser::Link;
+/// use parse_hyperlinks::parser::parse::take_link;
+/// use std::borrow::Cow;
+///
+/// let i = r#"abc[text1][label1]abc
+/// abc[text2](destination2 "title2")
+/// [label1]: destination1 'title1'
+/// "#;
+///
+/// let (i, r) = take_link(i).unwrap();
+/// assert_eq!(r.0, "abc");
+/// assert_eq!(r.1, Link::Text2Label(Cow::from("text1"), Cow::from("label1")));
+/// let (i, r) = take_link(i).unwrap();
+/// assert_eq!(r.0, "abc\nabc");
+/// assert_eq!(r.1, Link::Text2Dest(Cow::from("text2"), Cow::from("destination2"), Cow::from("title2")));
+/// let (i, r) = take_link(i).unwrap();
+/// assert_eq!(r.0, "\n");
+/// assert_eq!(r.1, Link::Label2Dest(Cow::from("label1"), Cow::from("destination1"), Cow::from("title1")));
+/// ```
+/// # reStructuredText
+///
+/// ```
+/// use parse_hyperlinks::parser::Link;
+/// use parse_hyperlinks::parser::parse::take_link;
+/// use std::borrow::Cow;
+///
+/// let i = r#"abc
+/// abc `text0 <destination0>`_abc
+/// abc `text1 <destination1>`__abc
+/// abc `text2 <label2_>`_abc
+/// abc text3__ abc
+/// .. _label1: destination1
+/// .. __: destination3
+/// __ destination4
+/// "#;
+///
+/// let (i, r) = take_link(i).unwrap();
+/// assert_eq!(r.0, "abc\nabc ");
+/// assert_eq!(r.1, Link::TextLabel2Dest(Cow::from("text0"), Cow::from("destination0"), Cow::from("")));
+/// let (i, r) = take_link(i).unwrap();
+/// assert_eq!(r.1, Link::Text2Dest(Cow::from("text1"), Cow::from("destination1"), Cow::from("")));
+/// let (i, r) = take_link(i).unwrap();
+/// assert_eq!(r.1, Link::Text2Label(Cow::from("text2"), Cow::from("label2")));
+/// let (i, r) = take_link(i).unwrap();
+/// assert_eq!(r.1, Link::Text2Label(Cow::from("text3"), Cow::from("_")));
+/// let (i, r) = take_link(i).unwrap();
+/// assert_eq!(r.1, Link::Label2Dest(Cow::from("label1"), Cow::from("destination1"), Cow::from("")));
+/// let (i, r) = take_link(i).unwrap();
+/// assert_eq!(r.1, Link::Label2Dest(Cow::from("_"), Cow::from("destination3"), Cow::from("")));
+/// let (i, r) = take_link(i).unwrap();
+/// assert_eq!(r.1, Link::Label2Dest(Cow::from("_"), Cow::from("destination4"), Cow::from("")));
+/// ```
+/// # Asciidoc
+///
+/// ```
+/// use parse_hyperlinks::parser::Link;
+/// use parse_hyperlinks::parser::parse::take_link;
+/// use std::borrow::Cow;
+///
+/// let i = r#"abc
+/// abc https://destination0[text0]abc
+/// abc link:https://destination1[text1]abc
+/// abc{label2}[text2]abc
+/// abc{label3}abc
+/// :label4: https://destination4
+/// "#;
+///
+/// let (i, r) = take_link(i).unwrap();
+/// assert_eq!(r.0, "abc\nabc ");
+/// assert_eq!(r.1, Link::Text2Dest(Cow::from("text0"), Cow::from("https://destination0"), Cow::from("")));
+/// let (i, r) = take_link(i).unwrap();
+/// assert_eq!(r.1, Link::Text2Dest(Cow::from("text1"), Cow::from("https://destination1"), Cow::from("")));
+/// let (i, r) = take_link(i).unwrap();
+/// assert_eq!(r.1, Link::Text2Label(Cow::from("text2"), Cow::from("label2")));
+/// let (i, r) = take_link(i).unwrap();
+/// assert_eq!(r.1, Link::Text2Label(Cow::from(""), Cow::from("label3")));
+/// let (i, r) = take_link(i).unwrap();
+/// assert_eq!(r.1, Link::Label2Dest(Cow::from("label4"), Cow::from("https://destination4"), Cow::from("")));
+/// ```
+///
+/// # HTML
+///
+/// ```
+/// use parse_hyperlinks::parser::Link;
+/// use parse_hyperlinks::parser::parse::take_link;
+/// use std::borrow::Cow;
+///
+/// let i = r#"abc<a href="destination1" title="title1">text1</a>abc
+/// abc<a href="destination2" title="title2">text2</a>abc
+/// "#;
+///
+/// let (i, r) = take_link(i).unwrap();
+/// assert_eq!(r.0, "abc");
+/// assert_eq!(r.1, Link::Text2Dest(Cow::from("text1"), Cow::from("destination1"), Cow::from("title1")));
+/// let (i, r) = take_link(i).unwrap();
+/// assert_eq!(r.0, "abc\nabc");
+/// assert_eq!(r.1, Link::Text2Dest(Cow::from("text2"), Cow::from("destination2"), Cow::from("title2")));
+/// ```
+pub fn take_link(i: &str) -> nom::IResult<&str, (&str, Link)> {
+    let mut j = i;
+    let mut skip_count = 0;
+    let mut input_start = true;
+    let mut line_start;
+    let mut whitespace;
+    let res = loop {
+        // Are we on a new line character? consume it.
+        line_start = false;
+        // Does never fail.
+        let (k, count) = nom::multi::many0_count(nom::character::complete::newline)(j)?;
+        debug_assert_eq!(j.len() - k.len(), count);
+        if count > 0 {
+            skip_count += j.len() - k.len();
+            j = k;
+            line_start = true;
+        };
+
+        // Are we at the beginning of a line?
+        if line_start || input_start {
+            if let Ok((k, r)) = alt((
+                // Now we search for `label2*`.
+                // For both parser is the indent meaningful. We mustn't consume them.
+                rst_label2label_link,
+                rst_label2dest_link,
+            ))(j)
+            {
+                break (k, r);
+            };
+        };
+
+        // Are we on a whitespace? Now consume them.
+        whitespace = false;
+        if let (k, Some(_)) = nom::combinator::opt(nom::character::complete::space1)(j)? {
+            skip_count += j.len() - k.len();
+            j = k;
+            whitespace = true;
+        }
+
+        // Are we at the beginning of a line?
+        if line_start || input_start {
+            if let Ok((k, r)) = alt((
+                // Now we search for `label2*`.
+                // These parsers do not care about the indent, as long it is
+                // only whitespace.
+                wikitext_text2dest_link,
+                md_label2dest_link,
+                adoc_label2dest_link,
+            ))(j)
+            {
+                break (k, r);
+            };
+        };
+        // Start searching for links.
+
+        // Regular `text` links can start everywhere.
+        if let Ok((k, r)) = alt((
+            // This should be first, because it is very specific.
+            wikitext_text2dest_link,
+            // Start with `text2dest`.
+            md_text2dest_link,
+            // `rst_text2dest` must be always placed before `rst_text2label`.
+            rst_text2dest_link,
+            rst_text_label2dest_link,
+            adoc_text2label_link,
+            html_text2dest_link,
+        ))(j)
+        {
+            break (k, r);
+        };
+
+        if whitespace || line_start || input_start {
+            // There must be at least one more byte. If it is one of `([<'"`, skip it.
+            let k = if let (k, Some(_)) =
+                nom::combinator::opt(nom::character::complete::one_of("([<'\""))(j)?
+            {
+                // Skip that char.
+                k
+            } else {
+                // Change nothing.
+                j
+            };
+
+            // `rst_text2label` must be always placed after `rst_text2dest`.
+            // `md_text2label` must be always placed after `adoc_text2label` and `adoc_text2dest`,
+            // because the former consumes `[*]`.
+            if let Ok((l, r)) = alt((rst_text2label_link, adoc_text2dest_link))(k) {
+                // If ever we have skipped a char, remember it now.
+                skip_count += j.len() - k.len();
+                break (l, r);
+            };
+        };
+
+        // This parser is so unspecific, that it must be the last.
+        if let Ok((k, r)) = md_text2label_link(j) {
+            break (k, r);
+        };
+
+        // This makes sure that we advance.
+        let (k, _) = anychar(j)?;
+        skip_count += j.len() - k.len();
+        j = k;
+
+        // This might not consume bytes and never fails.
+        let (k, _) = take_till(|c|
+            // After this, we should check for: `md_label2dest`, `rst_label2dest`, `rst_text2label`, `adoc_text2dest`.
+            c == '\n'
+            // After this, possible start for `adoc_text2dest` or `rst_text2label`:
+            || c == ' ' || c == '\t'
+            // These are candidates for `rst_text2label`, `rst_text_label2dest` `rst_text2dest`:
+            || c == '`'
+            // These could be the start of all `md_*` link types.
+            || c == '['
+            // These could be the start of the `adoc_text2label` link type.
+            || c == '{'
+            // And this could be an HTML hyperlink:
+            || c == '<')(j)?;
+
+        skip_count += j.len() - k.len();
+        j = k;
+        input_start = false;
+    };
+
+    // Before we return `res`, we need to check again for `md_link_ref` and
+    // `rst_link_ref` and consume them silently, without returning their result.
+    // These are only allowed at the beginning of a line and we know here, that
+    // we are not. We have to act now, because the next parser can not tell if
+    // its first byte is at the beginning of the line, because it does not know
+    // if it was called for the first time ore not. By consuming more now, we
+    // make sure that no `md_link_ref` and `rst_link_ref` is mistakenly
+    // recognized in the middle of a line.
+    // It is sufficient to do this check once, because both parser guarantee to
+    // consume the whole line in case of success.
+    let (mut l, link) = res;
+    match link {
+        Link::Label2Dest(_, _, _) | Link::Label2Label(_, _) => {}
+        _ => {
+            // Just consume, the result does not matter.
+            let (m, _) = nom::combinator::opt(alt((rst_label2dest_link, md_label2dest_link)))(l)?;
+            l = m;
+        }
+    };
+
+    let skipped_input = &i[0..skip_count];
+
+    Ok((l, (skipped_input, link)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_take_link() {
+        let expected = nom::Err::Error(nom::error::Error::new("", nom::error::ErrorKind::Eof));
+        let err = take_link("").unwrap_err();
+        assert_eq!(err, expected);
+
+        let i = r#"[md label1]: md_destination1 "md title1"
+abc [md text2](md_destination2 "md title2")[md text3]: abc[md text4]: abc
+   [md label5]: md_destination5 "md title5"
+abc `rst text1 <rst_destination1>`__abc
+abc `rst text2 <rst_label2_>`_ .. _norst: no .. _norst: no
+.. _rst label3: rst_destination3
+  .. _rst label4: rst_d
+     estination4
+__ rst_label5_
+abc `rst text_label6 <rst_destination6>`_abc
+<a href="html_destination1"
+   title="html title1">html text1</a>
+abc https://adoc_destination1[adoc text1] abc
+abc {adoc-label2}abc {adoc-label3}[adoc text3]abc
+ :adoc-label4: https://adoc_destination4
+abc{adoc-label5}abc https://adoc_destination6 abc
+abc[https://wikitext.link Wikitext Testlink]abc
+"#;
+
+        let expected = Link::Label2Dest(
+            Cow::from("md label1"),
+            Cow::from("md_destination1"),
+            Cow::from("md title1"),
+        );
+        let (i, (_, res)) = take_link(i).unwrap();
+        assert_eq!(res, expected);
+
+        let expected = Link::Text2Dest(
+            Cow::from("md text2"),
+            Cow::from("md_destination2"),
+            Cow::from("md title2"),
+        );
+        let (i, (skipped, res)) = take_link(i).unwrap();
+        assert_eq!(skipped, "\nabc ");
+        assert_eq!(res, expected);
+
+        let expected = Link::Text2Label(Cow::from("md text3"), Cow::from("md text3"));
+        let (i, (_, res)) = take_link(i).unwrap();
+        assert_eq!(res, expected);
+
+        let expected = Link::Text2Label(Cow::from("md text4"), Cow::from("md text4"));
+        let (i, (_, res)) = take_link(i).unwrap();
+        assert_eq!(res, expected);
+
+        let expected = Link::Label2Dest(
+            Cow::from("md label5"),
+            Cow::from("md_destination5"),
+            Cow::from("md title5"),
+        );
+        let (i, (_, res)) = take_link(i).unwrap();
+        assert_eq!(res, expected);
+
+        let expected = Link::Text2Dest(
+            Cow::from("rst text1"),
+            Cow::from("rst_destination1"),
+            Cow::from(""),
+        );
+        let (i, (_, res)) = take_link(i).unwrap();
+        assert_eq!(res, expected);
+
+        let expected = Link::Text2Label(Cow::from("rst text2"), Cow::from("rst_label2"));
+        let (i, (_, res)) = take_link(i).unwrap();
+        assert_eq!(res, expected);
+
+        let expected = Link::Label2Dest(
+            Cow::from("rst label3"),
+            Cow::from("rst_destination3"),
+            Cow::from(""),
+        );
+        let (i, (_, res)) = take_link(i).unwrap();
+        assert_eq!(res, expected);
+
+        let expected = Link::Label2Dest(
+            Cow::from("rst label4"),
+            Cow::from("rst_destination4"),
+            Cow::from(""),
+        );
+        let (i, (_, res)) = take_link(i).unwrap();
+        assert_eq!(res, expected);
+
+        let expected = Link::Label2Label(Cow::from("_"), Cow::from("rst_label5"));
+        let (i, (_, res)) = take_link(i).unwrap();
+        assert_eq!(res, expected);
+
+        let expected = Link::TextLabel2Dest(
+            Cow::from("rst text_label6"),
+            Cow::from("rst_destination6"),
+            Cow::from(""),
+        );
+        let (i, (_, res)) = take_link(i).unwrap();
+        assert_eq!(res, expected);
+
+        let expected = Link::Text2Dest(
+            Cow::from("html text1"),
+            Cow::from("html_destination1"),
+            Cow::from("html title1"),
+        );
+        let (i, (_, res)) = take_link(i).unwrap();
+        assert_eq!(res, expected);
+
+        let expected = Link::Text2Dest(
+            Cow::from("adoc text1"),
+            Cow::from("https://adoc_destination1"),
+            Cow::from(""),
+        );
+        let (i, (_, res)) = take_link(i).unwrap();
+        assert_eq!(res, expected);
+
+        let expected = Link::Text2Label(Cow::from(""), Cow::from("adoc-label2"));
+        let (i, (_, res)) = take_link(i).unwrap();
+        assert_eq!(res, expected);
+
+        let expected = Link::Text2Label(Cow::from("adoc text3"), Cow::from("adoc-label3"));
+        let (i, (_, res)) = take_link(i).unwrap();
+        assert_eq!(res, expected);
+
+        let expected = Link::Label2Dest(
+            Cow::from("adoc-label4"),
+            Cow::from("https://adoc_destination4"),
+            Cow::from(""),
+        );
+        let (i, (_, res)) = take_link(i).unwrap();
+        assert_eq!(res, expected);
+
+        let expected = Link::Text2Label(Cow::from(""), Cow::from("adoc-label5"));
+        let (i, (skipped, res)) = take_link(i).unwrap();
+        assert_eq!(res, expected);
+        assert_eq!(skipped, "\nabc");
+
+        let expected = Link::Text2Dest(
+            Cow::from("https://adoc_destination6"),
+            Cow::from("https://adoc_destination6"),
+            Cow::from(""),
+        );
+        let (i, (skipped, res)) = take_link(i).unwrap();
+        assert_eq!(res, expected);
+        assert_eq!(skipped, "abc ");
+
+        let expected = Link::Text2Dest(
+            Cow::from("Wikitext Testlink"),
+            Cow::from("https://wikitext.link"),
+            Cow::from(""),
+        );
+        let (_i, (skipped, res)) = take_link(i).unwrap();
+        assert_eq!(res, expected);
+        assert_eq!(skipped, " abc\nabc");
+    }
+
+    #[test]
+    fn test_take_link2() {
+        // New input:
+        // Do we find the same at the input start also?
+        let i = ".. _`My: home page`: http://getreu.net\nabc";
+        let expected = Link::Label2Dest(
+            Cow::from("My: home page"),
+            Cow::from("http://getreu.net"),
+            Cow::from(""),
+        );
+        let (i, (_, res)) = take_link(i).unwrap();
+        assert_eq!(res, expected);
+        assert_eq!(i, "\nabc");
+
+        let i = "https://adoc_link_destination[adoc link text]abc";
+        let expected = Link::Text2Dest(
+            Cow::from("adoc link text"),
+            Cow::from("https://adoc_link_destination"),
+            Cow::from(""),
+        );
+        let (i, (_, res)) = take_link(i).unwrap();
+        assert_eq!(res, expected);
+        assert_eq!(i, "abc");
+    }
+
+    #[test]
+    fn test_take_link3() {
+        let i = r#"   [md label3]: md_destination3 "md title3"
+        [md label1]: md_destination1 "md title1"
+        [md label2]: md_destination2 "md title2"
+        abc[md text_label3]abc[md text_label4]
+        "#;
+
+        let expected = Link::Label2Dest(
+            Cow::from("md label3"),
+            Cow::from("md_destination3"),
+            Cow::from("md title3"),
+        );
+        let (i, (_, res)) = take_link(i).unwrap();
+        assert_eq!(res, expected);
+
+        let expected = Link::Label2Dest(
+            Cow::from("md label1"),
+            Cow::from("md_destination1"),
+            Cow::from("md title1"),
+        );
+        let (i, (_, res)) = take_link(i).unwrap();
+        assert_eq!(res, expected);
+
+        let expected = Link::Label2Dest(
+            Cow::from("md label2"),
+            Cow::from("md_destination2"),
+            Cow::from("md title2"),
+        );
+        let (i, (_, res)) = take_link(i).unwrap();
+        assert_eq!(res, expected);
+
+        let expected = Link::Text2Label(Cow::from("md text_label3"), Cow::from("md text_label3"));
+        let (i, (_, res)) = take_link(i).unwrap();
+        assert_eq!(res, expected);
+
+        let expected = Link::Text2Label(Cow::from("md text_label4"), Cow::from("md text_label4"));
+        let (_i, (_, res)) = take_link(i).unwrap();
+        assert_eq!(res, expected);
+    }
+
+    #[test]
+    fn test_take_link4() {
+        let i = r#"
+.. _label4: label3_
+label2__
+__ label5
+"#;
+
+        let expected = Link::Label2Label(Cow::from("label4"), Cow::from("label3"));
+        let (i, (_, res)) = take_link(i).unwrap();
+        assert_eq!(res, expected);
+
+        let expected = Link::Text2Label(Cow::from("label2"), Cow::from("_"));
+        let (i, (_, res)) = take_link(i).unwrap();
+        assert_eq!(res, expected);
+
+        let expected = Link::Label2Dest(Cow::from("_"), Cow::from("label5"), Cow::from(""));
+        let (_i, (_, res)) = take_link(i).unwrap();
+        assert_eq!(res, expected);
+    }
+}

--- a/deps/parse-hyperlinks/src/parser/restructured_text.rs
+++ b/deps/parse-hyperlinks/src/parser/restructured_text.rs
@@ -1,0 +1,1272 @@
+//! This module implements parsers for RestructuredText hyperlinks.
+#![allow(dead_code)]
+#![allow(clippy::type_complexity)]
+
+use crate::parser::parse::LABEL_LEN_MAX;
+use crate::parser::Link;
+use nom::branch::alt;
+use nom::bytes::complete::tag;
+use nom::combinator::*;
+use nom::IResult;
+use std::borrow::Cow;
+
+/// Character that can be escaped with `\`.
+///
+/// Note: If ever you change this, change also
+/// `rst_escaped_link_text_transform()`.
+const ESCAPABLE: &str = r#" `:<>_\"#;
+
+/// Wrapper around `rst_text2dest()` that packs the result in
+/// `Link::Text2Dest`.
+pub fn rst_text2dest_link(i: &str) -> nom::IResult<&str, Link> {
+    let (i, (te, de, ti)) = rst_text2dest(i)?;
+    Ok((i, Link::Text2Dest(te, de, ti)))
+}
+
+/// Parse a RestructuredText _inline hyperlink_.
+///
+/// The parser expects to start at the link start (\`) to succeed.
+/// As rst does not know about link titles,
+/// the parser always returns an empty `link_title` as `Cow::Borrowed("")`
+/// ```
+/// use parse_hyperlinks::parser::Link;
+/// use parse_hyperlinks::parser::restructured_text::rst_text2dest;
+/// use std::borrow::Cow;
+///
+/// assert_eq!(
+///   rst_text2dest("`name <destination>`__abc"),
+///   Ok(("abc", (Cow::from("name"), Cow::from("destination"), Cow::from(""))))
+/// );
+/// ```
+/// A hyperlink reference may directly embed a destination URI or (since Docutils
+/// 0.11) a hyperlink reference within angle brackets `<>` as shown in the
+/// following example:
+/// ```rst
+/// abc `Python home page <http://www.python.org>`__ abc
+/// ```
+/// The bracketed URI must be preceded by whitespace and be the last text
+/// before the end string.
+pub fn rst_text2dest(i: &str) -> nom::IResult<&str, (Cow<str>, Cow<str>, Cow<str>)> {
+    let (i, (ln, ld)) = rst_parse_text2target(true, false)(i)?;
+    let ln = rst_escaped_link_text_transform(ln)?.1;
+    let ld = rst_escaped_link_destination_transform(ld)?.1;
+
+    Ok((i, (ln, ld, Cow::Borrowed(""))))
+}
+
+/// Wrapper around `rst_textlabel2dest()` that packs the result in
+/// `Link::TextLabel2Dest`.
+pub fn rst_text_label2dest_link(i: &str) -> nom::IResult<&str, Link> {
+    let (i, (te, de, ti)) = rst_text_label2dest(i)?;
+    Ok((i, Link::TextLabel2Dest(te, de, ti)))
+}
+
+/// Parse a RestructuredText combined _inline hyperlink_ with _link reference definition_.
+///
+/// The parser expects to start at the link start (\`) to succeed.
+/// As rst does not know about link titles,
+/// the parser always returns an empty `link_title` as `Cow::Borrowed("")`.
+/// ```
+/// use parse_hyperlinks::parser::Link;
+/// use parse_hyperlinks::parser::restructured_text::rst_text_label2dest;
+/// use std::borrow::Cow;
+///
+/// assert_eq!(
+///   rst_text_label2dest("`name <destination>`_abc"),
+///   Ok(("abc", (Cow::from("name"), Cow::from("destination"), Cow::from(""))))
+/// );
+/// ```
+/// A hyperlink reference may directly embed a destination URI or (since Docutils
+/// 0.11) a hyperlink reference within angle brackets `<>` as shown in the
+/// following example:
+/// ```rst
+/// abc `Python home page <http://www.python.org>`_ abc
+/// ```
+/// The bracketed URI must be preceded by whitespace and be the last text
+/// before the end string.
+pub fn rst_text_label2dest(i: &str) -> nom::IResult<&str, (Cow<str>, Cow<str>, Cow<str>)> {
+    let (i, (ln, ld)) = rst_parse_text2target(false, false)(i)?;
+    let ln = rst_escaped_link_text_transform(ln)?.1;
+    let ld = rst_escaped_link_destination_transform(ld)?.1;
+
+    Ok((i, (ln, ld, Cow::Borrowed(""))))
+}
+
+/// This parser finds rst links of type:
+///     `*<*>`__
+/// or:
+///     `*<*>`_
+///
+/// Escape sequences are recognized and skipped, but not replaced here.
+/// If `anonym==true`: it recognizes:
+///     `*<*>`__
+/// otherwise:
+///     `*<*>`_
+///
+/// If `label==true` (`target==label`): it recognizes
+///     `*<*_>`_?
+/// otherwise (`target==dest`):
+///     `*<*>`_?
+fn rst_parse_text2target(
+    anonym: bool,
+    label: bool,
+) -> impl Fn(&str) -> IResult<&str, (&str, &str)> {
+    move |i: &str| {
+        let (mut i, inner) = nom::sequence::delimited(
+            tag("`"),
+            nom::bytes::complete::escaped(
+                nom::character::complete::none_of(r#"\`"#),
+                '\\',
+                nom::character::complete::one_of(ESCAPABLE),
+            ),
+            tag("`_"),
+        )(i)?;
+
+        if anonym {
+            let (j, _) = nom::character::complete::char('_')(i)?;
+            i = j;
+        };
+
+        // Assure that the next char is not`_`.
+        if !i.is_empty() {
+            let _ = nom::combinator::not(nom::character::complete::char('_'))(i)?;
+        };
+
+        // From here on, we only deal with the inner result of the above.
+        // Take everything until the first unescaped `<`
+        let (inner_rest, link_text): (&str, &str) = nom::bytes::complete::escaped(
+            nom::character::complete::none_of(r#"\<"#),
+            '\\',
+            nom::character::complete::one_of(ESCAPABLE),
+        )(inner)?;
+        // Trim trailing whitespace.
+        let link_text = link_text.trim_end();
+
+        let (j, mut link_dest_label) = nom::sequence::delimited(
+            tag("<"),
+            nom::bytes::complete::escaped(
+                nom::character::complete::none_of(r#"\<>"#),
+                '\\',
+                nom::character::complete::one_of(ESCAPABLE),
+            ),
+            tag(">"),
+        )(inner_rest)?;
+
+        // Fail if there are bytes left between `>` and `\``.
+        let (_, _) = nom::combinator::eof(j)?;
+
+        // Now check if `link_dest_label` is what we are expecting (which depends
+        // on `label`).
+
+        // Fail if `link_dest_label` is empty.
+        let (_, _) = nom::combinator::not(nom::combinator::eof)(link_dest_label)?;
+
+        // Get last char.
+        let last_char_is_ = link_dest_label.is_char_boundary(link_dest_label.len() - 1)
+            && &link_dest_label[link_dest_label.len() - 1..] == "_";
+        // If (`label==true`), we expect trailing `_`, fail otherwise.
+        // If (`label==false`), we fail when there is a trailing `_`.
+        if (label && !last_char_is_) || (!label && last_char_is_) {
+            return Err(nom::Err::Error(nom::error::Error::new(
+                i,
+                nom::error::ErrorKind::Tag,
+            )));
+        };
+        // When label, strip trailing `_`.
+        if label {
+            link_dest_label = &link_dest_label[..link_dest_label.len() - 1];
+        };
+
+        Ok((i, (link_text, link_dest_label)))
+    }
+}
+
+/// Wrapper around `rst_text2dest()` that packs the result in
+/// `Link::Text2Dest`.
+pub fn rst_text2label_link(i: &str) -> nom::IResult<&str, Link> {
+    let (i, (te, la)) = rst_text2label(i)?;
+    Ok((i, Link::Text2Label(te, la)))
+}
+
+/// Parse a RestructuredText _reference link_.
+///
+/// The caller must guarantee, that
+/// * the parser is at the input start (no bytes exist before).
+/// * the preceding bytes are whitespaces or newline, _or_
+/// * the preceding bytes are whitespaces or newline, followed by one of: `([<'"`
+/// ```rust
+/// use parse_hyperlinks::parser::Link;
+/// use parse_hyperlinks::parser::restructured_text::rst_text2label;
+/// use std::borrow::Cow;
+///
+/// assert_eq!(
+///   rst_text2label("linktext_ abc"),
+///   Ok((" abc", (Cow::from("linktext"), Cow::from("linktext"))))
+/// );
+/// assert_eq!(
+///   rst_text2label("`link text`_ abc"),
+///   Ok((" abc", (Cow::from("link text"), Cow::from("link text"))))
+/// );
+/// assert_eq!(
+///   rst_text2label("`link text<link label_>`_ abc"),
+///   Ok((" abc", (Cow::from("link text"), Cow::from("link label"))))
+/// );
+/// assert_eq!(
+///   rst_text2label("`link text`__ abc"),
+///   Ok((" abc", (Cow::from("link text"), Cow::from("_"))))
+/// );
+/// ```
+///
+pub fn rst_text2label(i: &str) -> nom::IResult<&str, (Cow<str>, Cow<str>)> {
+    let (i, (te, la)) = rst_parse_text2label(i)?;
+    let te = rst_escaped_link_text_transform(te)?.1;
+    let la = rst_escaped_link_text_transform(la)?.1;
+
+    Ok((i, (te, la)))
+}
+
+/// Parses a _reference link_. (Doctree element `reference`).
+///
+/// Named hyperlink references:
+/// No start-string, end-string = `_.
+/// Start-string = "`", end-string = `\`_`. (Phrase references.)
+/// Anonymous hyperlink references:
+/// No start-string, end-string = `__`.
+/// Start-string = "`", end-string = `\`__`. (Phrase references.)
+///
+///
+/// Hyperlink references are indicated by a trailing underscore, "_", except for
+/// standalone hyperlinks which are recognized independently.
+///
+/// Important: before this parser try `rst_text2dest()` first!
+///
+/// The caller must guarantee, that either:
+/// * we are at the input start -or-
+/// * the byte just before was a whitespace (including newline)!
+///
+/// For named references in reStructuredText `link_text` and `link_label`
+/// are the same. By convention we return for anonymous references:
+/// `link_label='_'`.
+///
+/// The parser checks that this _reference link_ is followed by a whitespace
+/// without consuming it.
+///
+fn rst_parse_text2label(i: &str) -> nom::IResult<&str, (&str, &str)> {
+    let (mut i, (link_text, mut link_label)) = alt((
+        rst_parse_text2target(false, true),
+        nom::combinator::map(rst_parse_simple_label, |s| (s, s)),
+    ))(i)?;
+
+    // Is this an anonymous reference? Consume the second `_` also.
+    if let (j, Some(_)) = nom::combinator::opt(nom::character::complete::char('_'))(i)? {
+        link_label = "_";
+        i = j;
+    };
+
+    Ok((i, (link_text, link_label)))
+}
+
+/// Wrapper around `rst_label2dest()` that packs the result in
+/// `Link::Label2Dest`.
+pub fn rst_label2dest_link(i: &str) -> nom::IResult<&str, Link> {
+    let (i, (l, d, t)) = rst_label2dest(i)?;
+    Ok((i, Link::Label2Dest(l, d, t)))
+}
+
+/// Parse a reStructuredText _link reference definition_.
+///
+/// This parser consumes until the end of the line. As rst does not know about link titles,
+/// the parser always returns an empty `link_title` as `Cow::Borrowed("")`.
+/// ```
+/// use parse_hyperlinks::parser::Link;
+/// use parse_hyperlinks::parser::restructured_text::rst_label2dest;
+/// use std::borrow::Cow;
+///
+/// assert_eq!(
+///   rst_label2dest("   .. _`label`: destination\nabc"),
+///   Ok(("\nabc", (Cow::from("label"), Cow::from("destination"), Cow::from(""))))
+/// );
+/// assert_eq!(
+///   rst_label2dest("   .. __: destination\nabc"),
+///   Ok(("\nabc", (Cow::from("_"), Cow::from("destination"), Cow::from(""))))
+/// );
+/// assert_eq!(
+///   rst_label2dest("   __ destination\nabc"),
+///   Ok(("\nabc", (Cow::from("_"), Cow::from("destination"), Cow::from(""))))
+/// );
+/// ```
+/// Here some examples for link references:
+/// ```rst
+/// .. _Python home page: http://www.python.org
+/// .. _`Python: home page`: http://www.python.org
+/// ```
+/// See unit test `test_rst_label2dest()` for more examples.
+pub fn rst_label2dest(i: &str) -> nom::IResult<&str, (Cow<str>, Cow<str>, Cow<str>)> {
+    let (i, (l, d)) = rst_label2target(false, i)?;
+    Ok((i, (l, d, Cow::from(""))))
+}
+
+/// Wrapper around `rst_label2label()` that packs the result in
+/// `Link::Label2Label`.
+pub fn rst_label2label_link(i: &str) -> nom::IResult<&str, Link> {
+    let (i, (l1, l2)) = rst_label2label(i)?;
+    Ok((i, Link::Label2Label(l1, l2)))
+}
+
+/// Parse a reStructuredText _link reference to link reference definition_.
+/// This type defines an alias (alternative name) for a link reference:
+/// ```
+/// use parse_hyperlinks::parser::Link;
+/// use parse_hyperlinks::parser::restructured_text::rst_label2label;
+/// use std::borrow::Cow;
+///
+/// assert_eq!(
+///   rst_label2label("   .. _`alt label`: `label`_\nabc"),
+///   Ok(("\nabc", (Cow::from("alt label"), Cow::from("label"))))
+/// );
+/// assert_eq!(
+///   rst_label2label("   .. __: label_\nabc"),
+///   Ok(("\nabc", (Cow::from("_"), Cow::from("label"))))
+/// );
+/// assert_eq!(
+///   rst_label2label("   __ label_\nabc"),
+///   Ok(("\nabc", (Cow::from("_"), Cow::from("label"))))
+/// );
+/// ```
+pub fn rst_label2label(i: &str) -> nom::IResult<&str, (Cow<str>, Cow<str>)> {
+    rst_label2target(true, i)
+}
+
+/// Parser for _link_reference_definitions_:
+/// * `label==false`:  the link is of type `Label2Dest`
+/// * `label==true`: the link is of type `Label2Label`
+fn rst_label2target(label: bool, i: &str) -> nom::IResult<&str, (Cow<str>, Cow<str>)> {
+    let my_err = |_| {
+        nom::Err::Error(nom::error::Error::new(
+            i,
+            nom::error::ErrorKind::EscapedTransform,
+        ))
+    };
+
+    // If there is a block start? What kind of?
+    let (i, c, block_header_is__) =
+        if let (i, Some(c)) = nom::combinator::opt(rst_explicit_markup_block(".. "))(i)? {
+            (i, c, false)
+        } else {
+            let (i, c) = rst_explicit_markup_block("__ ")(i)?;
+            (i, c, true)
+        };
+
+    let (source, target) = match c {
+        Cow::Borrowed(s) => {
+            let (_, (ls, lt)) = if !block_header_is__ {
+                rst_parse_label2target(label)(s)?
+            } else if label {
+                // This is supposed to be a label.
+                ("", ("_", rst_parse_simple_label(s)?.1))
+            } else {
+                // This is supposed to be a destination (url).
+                ("", ("_", s))
+            };
+            // If the target is a destination (not a label), the last char must not be `_`.
+            if !label {
+                let _ = nom::combinator::not(rst_parse_simple_label)(lt).map_err(my_err)?;
+            };
+            (
+                rst_escaped_link_text_transform(ls)?.1,
+                rst_escaped_link_destination_transform(lt)?.1,
+            )
+        }
+
+        Cow::Owned(strg) => {
+            let (_, (ls, lt)) = if !block_header_is__ {
+                rst_parse_label2target(label)(&strg).map_err(my_err)?
+            } else if label {
+                // This is supposed to be a label.
+                let s = rst_parse_simple_label(&strg).map_err(my_err)?.1;
+                ("", ("_", s))
+            } else {
+                // This is supposed to be a destination (url).
+                ("", ("_", strg.as_str()))
+            };
+            // If the target is a destination (not a label), the last char must not be `_`.
+            if !label {
+                let _ = nom::combinator::not(rst_parse_simple_label)(lt).map_err(my_err)?;
+            };
+            let ls = Cow::Owned(
+                rst_escaped_link_text_transform(ls)
+                    .map_err(my_err)?
+                    .1
+                    .to_string(),
+            );
+            let lt = Cow::Owned(
+                rst_escaped_link_destination_transform(lt)
+                    .map_err(my_err)?
+                    .1
+                    .to_string(),
+            );
+            (ls, lt)
+        }
+    };
+
+    // We do not need to consume whitespace until the end of the line,
+    // because `rst_explicit_markup_block()` had stripped the whitespace
+    // already.
+
+    Ok((i, (source, target)))
+}
+
+/// The parser recognizes `Label2Dest` links (`label==false`):
+///     _label: dest
+/// or `Label2Label` links (`label==true):
+///     _alt_label: label_
+/// It does not perform any escape character transformation.
+fn rst_parse_label2target(label: bool) -> impl Fn(&str) -> IResult<&str, (&str, &str)> {
+    move |i: &str| {
+        let (i, link_text) = alt((
+            nom::sequence::delimited(
+                tag("_`"),
+                nom::bytes::complete::escaped(
+                    nom::character::complete::none_of(r#"\`"#),
+                    '\\',
+                    nom::character::complete::one_of(ESCAPABLE),
+                ),
+                tag("`: "),
+            ),
+            nom::sequence::delimited(
+                tag("_"),
+                nom::bytes::complete::escaped(
+                    nom::character::complete::none_of(r#"\:"#),
+                    '\\',
+                    nom::character::complete::one_of(ESCAPABLE),
+                ),
+                tag(": "),
+            ),
+            nom::combinator::value("_", tag("__: ")),
+        ))(i)?;
+
+        let link_target = if label {
+            // The target is another label.
+            rst_parse_simple_label(i)?.1
+        } else {
+            // The target is a destination.
+            i
+        };
+
+        Ok(("", (link_text, link_target)))
+    }
+}
+
+/// This parser consumes a simple label:
+///     one_word_label_
+/// or
+///     `more words label`_
+fn rst_parse_simple_label(i: &str) -> nom::IResult<&str, &str> {
+    // Consumes and returns a word ending with `_`.
+    // Strips off one the trailing `_` before returning the result.
+    fn take_word_consume_first_ending_underscore(i: &str) -> nom::IResult<&str, &str> {
+        let mut i = i;
+        let (k, mut r) = nom::bytes::complete::take_till1(|c: char| {
+            !(c.is_alphanumeric() || c == '-' || c == '_')
+        })(i)?;
+        // Is `r` ending with `__`? There should be at least 2 bytes: `"__".len()`
+        if r.len() >= 3 && r.is_char_boundary(r.len() - 2) && &r[r.len() - 2..] == "__" {
+            // Consume one `_`, but keep one `_` in remaining bytes.
+            i = &i[r.len() - 1..];
+            // Strip two `__` from result.
+            r = &r[..r.len() - 2];
+        // Is `r` ending with `_`? There should be at least 1 byte: `"_".len()`.
+        } else if !r.is_empty() && r.is_char_boundary(r.len() - 1) && &r[r.len() - 1..] == "_" {
+            // Remaining bytes.
+            i = k;
+            // Strip `_` from result.
+            r = &r[..r.len() - 1]
+        } else {
+            return Err(nom::Err::Error(nom::error::Error::new(
+                k,
+                nom::error::ErrorKind::Tag,
+            )));
+        };
+
+        Ok((i, r))
+    }
+
+    let (i, r) = nom::combinator::verify(
+        alt((
+            nom::sequence::delimited(
+                tag("`"),
+                nom::bytes::complete::escaped(
+                    nom::character::complete::none_of(r#"\`"#),
+                    '\\',
+                    nom::character::complete::one_of(ESCAPABLE),
+                ),
+                tag("`_"),
+            ),
+            take_word_consume_first_ending_underscore,
+        )),
+        |s: &str| s.len() <= LABEL_LEN_MAX,
+    )(i)?;
+
+    // Return error if label is empty.
+    let _ = nom::combinator::not(alt((nom::combinator::eof, tag("``"))))(r)?;
+
+    Ok((i, r))
+}
+
+/// This parses an explicit markup block.
+/// The parser expects to start at the beginning of the line.
+/// Syntax diagram:
+/// ```text
+/// +-------+----------------------+
+/// | ".. " | in  1                |
+/// +-------+ in  2                |
+///         |    in  3             |
+///         +----------------------+
+/// out
+/// ```
+/// An explicit markup block is a text block:
+/// * whose first line begins with ".." followed by whitespace (the "explicit
+///   markup start"),
+/// * whose second and subsequent lines (if any) are indented relative to the
+///   first, and
+/// * which ends before an unindented line
+/// As with external hyperlink targets, the link block of an indirect
+/// hyperlink target may begin on the same line as the explicit markup start
+/// or the next line. It may also be split over multiple lines, in which case
+/// the lines are joined with whitespace before being normalized.
+fn rst_explicit_markup_block<'a>(
+    block_header: &'a str,
+) -> impl Fn(&'a str) -> IResult<&'a str, Cow<'a, str>> {
+    move |i: &'a str| {
+        fn indent<'a>(wsp1: &'a str, wsp2: &'a str) -> impl Fn(&'a str) -> IResult<&'a str, ()> {
+            move |i: &str| {
+                let (i, _) = nom::character::complete::line_ending(i)?;
+                let (i, _) = nom::bytes::complete::tag(wsp1)(i)?;
+                let (i, _) = nom::bytes::complete::tag(wsp2)(i)?;
+                Ok((i, ()))
+            }
+        }
+
+        let (i, (wsp1, wsp2)) = nom::sequence::pair(
+            nom::character::complete::space0,
+            nom::combinator::map(nom::bytes::complete::tag(block_header), |_| "   "),
+        )(i)?;
+
+        let (j, v) = nom::multi::separated_list1(
+            indent(wsp1, wsp2),
+            nom::character::complete::not_line_ending,
+        )(i)?;
+
+        // If the block consists of only one line return now.
+        if v.len() == 1 {
+            return Ok((j, Cow::Borrowed(v[0])));
+        };
+
+        let mut s = String::new();
+        let mut is_first = true;
+
+        for subs in &v {
+            if !is_first {
+                s.push(' ');
+            }
+            s.push_str(subs);
+            is_first = false;
+        }
+
+        Ok((j, Cow::from(s)))
+    }
+}
+
+/// Replace the following escaped characters:
+///     \\\`\ \:\<\>
+/// with:
+///     \`:<>
+/// Preserves usual whitespace, but removes `\ `.
+fn rst_escaped_link_text_transform(i: &str) -> IResult<&str, Cow<str>> {
+    nom::combinator::map(
+        nom::bytes::complete::escaped_transform(
+            nom::bytes::complete::is_not("\\"),
+            '\\',
+            // This list is the same as `ESCAPABLE`.
+            alt((
+                tag("\\"),
+                tag("`"),
+                tag(":"),
+                tag("<"),
+                tag(">"),
+                tag("_"),
+                value("", tag(" ")),
+            )),
+        ),
+        |s| if s == i { Cow::from(i) } else { Cow::from(s) },
+    )(i)
+}
+
+/// Deletes all whitespace, but keeps one space for each `\ `.
+fn remove_whitespace(i: &str) -> IResult<&str, Cow<str>> {
+    let mut res = Cow::Borrowed("");
+    let mut j = i;
+    while !j.is_empty() {
+        let (k, _) = nom::character::complete::multispace0(j)?;
+        let (k, s) = nom::bytes::complete::escaped(
+            nom::character::complete::none_of("\\\r\n \t"),
+            '\\',
+            nom::character::complete::one_of(r#" :`<>\"#),
+        )(k)?;
+        res = match res {
+            Cow::Borrowed("") => Cow::Borrowed(s),
+            Cow::Borrowed(res_str) => {
+                let mut strg = res_str.to_string();
+                strg.push_str(s);
+                Cow::Owned(strg)
+            }
+            Cow::Owned(mut strg) => {
+                strg.push_str(s);
+                Cow::Owned(strg)
+            }
+        };
+        j = k;
+    }
+
+    Ok((j, res))
+}
+
+/// Replace the following escaped characters:
+///     \\\`\ \:\<\>
+/// with:
+///     \` :<>
+fn rst_escaped_link_destination_transform(i: &str) -> IResult<&str, Cow<str>> {
+    let my_err = |_| {
+        nom::Err::Error(nom::error::Error::new(
+            i,
+            nom::error::ErrorKind::EscapedTransform,
+        ))
+    };
+
+    let c = &*remove_whitespace(i)?.1;
+
+    let s = nom::bytes::complete::escaped_transform::<_, nom::error::Error<_>, _, _, _, _, _, _>(
+        nom::bytes::complete::is_not("\\"),
+        '\\',
+        nom::character::complete::one_of(ESCAPABLE),
+    )(c)
+    .map_err(my_err)?
+    .1;
+
+    // When nothing was changed we can continue with `Borrowed`.
+    if s == i {
+        Ok(("", Cow::Borrowed(i)))
+    } else {
+        Ok(("", Cow::Owned(s)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nom::error::ErrorKind;
+
+    #[test]
+    fn test_rst_text2dest() {
+        let expected = (
+            "abc",
+            (
+                Cow::from("Python home page"),
+                Cow::from("http://www.python.org"),
+                Cow::from(""),
+            ),
+        );
+        assert_eq!(
+            rst_text2dest("`Python home page <http://www.python.org>`__abc").unwrap(),
+            expected
+        );
+
+        let expected = (
+            "abc",
+            (
+                Cow::from(r#"Python<home> page"#),
+                Cow::from("http://www.python.org"),
+                Cow::from(""),
+            ),
+        );
+        assert_eq!(
+            rst_text2dest(r#"`Python\ \<home\> page <http://www.python.org>`__abc"#).unwrap(),
+            expected
+        );
+
+        let expected = (
+            "abc",
+            (
+                Cow::from(r#"my news at <http://python.org>"#),
+                Cow::from("http://news.python.org"),
+                Cow::from(""),
+            ),
+        );
+        assert_eq!(
+            rst_text2dest(r#"`my news at \<http://python.org\> <http://news.python.org>`__abc"#)
+                .unwrap(),
+            expected
+        );
+
+        let expected = (
+            "abc",
+            (
+                Cow::from(r#"my news at <http://python.org>"#),
+                Cow::from(r#"http://news. <python>.org"#),
+                Cow::from(""),
+            ),
+        );
+        assert_eq!(
+            rst_text2dest(
+                r#"`my news at \<http\://python.org\> <http:// news.\ \<python\>.org>`__abc"#
+            )
+            .unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn test_rst_parse_text2dest_label() {
+        let expected = ("abc", ("Python home page", "http://www.python.org"));
+        assert_eq!(
+            rst_parse_text2target(false, false)("`Python home page <http://www.python.org>`_abc")
+                .unwrap(),
+            expected
+        );
+
+        let expected = nom::Err::Error(nom::error::Error::new("abc", ErrorKind::Tag));
+        assert_eq!(
+            rst_parse_text2target(false, false)("`Python home page <http://www.python.org_>`_abc")
+                .unwrap_err(),
+            expected
+        );
+
+        let expected = nom::Err::Error(nom::error::Error::new("", ErrorKind::Tag));
+        assert_eq!(
+            rst_parse_text2target(false, false)("`_abc").unwrap_err(),
+            expected
+        );
+
+        let expected = ("abc", ("Python home page", "http://www.python.org"));
+        assert_eq!(
+            rst_parse_text2target(true, false)("`Python home page <http://www.python.org>`__abc")
+                .unwrap(),
+            expected
+        );
+
+        let expected = ("abc", (r#"Python\ \<home\> page"#, "http://www.python.org"));
+        assert_eq!(
+            rst_parse_text2target(false, false)(
+                r#"`Python\ \<home\> page <http://www.python.org>`_abc"#
+            )
+            .unwrap(),
+            expected
+        );
+
+        let expected = (
+            "abc",
+            (
+                r#"my news at \<http://python.org\>"#,
+                "http://news.python.org",
+            ),
+        );
+        assert_eq!(
+            rst_parse_text2target(false, false)(
+                r#"`my news at \<http://python.org\> <http://news.python.org>`_abc"#
+            )
+            .unwrap(),
+            expected
+        );
+
+        let expected = (
+            "abc",
+            (
+                r#"my news at \<http\://python.org\>"#,
+                r#"http:// news.\ \<python\>.org"#,
+            ),
+        );
+        assert_eq!(
+            rst_parse_text2target(false, false)(
+                r#"`my news at \<http\://python.org\> <http:// news.\ \<python\>.org>`_abc"#
+            )
+            .unwrap(),
+            expected
+        );
+
+        let expected = (
+            "abc",
+            (
+                r#"my news at \<http\://python.org\>"#,
+                r#"http:// news.\ \<python\>.org"#,
+            ),
+        );
+        assert_eq!(
+            rst_parse_text2target(false, false)(
+                r#"`my news at \<http\://python.org\> <http:// news.\ \<python\>.org>`_abc"#
+            )
+            .unwrap(),
+            expected
+        );
+        let expected = ("abc", (r#"rst link text"#, "rst_link_label"));
+        assert_eq!(
+            rst_parse_text2target(false, true)(r#"`rst link text <rst_link_label_>`_abc"#).unwrap(),
+            expected
+        );
+
+        let expected = nom::Err::Error(nom::error::Error::new("abc", ErrorKind::Tag));
+        assert_eq!(
+            rst_parse_text2target(false, true)(r#"`my news <python webpage>`_abc"#).unwrap_err(),
+            expected
+        );
+    }
+
+    #[test]
+    fn test_rst_text2label() {
+        assert_eq!(
+            rst_text2label(r#"link_text_ abc"#),
+            Ok((" abc", (Cow::from("link_text"), Cow::from("link_text"))))
+        );
+        assert_eq!(
+            rst_text2label(r#"`li\:nk text`_ abc"#),
+            Ok((" abc", (Cow::from("li:nk text"), Cow::from("li:nk text"))))
+        );
+        assert_eq!(
+            rst_text2label("`link text`__ abc"),
+            Ok((" abc", (Cow::from("link text"), Cow::from("_"))))
+        );
+    }
+
+    #[test]
+    fn test_rst_parse_text2label() {
+        assert_eq!(
+            rst_parse_text2label("linktext_ abc"),
+            Ok((" abc", ("linktext", "linktext")))
+        );
+
+        assert_eq!(
+            rst_parse_text2label("linktext__ abc"),
+            Ok((" abc", ("linktext", "_")))
+        );
+
+        assert_eq!(
+            rst_parse_text2label("link_text_ abc"),
+            Ok((" abc", ("link_text", "link_text")))
+        );
+
+        assert_eq!(
+            rst_parse_text2label("`link text`_ abc"),
+            Ok((" abc", ("link text", "link text")))
+        );
+
+        assert_eq!(
+            rst_parse_text2label("`link text`_abc"),
+            Ok(("abc", ("link text", "link text")))
+        );
+
+        assert_eq!(
+            rst_parse_text2label("`link_text`_ abc"),
+            Ok((" abc", ("link_text", "link_text")))
+        );
+
+        assert_eq!(
+            rst_parse_text2label("`link text`__ abc"),
+            Ok((" abc", ("link text", "_")))
+        );
+
+        assert_eq!(
+            rst_parse_text2label("`link text<link label_>`_ abc"),
+            Ok((" abc", ("link text", "link label")))
+        );
+    }
+
+    #[test]
+    fn test_rst_label2dest() {
+        let expected = (
+            "\nabc",
+            (
+                Cow::from("Python: home page"),
+                Cow::from("http://www.python.org"),
+                Cow::from(""),
+            ),
+        );
+        assert_eq!(
+            rst_label2dest(".. _`Python: home page`: http://www.python.org\nabc").unwrap(),
+            expected
+        );
+        assert_eq!(
+            rst_label2dest("  .. _`Python: home page`: http://www.py\n     thon.org    \nabc")
+                .unwrap(),
+            expected
+        );
+
+        let expected = nom::Err::Error(nom::error::Error::new(
+            "x .. _`Python: home page`: http://www.python.org\nabc",
+            ErrorKind::Tag,
+        ));
+        assert_eq!(
+            rst_label2dest("x .. _`Python: home page`: http://www.python.org\nabc").unwrap_err(),
+            expected
+        );
+
+        let expected = (
+            "",
+            (
+                Cow::from("Python: `home page`"),
+                Cow::from("http://www.python .org"),
+                Cow::from(""),
+            ),
+        );
+        assert_eq!(
+            rst_label2dest(r#".. _Python\: \`home page\`: http://www.python\ .org"#).unwrap(),
+            expected
+        );
+        assert_eq!(
+            rst_label2dest(r#".. _`Python: \`home page\``: http://www.python\ .org"#).unwrap(),
+            expected
+        );
+
+        let expected = (
+            "",
+            (
+                Cow::from("my news at <http://python.org>"),
+                Cow::from("http://news.python.org"),
+                Cow::from(""),
+            ),
+        );
+        assert_eq!(
+            rst_label2dest(r#".. _`my news at <http://python.org>`: http://news.python.org"#)
+                .unwrap(),
+            expected
+        );
+        assert_eq!(
+            rst_label2dest(r#".. _`my news at \<http://python.org\>`: http://news.python.org"#)
+                .unwrap(),
+            expected
+        );
+        assert_eq!(
+            rst_label2dest(r#".. _my news at \<http\://python.org\>: http://news.python.org"#)
+                .unwrap(),
+            expected
+        );
+
+        let expected = (
+            "",
+            (
+                Cow::from("my news"),
+                Cow::from("http://news.<python>.org"),
+                Cow::from(""),
+            ),
+        );
+        assert_eq!(
+            rst_label2dest(r#".. _my news: http://news.<python>.org"#).unwrap(),
+            expected
+        );
+        assert_eq!(
+            rst_label2dest(r#".. _my news: http://news.\<python\>.org"#).unwrap(),
+            expected
+        );
+
+        let expected = (
+            "",
+            (
+                Cow::from("_"),
+                Cow::from("http://news.python.org"),
+                Cow::from(""),
+            ),
+        );
+        assert_eq!(
+            rst_label2dest(r#".. __: http://news.python.org"#).unwrap(),
+            expected
+        );
+        assert_eq!(
+            rst_label2dest(r#"__ http://news.python.org"#).unwrap(),
+            expected
+        );
+        assert_eq!(
+            rst_label2dest(".. _label: `link destination`_").unwrap_err(),
+            nom::Err::Error(nom::error::Error::new(
+                ".. _label: `link destination`_",
+                ErrorKind::EscapedTransform
+            )),
+        );
+        assert_eq!(
+            rst_label2dest("__ link_destination_").unwrap_err(),
+            nom::Err::Error(nom::error::Error::new(
+                "__ link_destination_",
+                ErrorKind::EscapedTransform
+            )),
+        );
+    }
+
+    #[test]
+    fn test_rst_label2label() {
+        assert_eq!(
+            rst_label2label("   .. _`alt label`: `label`_\nabc"),
+            Ok(("\nabc", (Cow::from("alt label"), Cow::from("label"))))
+        );
+        assert_eq!(
+            rst_label2label("   .. __: label_\nabc"),
+            Ok(("\nabc", (Cow::from("_"), Cow::from("label"))))
+        );
+        assert_eq!(
+            rst_label2label("   __ label_\nabc"),
+            Ok(("\nabc", (Cow::from("_"), Cow::from("label"))))
+        );
+        assert_eq!(
+            rst_label2label("_label: label").unwrap_err(),
+            nom::Err::Error(nom::error::Error::new("_label: label", ErrorKind::Tag)),
+        );
+        assert_eq!(
+            rst_label2label("__ destination").unwrap_err(),
+            nom::Err::Error(nom::error::Error::new("", ErrorKind::Tag)),
+        );
+    }
+
+    #[test]
+    fn test_rst_parse_label2target() {
+        let expected = ("", ("Python home page", "http://www.python.org"));
+        assert_eq!(
+            rst_parse_label2target(false)("_Python home page: http://www.python.org").unwrap(),
+            expected
+        );
+        assert_eq!(
+            rst_parse_label2target(false)("_`Python home page`: http://www.python.org").unwrap(),
+            expected
+        );
+
+        let expected = ("", ("Python: home page", "http://www.python.org"));
+        assert_eq!(
+            rst_parse_label2target(false)("_`Python: home page`: http://www.python.org").unwrap(),
+            expected
+        );
+
+        let expected = ("", (r#"Python\: home page"#, "http://www.python.org"));
+        assert_eq!(
+            rst_parse_label2target(false)(r#"_Python\: home page: http://www.python.org"#).unwrap(),
+            expected
+        );
+
+        let expected = (
+            "",
+            ("my news at <http://python.org>", "http://news.python.org"),
+        );
+        assert_eq!(
+            rst_parse_label2target(false)(
+                r#"_`my news at <http://python.org>`: http://news.python.org"#
+            )
+            .unwrap(),
+            expected
+        );
+
+        let expected = (
+            "",
+            (
+                r#"my news at \<http://python.org\>"#,
+                "http://news.python.org",
+            ),
+        );
+        assert_eq!(
+            rst_parse_label2target(false)(
+                r#"_`my news at \<http://python.org\>`: http://news.python.org"#
+            )
+            .unwrap(),
+            expected
+        );
+
+        let expected = (
+            "",
+            (
+                r#"my news at \<http\://python.org\>"#,
+                "http://news.python.org",
+            ),
+        );
+        assert_eq!(
+            rst_parse_label2target(false)(
+                r#"_my news at \<http\://python.org\>: http://news.python.org"#
+            )
+            .unwrap(),
+            expected
+        );
+
+        let expected = ("", ("_", "http://news.python.org"));
+        assert_eq!(
+            rst_parse_label2target(false)(r#"__: http://news.python.org"#).unwrap(),
+            expected
+        );
+
+        let expected = ("", ("alt_label", "one_word_label"));
+        assert_eq!(
+            rst_parse_label2target(true)("_alt_label: one_word_label_").unwrap(),
+            expected
+        );
+
+        let expected = ("", ("alt label", "more words label"));
+        assert_eq!(
+            rst_parse_label2target(true)("_`alt label`: `more words label`_").unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn test_parse_simple_label() {
+        let expected = ("", "one_word_label");
+        assert_eq!(rst_parse_simple_label("one_word_label_").unwrap(), expected);
+
+        let expected = (" abc", "one_word_label");
+        assert_eq!(
+            rst_parse_simple_label("one_word_label_ abc").unwrap(),
+            expected
+        );
+        assert_eq!(
+            rst_parse_simple_label("`one_word_label`_ abc").unwrap(),
+            expected
+        );
+
+        let expected = ("", "more words label");
+        assert_eq!(
+            rst_parse_simple_label("`more words label`_").unwrap(),
+            expected
+        );
+
+        let expected = (". abc", "more words label");
+        assert_eq!(
+            rst_parse_simple_label("`more words label`_. abc").unwrap(),
+            expected
+        );
+
+        let expected = ("? abc", "more words label");
+        assert_eq!(
+            rst_parse_simple_label("`more words label`_? abc").unwrap(),
+            expected
+        );
+
+        let expected = (" abc", "more words label");
+        assert_eq!(
+            rst_parse_simple_label("`more words label`_ abc").unwrap(),
+            expected
+        );
+
+        assert_eq!(
+            rst_parse_simple_label("_").unwrap_err(),
+            nom::Err::Error(nom::error::Error::new("", ErrorKind::Not)),
+        );
+
+        assert_eq!(
+            rst_parse_simple_label("``_").unwrap_err(),
+            nom::Err::Error(nom::error::Error::new("``_", ErrorKind::TakeTill1)),
+        );
+    }
+
+    #[test]
+    fn test_rst_explicit_markup_block() {
+        assert_eq!(
+            rst_explicit_markup_block(".. ")(".. 11111"),
+            Ok(("", Cow::from("11111")))
+        );
+        assert_eq!(
+            rst_explicit_markup_block(".. ")("   .. 11111\nout"),
+            Ok(("\nout", Cow::from("11111")))
+        );
+        assert_eq!(
+            rst_explicit_markup_block(".. ")("   .. 11111\n      222222\n      333333\nout"),
+            Ok(("\nout", Cow::from("11111 222222 333333")))
+        );
+        assert_eq!(
+            rst_explicit_markup_block(".. ")("   .. first\n      second\n       1indent\nout"),
+            Ok(("\nout", Cow::from("first second  1indent")))
+        );
+        assert_eq!(
+            rst_explicit_markup_block(".. ")("   ..first"),
+            Err(nom::Err::Error(nom::error::Error::new(
+                "..first",
+                ErrorKind::Tag
+            )))
+        );
+        assert_eq!(
+            rst_explicit_markup_block(".. ")("x  .. first"),
+            Err(nom::Err::Error(nom::error::Error::new(
+                "x  .. first",
+                ErrorKind::Tag
+            )))
+        );
+    }
+
+    #[test]
+    fn test_rst_escaped_link_text_transform() {
+        assert_eq!(rst_escaped_link_text_transform(""), Ok(("", Cow::from(""))));
+        // Different than the link destination version.
+        assert_eq!(
+            rst_escaped_link_text_transform("   "),
+            Ok(("", Cow::from("   ")))
+        );
+        // Different than the link destination version.
+        assert_eq!(
+            rst_escaped_link_text_transform(r#"\ \ \ "#),
+            Ok(("", Cow::from("")))
+        );
+        assert_eq!(
+            rst_escaped_link_text_transform(r#"abc`:<>abc"#),
+            Ok(("", Cow::from(r#"abc`:<>abc"#)))
+        );
+        assert_eq!(
+            rst_escaped_link_text_transform(r#"\:\`\<\>\\"#),
+            Ok(("", Cow::from(r#":`<>\"#)))
+        );
+    }
+
+    #[test]
+    fn test_rst_escaped_link_destination_transform() {
+        assert_eq!(
+            rst_escaped_link_destination_transform(""),
+            Ok(("", Cow::Borrowed("")))
+        );
+        // Different than the link name version.
+        assert_eq!(
+            rst_escaped_link_destination_transform("  "),
+            Ok(("", Cow::Borrowed("")))
+        );
+        assert_eq!(
+            rst_escaped_link_destination_transform(" x x"),
+            Ok(("", Cow::Owned("xx".to_string())))
+        );
+        // Different than the link name version.
+        assert_eq!(
+            rst_escaped_link_destination_transform(r#"\ \ \ "#),
+            Ok(("", Cow::Owned("   ".to_string())))
+        );
+        assert_eq!(
+            rst_escaped_link_destination_transform(r#"abc`:<>abc"#),
+            Ok(("", Cow::Borrowed(r#"abc`:<>abc"#)))
+        );
+        assert_eq!(
+            rst_escaped_link_destination_transform(r#"\:\`\<\>\\"#),
+            Ok(("", Cow::Owned(r#":`<>\"#.to_string())))
+        );
+    }
+    #[test]
+    fn test_remove_whitespace() {
+        assert_eq!(remove_whitespace(" abc "), Ok(("", Cow::Borrowed("abc"))));
+        assert_eq!(
+            remove_whitespace(" x x"),
+            Ok(("", Cow::Owned("xx".to_string())))
+        );
+        assert_eq!(remove_whitespace("  \t \r \n"), Ok(("", Cow::from(""))));
+        assert_eq!(
+            remove_whitespace(r#"\ \ \ "#),
+            Ok(("", Cow::Borrowed(r#"\ \ \ "#)))
+        );
+        assert_eq!(
+            remove_whitespace(r#"abc`:<>abc"#),
+            Ok(("", Cow::Borrowed(r#"abc`:<>abc"#)))
+        );
+        assert_eq!(
+            remove_whitespace(r#"\:\`\<\>\\"#),
+            Ok(("", Cow::Borrowed(r#"\:\`\<\>\\"#)))
+        );
+
+        assert_eq!(
+            remove_whitespace("http://www.py\n     thon.org"),
+            Ok(("", Cow::Owned("http://www.python.org".to_string())))
+        );
+    }
+}

--- a/deps/parse-hyperlinks/src/parser/wikitext.rs
+++ b/deps/parse-hyperlinks/src/parser/wikitext.rs
@@ -1,0 +1,162 @@
+//! This module implements parsers for Wikitext hyperlinks.
+#![allow(dead_code)]
+#![allow(clippy::type_complexity)]
+
+use crate::parser::Link;
+use nom::branch::alt;
+use nom::bytes::complete::is_not;
+use nom::bytes::complete::tag;
+use percent_encoding::percent_decode_str;
+use std::borrow::Cow;
+
+/// Wrapper around `wikitext_text2dest()` that packs the result in
+/// `Link::Text2Dest`.
+pub fn wikitext_text2dest_link(i: &str) -> nom::IResult<&str, Link> {
+    let (i, (te, de, ti)) = wikitext_text2dest(i)?;
+    Ok((i, Link::Text2Dest(te, de, ti)))
+}
+
+/// Parse an Wikitext _inline hyperlink_.
+///
+/// It returns either `Ok((i, (link_text, link_destination, Cow::from("")))`
+/// or some error.
+///
+/// The parser expects to start at the link start (`[`) to succeed.
+/// ```
+/// use parse_hyperlinks::parser::Link;
+/// use parse_hyperlinks::parser::wikitext::wikitext_text2dest;
+/// use std::borrow::Cow;
+///
+/// let expected = (
+///     "abc",
+///     (
+///         Cow::from("W3Schools"),
+///         Cow::from("https://www.w3schools.com/"),
+///         Cow::from(""),
+///     ),
+/// );
+/// assert_eq!(
+///     wikitext_text2dest("[https://www.w3schools.com/ W3Schools]abc").unwrap(),
+///     expected
+/// );
+/// ```
+pub fn wikitext_text2dest(i: &str) -> nom::IResult<&str, (Cow<str>, Cow<str>, Cow<str>)> {
+    let (i, (link_text, link_destination)) = nom::sequence::delimited(
+        // HTML is case insensitive. XHTML, that is being XML is case sensitive.
+        // Here we deal with HTML.
+        tag("["),
+        nom::combinator::map_parser(is_not("]\n\r"), parse_inner),
+        tag("]"),
+    )(i)?;
+    Ok((i, (link_text, link_destination, Cow::from(""))))
+}
+
+/// Parse link destination and link text.
+fn parse_inner(i: &str) -> nom::IResult<&str, (Cow<str>, Cow<str>)> {
+    let (i, link_destination) = nom::sequence::terminated(
+        nom::combinator::map_parser(
+            nom::bytes::complete::take_till(|c| c == ' ' || c == '\t'),
+            parse_url,
+        ),
+        nom::character::complete::space0,
+    )(i)?;
+    let link_text = i;
+    Ok((i, (Cow::from(link_text), link_destination)))
+}
+
+/// Parse URL.
+fn parse_url(i: &str) -> nom::IResult<&str, Cow<str>> {
+    nom::combinator::peek(alt((tag("http:"), tag("https:"), tag("mailto:"))))(i)?;
+    // We can safely unwrap here because `str` is guaranteed to be
+    // UTF-8.
+    let url = percent_decode_str(i).decode_utf8().unwrap();
+    Ok(("", url))
+}
+
+#[test]
+fn test_wikitext_text2dest() {
+    let expected = (
+        "abc",
+        (
+            Cow::from("W3Schools"),
+            Cow::from("https://www.w3schools.com/"),
+            Cow::from(""),
+        ),
+    );
+    assert_eq!(
+        wikitext_text2dest(r#"[https://www.w3schools.com/ W3Schools]abc"#).unwrap(),
+        expected
+    );
+    assert_eq!(
+        wikitext_text2dest(r#"[https://www.w3schools.com/   W3Schools]abc"#).unwrap(),
+        expected
+    );
+    let expected = (
+        "abc",
+        (
+            Cow::from("W3Schools"),
+            Cow::from("http://www.w3schools.com/"),
+            Cow::from(""),
+        ),
+    );
+    assert_eq!(
+        wikitext_text2dest(r#"[http://www.w3schools.com/ W3Schools]abc"#).unwrap(),
+        expected
+    );
+    let expected = (
+        "abc",
+        (
+            Cow::from("W3Schools website"),
+            Cow::from("http://www.w3schools.com/"),
+            Cow::from(""),
+        ),
+    );
+    assert_eq!(
+        wikitext_text2dest(r#"[http://www.w3schools.com/ W3Schools website]abc"#).unwrap(),
+        expected
+    );
+    assert_eq!(
+        wikitext_text2dest("[http://www.w3schools.com/\tW3Schools website]abc").unwrap(),
+        expected
+    );
+    let expected = (
+        "abc",
+        (
+            Cow::from(""),
+            Cow::from("http://www.w3schools.com/"),
+            Cow::from(""),
+        ),
+    );
+    assert_eq!(
+        wikitext_text2dest(r#"[http://www.w3schools.com/]abc"#).unwrap(),
+        expected
+    );
+    assert_eq!(
+        wikitext_text2dest(r#"[http://www.w3schools.com/ ]abc"#).unwrap(),
+        expected
+    );
+    assert_eq!(
+        wikitext_text2dest("[http://www.w3schools.com/\t ]abc").unwrap(),
+        expected
+    );
+    let expected = (
+        "abc",
+        (
+            Cow::from("John Don"),
+            Cow::from("mailto:john.don@somemail.com"),
+            Cow::from(""),
+        ),
+    );
+    assert_eq!(
+        wikitext_text2dest(r#"[mailto:john.don@somemail.com John Don]abc"#).unwrap(),
+        expected
+    );
+
+    assert_eq!(
+        wikitext_text2dest(r#"[httpx://www.w3schools.com/ W3Schools]abc"#).unwrap_err(),
+        nom::Err::Error(nom::error::Error::new(
+            "httpx://www.w3schools.com/",
+            nom::error::ErrorKind::Tag
+        ))
+    );
+}

--- a/deps/parse-hyperlinks/src/renderer.rs
+++ b/deps/parse-hyperlinks/src/renderer.rs
@@ -1,0 +1,831 @@
+//! A set of functions providing markup source code to HTML renderer, that make
+//! hyperlinks clickable.
+
+use crate::iterator::Hyperlink;
+use html_escape::encode_double_quoted_attribute;
+use html_escape::encode_safe;
+use html_escape::encode_text;
+use std::borrow::Cow;
+use std::io;
+use std::io::Write;
+
+fn render<'a, O, P, W>(
+    input: &'a str,
+    begin_doc: &str,
+    end_doc: &str,
+    verb_renderer: O,
+    link_renderer: P,
+    render_label: bool,
+    output: &mut W,
+) -> Result<(), io::Error>
+where
+    O: Fn(Cow<'a, str>) -> Cow<'a, str>,
+    P: Fn((Cow<'a, str>, (String, String, String))) -> String,
+    W: Write,
+{
+    // As this will be overwritten inside the loop, the first value only counts
+    // when there are no hyperlinks in the input. In this case we print the
+    // input as a whole.
+    let mut rest = Cow::Borrowed(input);
+
+    output.write_all(begin_doc.as_bytes())?;
+    for ((skipped2, consumed2, remaining2), (text2, dest2, title2)) in
+        Hyperlink::new(input, render_label)
+    {
+        let skipped = encode_text(skipped2);
+        let consumed = encode_text(consumed2);
+        let remaining = encode_text(remaining2);
+        let text = encode_safe(&text2).to_string();
+        let dest = encode_double_quoted_attribute(&dest2).to_string();
+        let title = encode_double_quoted_attribute(&title2).to_string();
+        output.write_all(verb_renderer(skipped).as_bytes())?;
+        let rendered_link = link_renderer((consumed, (text, dest, title)));
+        output.write_all(rendered_link.as_bytes())?;
+        rest = remaining;
+    }
+    output.write_all(verb_renderer(rest).as_bytes())?;
+    output.write_all(end_doc.as_bytes())?;
+    Ok(())
+}
+
+/// # Source code viewer with link renderer
+///
+/// Text to HTML renderer that prints the input text “as it is”, but
+/// renders links with markup. Links are clickable and only their
+/// _link text_ is shown (the part enclosed with `<a>` and `</a>`).
+///
+/// ## Markdown
+/// ```
+/// use parse_hyperlinks::renderer::text_links2html;
+/// use std::borrow::Cow;
+///
+/// let i = r#"abc[text0](dest0 "title0")abc
+/// abc[text1][label1]abc
+/// abc[text2](dest2 "title2")abc
+/// [text3]: dest3 "title3"
+/// [label1]: dest1 "title1"
+/// abc[text3]abc
+/// "#;
+///
+/// let expected = "\
+/// <pre>abc<a href=\"dest0\" title=\"title0\">text0</a>abc
+/// abc<a href=\"dest1\" title=\"title1\">text1</a>abc
+/// abc<a href=\"dest2\" title=\"title2\">text2</a>abc
+/// <a href=\"dest3\" title=\"title3\">[text3]: dest3 &quot;title3&quot;</a>
+/// <a href=\"dest1\" title=\"title1\">[label1]: dest1 &quot;title1&quot;</a>
+/// abc<a href=\"dest3\" title=\"title3\">text3</a>abc
+/// </pre>";
+/// let res = text_links2html(i);
+/// assert_eq!(res, expected);
+/// ```
+///
+/// ### Rendered text
+///
+/// This is how the rendered text looks like in the browser:
+///
+/// <pre>abc<a href="dest0" title="title0">text0</a>abc
+/// abc<a href="dest1" title="title1">text1</a>abc
+/// abc<a href="dest2" title="title2">text2</a>abc
+/// <a href="dest3" title="title3">[text3]: dest3 &quot;title3&quot;</a>
+/// <a href="dest1" title="title1">[label1]: dest1 &quot;title1&quot;</a>
+/// abc<a href="dest3" title="title3">text3</a>abc
+/// </pre>
+///
+/// ## reStructuredText
+/// ```
+/// use parse_hyperlinks::renderer::text_links2html;
+/// use std::borrow::Cow;
+///
+/// let i = r#"abc `text1 <label1_>`_abc
+/// abc text2_ abc
+/// abc text3__ abc
+/// abc text_label4_ abc
+/// abc text5__ abc
+/// .. _label1: dest1
+/// .. _text2: dest2
+/// .. __: dest3
+/// __ dest5
+/// "#;
+///
+/// let expected = "\
+/// <pre>abc <a href=\"dest1\" title=\"\">text1</a>abc
+/// abc <a href=\"dest2\" title=\"\">text2</a> abc
+/// abc <a href=\"dest3\" title=\"\">text3</a> abc
+/// abc text_label4_ abc
+/// abc <a href=\"dest5\" title=\"\">text5</a> abc
+/// <a href=\"dest1\" title=\"\">.. _label1: dest1</a>
+/// <a href=\"dest2\" title=\"\">.. _text2: dest2</a>
+/// <a href=\"dest3\" title=\"\">.. __: dest3</a>
+/// <a href=\"dest5\" title=\"\">__ dest5</a>
+/// </pre>\
+/// ";
+///
+/// let res = text_links2html(i);
+/// assert_eq!(res, expected);
+/// ```
+///
+/// ### Rendered text
+///
+/// This is how the rendered text looks like in the browser:
+///
+/// <pre>abc <a href="dest1" title="">text1</a>abc
+/// abc <a href="dest2" title="">text2</a> abc
+/// abc <a href="dest3" title="">text3</a> abc
+/// abc text_label4_ abc
+/// abc <a href="dest5" title="">text5</a> abc
+/// <a href="dest1" title="">.. _label1: dest1</a>
+/// <a href="dest2" title="">.. _text2: dest2</a>
+/// <a href="dest3" title="">.. __: dest3</a>
+/// <a href="dest5" title="">__ dest5</a>
+/// </pre>
+///
+/// ## Asciidoc
+///
+/// ```
+/// use parse_hyperlinks::renderer::text_links2html;
+/// use std::borrow::Cow;
+///
+/// let i = r#"abc https://dest0[text0]abc
+/// abc link:https://dest1[text1]abc
+/// abc{label2}[text2]abc
+/// abc{label3}abc
+/// :label2: https://dest2
+/// :label3: https://dest3
+/// "#;
+///
+/// let expected = "\
+/// <pre>abc <a href=\"https://dest0\" title=\"\">text0</a>abc
+/// abc <a href=\"https://dest1\" title=\"\">text1</a>abc
+/// abc<a href=\"https://dest2\" title=\"\">text2</a>abc
+/// abc<a href=\"https://dest3\" title=\"\">https:&#x2F;&#x2F;dest3</a>abc
+/// <a href=\"https://dest2\" title=\"\">:label2: https:&#x2F;&#x2F;dest2</a>
+/// <a href=\"https://dest3\" title=\"\">:label3: https:&#x2F;&#x2F;dest3</a>
+/// </pre>";
+///
+/// let res = text_links2html(i);
+/// assert_eq!(res, expected);
+/// ```
+///
+/// ### Rendered text
+///
+/// This is how the rendered text looks like in the browser:
+///
+/// <pre>abc <a href="https://dest0" title="">text0</a>abc
+/// abc <a href="https://dest1" title="">text1</a>abc
+/// abc<a href="https://dest2" title="">text2</a>abc
+/// abc<a href="https://dest3" title="">https:&#x2F;&#x2F;dest3</a>abc
+/// <a href="https://dest2" title="">:label2: https:&#x2F;&#x2F;dest2</a>
+/// <a href="https://dest3" title="">:label3: https:&#x2F;&#x2F;dest3</a>
+/// </pre>
+///
+///
+/// ## Wikitext
+///
+/// ```
+/// use parse_hyperlinks::renderer::text_links2html;
+/// use std::borrow::Cow;
+///
+/// let i = r#"abc[https://dest0 text0]abc
+/// "#;
+///
+/// let expected = "\
+/// <pre>abc<a href=\"https://dest0\" title=\"\">text0</a>abc
+/// </pre>";
+///
+/// let res = text_links2html(i);
+/// assert_eq!(res, expected);
+/// ```
+///
+/// ### Rendered text
+///
+/// This is how the rendered text looks like in the browser:
+///
+/// <pre>abc<a href="https://dest0" title="">text0</a>abc
+/// </pre>
+///
+///
+/// ## HTML
+///
+/// HTML _inline links_ are sanitized and passed through.
+///
+/// ```
+/// use parse_hyperlinks::renderer::text_links2html;
+/// use std::borrow::Cow;
+///
+/// let i = r#"abc<a href="dest1" title="title1">text1</a>abc"#;
+///
+/// let expected = "<pre>\
+/// abc<a href=\"dest1\" title=\"title1\">text1</a>abc\
+/// </pre>";
+///
+/// let res = text_links2html(i);
+/// assert_eq!(res, expected);
+/// ```
+///
+/// ### Rendered text
+///
+/// This is how the rendered text looks like in the browser:
+///
+/// <pre>
+/// abc<a href="dest1" title="title1">text1</a>abc
+/// </pre>
+///
+#[inline]
+pub fn text_links2html(input: &str) -> String {
+    let mut output = Vec::new();
+    text_links2html_writer(input, &mut output).unwrap_or_default();
+    // We know this is safe, because only `str` have been written into `output`.
+    // So the following would be fine, but I want to keep this crate `unsafe`-free.
+    //    unsafe {String::from_utf8_unchecked(output)}
+    String::from_utf8(output).unwrap_or_default()
+}
+
+/// # Source code viewer with link renderer
+///
+/// Same as `text_links2html()`, but it uses `Write` for output. This function
+/// allocates much less memory and is faster because it avoids copying.
+///
+/// Usage example:
+/// ```no_run
+/// use parse_hyperlinks::renderer::text_links2html_writer;
+/// use std::io;
+/// use std::io::Read;
+/// fn main() -> Result<(), ::std::io::Error> {
+///     let mut stdin = String::new();
+///     Read::read_to_string(&mut io::stdin(), &mut stdin)?;
+///
+///     text_links2html_writer(&stdin, &mut io::stdout())?;
+///
+///     Ok(())
+/// }
+/// ```
+pub fn text_links2html_writer<'a, S: 'a + AsRef<str>, W: Write>(
+    input: S,
+    output: &mut W,
+) -> Result<(), io::Error> {
+    let input = input.as_ref();
+
+    let verb_renderer = |verb| verb;
+
+    let link_renderer = |(_, (text, dest, title)): (_, (String, String, String))| {
+        let mut s = String::new();
+        s.push_str(r#"<a href=""#);
+        s.push_str(&*dest);
+        s.push_str(r#"" title=""#);
+        s.push_str(&*title);
+        s.push_str(r#"">"#);
+        s.push_str(&*text);
+        s.push_str(r#"</a>"#);
+        s
+    };
+
+    render(
+        input,
+        "<pre>",
+        "</pre>",
+        verb_renderer,
+        link_renderer,
+        true,
+        output,
+    )
+}
+
+/// # Markup source code viewer
+///
+/// Markup source code viewer, that make hyperlinks
+/// clickable in your web-browser.
+///
+/// This function prints the input text “as it is”, but
+/// renders links with markup. Links are clickable.
+///
+/// ## Markdown
+/// ```
+/// use parse_hyperlinks::renderer::text_rawlinks2html;
+/// use std::borrow::Cow;
+///
+/// let i = r#"abc[text0](dest0 "title0")abc
+/// abc[text1][label1]abc
+/// abc[text2](dest2 "title2")abc
+/// [text3]: dest3 "title3"
+/// [label1]: dest1 "title1"
+/// abc[text3]abc
+/// "#;
+///
+/// let expected = "\
+/// <pre>abc<a href=\"dest0\" title=\"title0\">[text0](dest0 \"title0\")</a>abc
+/// abc<a href=\"dest1\" title=\"title1\">[text1][label1]</a>abc
+/// abc<a href=\"dest2\" title=\"title2\">[text2](dest2 \"title2\")</a>abc
+/// <a href=\"dest3\" title=\"title3\">[text3]: dest3 \"title3\"</a>
+/// <a href=\"dest1\" title=\"title1\">[label1]: dest1 \"title1\"</a>
+/// abc<a href=\"dest3\" title=\"title3\">[text3]</a>abc
+/// </pre>";
+///
+/// let res = text_rawlinks2html(i);
+/// assert_eq!(res, expected);
+/// ```
+///
+/// ### Rendered text
+///
+/// This is how the rendered text looks like in the browser:
+///
+/// <pre>abc<a href="dest0" title="title0">[text0](dest0 "title0")</a>abc
+/// abc<a href="dest1" title="title1">[text1][label1]</a>abc
+/// abc<a href="dest2" title="title2">[text2](dest2 "title2")</a>abc
+/// <a href="dest3" title="title3">[text3]: dest3 "title3"</a>
+/// <a href="dest1" title="title1">[label1]: dest1 "title1"</a>
+/// abc<a href="dest3" title="title3">[text3]</a>abc
+/// </pre>
+///
+/// ## reStructuredText
+/// ```
+/// use parse_hyperlinks::renderer::text_rawlinks2html;
+/// use std::borrow::Cow;
+///
+/// let i = r#"
+/// abc `text1 <label1_>`_abc
+/// abc text2_ abc
+/// abc text3__ abc
+/// abc text_label4_ abc
+/// abc text5__ abc
+/// .. _label1: dest1
+/// .. _text2: dest2
+/// .. __: dest3
+/// __ dest5
+/// "#;
+///
+/// let expected = "\
+/// <pre>
+/// abc <a href=\"dest1\" title=\"\">`text1 &lt;label1_&gt;`_</a>abc
+/// abc <a href=\"dest2\" title=\"\">text2_</a> abc
+/// abc <a href=\"dest3\" title=\"\">text3__</a> abc
+/// abc text_label4_ abc
+/// abc <a href=\"dest5\" title=\"\">text5__</a> abc
+/// <a href=\"dest1\" title=\"\">.. _label1: dest1</a>
+/// <a href=\"dest2\" title=\"\">.. _text2: dest2</a>
+/// <a href=\"dest3\" title=\"\">.. __: dest3</a>
+/// <a href=\"dest5\" title=\"\">__ dest5</a>
+/// </pre>";
+///
+/// let res = text_rawlinks2html(i);
+/// assert_eq!(res, expected);
+/// ```
+///
+/// ### Rendered text
+///
+/// This is how the rendered text look likes in the browser:
+///
+/// <pre>
+/// abc <a href="dest1" title="">`text1 &lt;label1_&gt;`_</a>abc
+/// abc <a href="dest2" title="">text2_</a> abc
+/// abc <a href="dest3" title="">text3__</a> abc
+/// abc text_label4_ abc
+/// abc <a href="dest5" title="">text5__</a> abc
+/// <a href="dest1" title="">.. _label1: dest1</a>
+/// <a href="dest2" title="">.. _text2: dest2</a>
+/// <a href="dest3" title="">.. __: dest3</a>
+/// <a href="dest5" title="">__ dest5</a>
+/// </pre>
+///
+/// ## Asciidoc
+///
+/// ```
+/// use parse_hyperlinks::renderer::text_rawlinks2html;
+/// use std::borrow::Cow;
+///
+/// let i = r#"abc https://dest0[text0]abc
+/// abc link:https://dest1[text1]abc
+/// abc{label2}[text2]abc
+/// abc{label3}abc
+/// :label2: https://dest2
+/// :label3: https://dest3
+/// "#;
+///
+/// let expected = "\
+/// <pre>abc <a href=\"https://dest0\" title=\"\">https://dest0[text0]</a>abc
+/// abc <a href=\"https://dest1\" title=\"\">link:https://dest1[text1]</a>abc
+/// abc<a href=\"https://dest2\" title=\"\">{label2}[text2]</a>abc
+/// abc<a href=\"https://dest3\" title=\"\">{label3}</a>abc
+/// <a href=\"https://dest2\" title=\"\">:label2: https://dest2</a>
+/// <a href=\"https://dest3\" title=\"\">:label3: https://dest3</a>
+/// </pre>";
+///
+/// let res = text_rawlinks2html(i);
+/// assert_eq!(res, expected);
+/// ```
+///
+/// ### Rendered text
+///
+/// This is how the rendered text looks like in the browser:
+///
+/// <pre>abc <a href="https://dest0" title="">https://dest0[text0]</a>abc
+/// abc <a href="https://dest1" title="">link:https://dest1[text1]</a>abc
+/// abc<a href="https://dest2" title="">{label2}[text2]</a>abc
+/// abc<a href="https://dest3" title="">{label3}</a>abc
+/// <a href="https://dest2" title="">:label2: https://dest2</a>
+/// <a href="https://dest3" title="">:label3: https://dest3</a>
+/// </pre>
+///
+///
+/// ## Wikitext
+///
+/// ```
+/// use parse_hyperlinks::renderer::text_rawlinks2html;
+/// use std::borrow::Cow;
+///
+/// let i = r#"abc[https://dest0 text0]abc
+/// "#;
+///
+/// let expected = "\
+/// <pre>abc<a href=\"https://dest0\" title=\"\">[https://dest0 text0]</a>abc
+/// </pre>";
+///
+/// let res = text_rawlinks2html(i);
+/// assert_eq!(res, expected);
+/// ```
+///
+/// ### Rendered text
+///
+/// This is how the rendered text looks like in the browser:
+///
+/// <pre>abc<a href="https://dest0" title="">[https://dest0 text0]</a>abc
+/// </pre>
+///
+/// ## HTML
+///
+/// HTML _inline links_ are sanitized and their link
+/// source code is shown as _link text_.
+///
+/// ```
+/// use parse_hyperlinks::renderer::text_rawlinks2html;
+/// use std::borrow::Cow;
+///
+/// let i = r#"abc<a href="dest1" title="title1">text1</a>abc"#;
+///
+/// let expected = "\
+/// <pre>abc<a href=\"dest1\" title=\"title1\">\
+/// &lt;a href=\"dest1\" title=\"title1\"&gt;text1&lt;/a&gt;\
+/// </a>abc</pre>";
+///
+/// let res = text_rawlinks2html(i);
+/// assert_eq!(res, expected);
+/// ```
+///
+/// ### Rendered text
+///
+/// This is how the rendered text looks like in the browser:
+///
+/// <pre>
+/// abc<a href="dest1" title="title1">&lt;a href="dest1" title="title1"&gt;text1&lt;/a&gt;</a>abc
+/// </pre>
+///
+#[inline]
+pub fn text_rawlinks2html(input: &str) -> String {
+    let mut output = Vec::new();
+    text_rawlinks2html_writer(input, &mut output).unwrap_or_default();
+    // We know this is safe, because only `str` have been written into `output`.
+    // So the following would be fine, but I want to keep this crate `unsafe`-free.
+    //    unsafe {String::from_utf8_unchecked(output)}
+    String::from_utf8(output).unwrap_or_default()
+}
+
+/// # Markup source code viewer
+///
+/// Same as `text_rawlinks2html()`, but it uses `Write` for output. This function
+/// allocates much less memory and is faster because it avoids copying.
+///
+/// Usage example:
+/// ```no_run
+/// use parse_hyperlinks::renderer::text_rawlinks2html_writer;
+/// use std::io;
+/// use std::io::Read;
+/// fn main() -> Result<(), ::std::io::Error> {
+///     let mut stdin = String::new();
+///     Read::read_to_string(&mut io::stdin(), &mut stdin)?;
+///
+///     text_rawlinks2html_writer(&stdin, &mut io::stdout())?;
+///
+///     Ok(())
+/// }
+/// ```
+pub fn text_rawlinks2html_writer<'a, S: 'a + AsRef<str>, W: Write>(
+    input: S,
+    output: &mut W,
+) -> Result<(), io::Error> {
+    let input = input.as_ref();
+
+    let verb_renderer = |verb| verb;
+
+    let link_renderer = |(consumed, (_, dest, title)): (Cow<str>, (_, String, String))| {
+        let mut s = String::new();
+        s.push_str(r#"<a href=""#);
+        s.push_str(&*dest);
+        s.push_str(r#"" title=""#);
+        s.push_str(&*title);
+        s.push_str(r#"">"#);
+        s.push_str(&*consumed);
+        s.push_str(r#"</a>"#);
+        s
+    };
+
+    render(
+        input,
+        "<pre>",
+        "</pre>",
+        verb_renderer,
+        link_renderer,
+        true,
+        output,
+    )
+}
+
+/// # Hyperlink extractor
+///
+/// Text to HTML renderer that prints only links with markup as
+/// a list, one per line. Links are clickable and only their
+/// _link text_ is shown (the part enclosed with `<a>` and `</a>`).
+///
+/// ## Markdown
+/// ```
+/// use parse_hyperlinks::renderer::links2html;
+/// use std::borrow::Cow;
+///
+/// let i = r#"abc[text0](dest0 "title0")abc
+/// abc[text1][label1]abc
+/// abc[text2](dest2 "title2")abc
+/// [text3]: dest3 "title3"
+/// [label1]: dest1 "title1"
+/// abc[text3]abc
+/// "#;
+///
+/// let expected = "\
+/// <a href=\"dest0\" title=\"title0\">text0</a>
+/// <a href=\"dest1\" title=\"title1\">text1</a>
+/// <a href=\"dest2\" title=\"title2\">text2</a>
+/// <a href=\"dest3\" title=\"title3\">text3</a>
+/// ";
+/// let res = links2html(i);
+/// assert_eq!(res, expected);
+/// ```
+///
+/// ### Rendered text
+///
+/// This is how the rendered text looks like in the browser:
+///
+/// <a href="dest0" title="title0">text0</a>
+/// <a href="dest1" title="title1">text1</a>
+/// <a href="dest2" title="title2">text2</a>
+/// <a href="dest3" title="title3">text3</a>
+///
+///
+/// ## reStructuredText
+/// ```
+/// use parse_hyperlinks::renderer::links2html;
+/// use std::borrow::Cow;
+///
+/// let i = r#"
+/// abc `text1 <label1_>`_abc
+/// abc text2_ abc
+/// abc text3__ abc
+/// abc text_label4_ abc
+/// abc text5__ abc
+/// .. _label1: dest1
+/// .. _text2: dest2
+/// .. __: dest3
+/// __ dest5
+/// "#;
+///
+/// let expected = "\
+/// <a href=\"dest1\" title=\"\">text1</a>
+/// <a href=\"dest2\" title=\"\">text2</a>
+/// <a href=\"dest3\" title=\"\">text3</a>
+/// <a href=\"dest5\" title=\"\">text5</a>
+/// ";
+///
+/// let res = links2html(i);
+/// assert_eq!(res, expected);
+/// ```
+///
+/// ### Rendered text
+///
+/// This is how the rendered text looks like in the browser:
+///
+/// <a href="dest1" title="">text1</a>
+/// <a href="dest2" title="">text2</a>
+/// <a href="dest3" title="">text3</a>
+/// <a href="dest5" title="">text5</a>
+///
+///
+/// ## Asciidoc
+///
+/// ```
+/// use parse_hyperlinks::renderer::links2html;
+/// use std::borrow::Cow;
+///
+/// let i = r#"abc https://dest0[text0]abc
+/// abc link:https://dest1[text1]abc
+/// abc{label2}[text2]abc
+/// abc{label3}abc
+/// :label2: https://dest2
+/// :label3: https://dest3
+/// "#;
+///
+/// let expected = "\
+/// <a href=\"https://dest0\" title=\"\">text0</a>
+/// <a href=\"https://dest1\" title=\"\">text1</a>
+/// <a href=\"https://dest2\" title=\"\">text2</a>
+/// <a href=\"https://dest3\" title=\"\">https:&#x2F;&#x2F;dest3</a>
+/// ";
+///
+/// let res = links2html(i);
+/// assert_eq!(res, expected);
+/// ```
+///
+/// ### Rendered text
+///
+/// This is how the rendered text looks like in the browser:
+///
+/// <a href="https://dest0" title="">text0</a>
+/// <a href="https://dest1" title="">text1</a>
+/// <a href="https://dest2" title="">text2</a>
+/// <a href="https://dest3" title="">https:&#x2F;&#x2F;dest3</a>
+///
+///
+/// ## Wikitext
+///
+/// ```
+/// use parse_hyperlinks::renderer::links2html;
+/// use std::borrow::Cow;
+///
+/// let i = r#"abc[https://dest0 text0]abc
+/// "#;
+///
+/// let expected = "\
+/// <a href=\"https://dest0\" title=\"\">text0</a>
+/// ";
+///
+/// let res = links2html(i);
+/// assert_eq!(res, expected);
+/// ```
+///
+/// ### Rendered text
+///
+/// This is how the rendered text looks like in the browser:
+///
+/// <a href="https://dest0" title="">text0</a>
+///
+///
+/// ## HTML
+///
+/// HTML _inline links_ are sanitized and listed, one per line.
+///
+/// ```
+/// use parse_hyperlinks::renderer::links2html;
+/// use std::borrow::Cow;
+///
+/// let i = r#"abc<a href="dest1" title="title1">text1</a>abc
+/// abc<a href="dest2" title="title2">text2</a>abc"#;
+///
+/// let expected = "\
+/// <a href=\"dest1\" title=\"title1\">text1</a>
+/// <a href=\"dest2\" title=\"title2\">text2</a>
+/// ";
+///
+/// let res = links2html(i);
+/// assert_eq!(res, expected);
+/// ```
+///
+/// ### Rendered text
+///
+/// This is how the rendered text looks like in the browser:
+///
+/// <a href="dest1" title="title1">text1</a>
+/// <a href="dest2" title="title2">text2</a>
+///
+#[inline]
+pub fn links2html(input: &str) -> String {
+    let mut output = Vec::new();
+    links2html_writer(input, &mut output).unwrap_or_default();
+    // We know this is safe, because only `str` have been written into `output`.
+    // So the following would be fine, but I want to keep this crate `unsafe`-free.
+    //    unsafe {String::from_utf8_unchecked(output)}
+    String::from_utf8(output).unwrap_or_default()
+}
+
+/// # Hyperlink extractor
+///
+/// Same as `links2html()`, but it uses `Write` for output. This function
+/// allocates much less memory and is faster because it avoids copying.
+///
+/// Usage example:
+/// ```no_run
+/// use parse_hyperlinks::renderer::links2html_writer;
+/// use std::io;
+/// use std::io::Read;
+/// fn main() -> Result<(), ::std::io::Error> {
+///     let mut stdin = String::new();
+///     Read::read_to_string(&mut io::stdin(), &mut stdin)?;
+///
+///     links2html_writer(&stdin, &mut io::stdout())?;
+///
+///     Ok(())
+/// }
+/// ```
+pub fn links2html_writer<'a, S: 'a + AsRef<str>, W: Write>(
+    input: S,
+    output: &mut W,
+) -> Result<(), io::Error> {
+    let input = input.as_ref();
+
+    let verb_renderer = |_| Cow::Borrowed("");
+
+    let link_renderer = |(_, (text, dest, title)): (_, (String, String, String))| {
+        let mut s = String::new();
+        s.push_str(r#"<a href=""#);
+        s.push_str(&*dest);
+        s.push_str(r#"" title=""#);
+        s.push_str(&*title);
+        s.push_str(r#"">"#);
+        s.push_str(&*text);
+        s.push_str("</a>\n");
+        s
+    };
+
+    render(input, "", "", verb_renderer, link_renderer, false, output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_text_links2html() {
+        let i = r#"abc[text1][label1]abc
+abc [text2](destination2 "title2")
+  [label3]: destination3 "title3"
+  [label1]: destination1 "title1"
+abc[label3]abc[label4]abc
+"#;
+
+        let expected = r#"<pre>abc<a href="destination1" title="title1">text1</a>abc
+abc <a href="destination2" title="title2">text2</a>
+  <a href="destination3" title="title3">[label3]: destination3 &quot;title3&quot;</a>
+  <a href="destination1" title="title1">[label1]: destination1 &quot;title1&quot;</a>
+abc<a href="destination3" title="title3">label3</a>abc[label4]abc
+</pre>"#;
+        let res = text_links2html(i);
+        //eprintln!("{}", res);
+        assert_eq!(res, expected);
+    }
+
+    #[test]
+    fn test_text_links2html2() {
+        let i = r#"abc
+abc
+"#;
+
+        let expected = r#"<pre>abc
+abc
+</pre>"#;
+        let res = text_links2html(i);
+        //eprintln!("{}", res);
+        assert_eq!(res, expected);
+    }
+
+    #[test]
+    fn test_text_rawlinks2html() {
+        let i = r#"abc[text1][label1]abc
+abc [text2](destination2 "title2")
+  [label3]: destination3 "title3"
+  [label1]: destination1 "title1"
+abc[label3]abc[label4]abc
+"#;
+
+        let expected = r#"<pre>abc<a href="destination1" title="title1">[text1][label1]</a>abc
+abc <a href="destination2" title="title2">[text2](destination2 "title2")</a>
+  <a href="destination3" title="title3">[label3]: destination3 "title3"</a>
+  <a href="destination1" title="title1">[label1]: destination1 "title1"</a>
+abc<a href="destination3" title="title3">[label3]</a>abc[label4]abc
+</pre>"#;
+        let res = text_rawlinks2html(i);
+        //eprintln!("{}", res);
+        assert_eq!(res, expected);
+    }
+
+    #[test]
+    fn test_links2html() {
+        let i = r#"abc[text1][label1]abc
+abc [text2](destination2 "title2")
+  [label3]: destination3 "title3"
+  [label1]: destination1 "title1"
+abc[label3]abc[label4]abc
+"#;
+
+        let expected = r#"<a href="destination1" title="title1">text1</a>
+<a href="destination2" title="title2">text2</a>
+<a href="destination3" title="title3">label3</a>
+"#;
+        let res = links2html(i);
+        //eprintln!("{}", res);
+        assert_eq!(res, expected);
+    }
+}


### PR DESCRIPTION
## Description

#461 reports an out-of-bounds access inside `parse_hyperlinks::take_until_unbalanced`. This fixes it by returning an error on odd number of `'\'` characters at the end of the input string.
For quicker integration of the fix the dependency has been vendored. That will probably be reverted until a new release comes out.

Fixes #461 