### PR TITLE
Change VMProxy and VirtualMachine fields visibility

### DIFF
--- a/src/hint_processor/proxies/vm_proxy.rs
+++ b/src/hint_processor/proxies/vm_proxy.rs
@@ -17,10 +17,10 @@ use super::memory_proxy::{get_memory_proxy, MemoryProxy};
 
 ///Structure representing a limited access to the VM's internal values
 pub struct VMProxy<'a> {
-    pub memory: MemoryProxy<'a>,
-    pub segments: &'a mut MemorySegmentManager,
+    memory: MemoryProxy<'a>,
+    segments: &'a mut MemorySegmentManager,
     run_context: &'a mut RunContext,
-    pub builtin_runners: &'a Vec<(String, Box<dyn BuiltinRunner>)>,
+    builtin_runners: &'a Vec<(String, Box<dyn BuiltinRunner>)>,
     prime: &'a BigInt,
 }
 

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -46,14 +46,14 @@ pub struct HintData {
 }
 
 pub struct VirtualMachine {
-    pub run_context: RunContext,
-    pub prime: BigInt,
-    pub builtin_runners: Vec<(String, Box<dyn BuiltinRunner>)>,
-    pub segments: MemorySegmentManager,
-    pub _program_base: Option<MaybeRelocatable>,
-    pub memory: Memory,
+    pub(crate) run_context: RunContext,
+    pub(crate) prime: BigInt,
+    pub(crate) builtin_runners: Vec<(String, Box<dyn BuiltinRunner>)>,
+    pub(crate) segments: MemorySegmentManager,
+    pub(crate) _program_base: Option<MaybeRelocatable>,
+    pub(crate) memory: Memory,
     accessed_addresses: Option<Vec<Relocatable>>,
-    pub trace: Option<Vec<TraceEntry>>,
+    pub(crate) trace: Option<Vec<TraceEntry>>,
     current_step: usize,
     skip_instruction_execution: bool,
 }


### PR DESCRIPTION
# Change VMProxy and VirtualMachine fields visibility

* Make VMProxy fields private
* Make Virtual machine fields pub(crate)

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
