### PR TITLE
Relocatable.segment_index to isize

### DIFF
--- a/src/hint_processor/builtin_hint_processor/set.rs
+++ b/src/hint_processor/builtin_hint_processor/set.rs
@@ -82,9 +82,9 @@ mod tests {
     const HINT_CODE: &str = "assert ids.elm_size > 0\nassert ids.set_ptr <= ids.set_end_ptr\nelm_list = memory.get_range(ids.elm_ptr, ids.elm_size)\nfor i in range(0, ids.set_end_ptr - ids.set_ptr, ids.elm_size):\n    if memory.get_range(ids.set_ptr + i, ids.elm_size) == elm_list:\n        ids.index = i // ids.elm_size\n        ids.is_elm_in_set = 1\n        break\nelse:\n    ids.is_elm_in_set = 0";
 
     fn init_vm_ids_data(
-        set_ptr: Option<(usize, usize)>,
+        set_ptr: Option<(isize, usize)>,
         elm_size: Option<i32>,
-        elm_a: Option<usize>,
+        elm_a: Option<isize>,
         elm_b: Option<usize>,
     ) -> (VirtualMachine, HashMap<String, HintReference>) {
         let mut vm = vm_with_range_check!();

--- a/src/types/relocatable.rs
+++ b/src/types/relocatable.rs
@@ -19,8 +19,8 @@ pub enum MaybeRelocatable {
     Int(BigInt),
 }
 
-impl From<(usize, usize)> for Relocatable {
-    fn from(index_offset: (usize, usize)) -> Self {
+impl From<(isize, usize)> for Relocatable {
+    fn from(index_offset: (isize, usize)) -> Self {
         Relocatable {
             segment_index: index_offset.0,
             offset: index_offset.1,
@@ -28,8 +28,8 @@ impl From<(usize, usize)> for Relocatable {
     }
 }
 
-impl From<(usize, usize)> for MaybeRelocatable {
-    fn from(index_offset: (usize, usize)) -> Self {
+impl From<(isize, usize)> for MaybeRelocatable {
+    fn from(index_offset: (isize, usize)) -> Self {
         MaybeRelocatable::RelocatableValue(Relocatable::from(index_offset))
     }
 }

--- a/src/types/relocatable.rs
+++ b/src/types/relocatable.rs
@@ -9,7 +9,7 @@ use std::ops::Add;
 
 #[derive(Eq, Hash, PartialEq, PartialOrd, Clone, Debug)]
 pub struct Relocatable {
-    pub segment_index: usize,
+    pub segment_index: isize,
     pub offset: usize,
 }
 

--- a/src/types/relocatable.rs
+++ b/src/types/relocatable.rs
@@ -363,12 +363,15 @@ pub fn relocate_value(
     match value {
         MaybeRelocatable::Int(num) => Ok(num),
         MaybeRelocatable::RelocatableValue(relocatable) => {
-            if relocation_table.len() <= relocatable.segment_index {
+            let segment_index: usize = relocatable
+                .segment_index
+                .try_into()
+                .map_err(|_| MemoryError::AddressInTemporarySegment(relocatable.segment_index))?;
+
+            if relocation_table.len() <= segment_index {
                 return Err(MemoryError::Relocation);
             }
-            match BigInt::from_usize(
-                relocation_table[relocatable.segment_index] + relocatable.offset,
-            ) {
+            match BigInt::from_usize(relocation_table[segment_index] + relocatable.offset) {
                 None => Err(MemoryError::Relocation),
                 Some(relocated_value) => Ok(relocated_value),
             }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-use crate::types::relocatable::Relocatable;
+use crate::{types::relocatable::Relocatable, vm::errors::memory_errors::MemoryError};
 use num_bigint::BigInt;
 use num_integer::Integer;
 use std::ops::Shr;
@@ -48,8 +48,15 @@ pub fn is_subsequence<T: PartialEq>(subsequence: &[T], mut sequence: &[T]) -> bo
     true
 }
 
-pub fn from_relocatable_to_indexes(relocatable: Relocatable) -> (usize, usize) {
-    (relocatable.segment_index, relocatable.offset)
+pub fn from_relocatable_to_indexes(
+    relocatable: Relocatable,
+) -> Result<(usize, usize), MemoryError> {
+    let segment_index: usize = relocatable
+        .segment_index
+        .try_into()
+        .map_err(|_| MemoryError::AddressInTemporarySegment(relocatable.segment_index))?;
+
+    Ok((segment_index, relocatable.offset))
 }
 
 ///Converts val to an integer in the range (-prime/2, prime/2) which is

--- a/src/vm/errors/memory_errors.rs
+++ b/src/vm/errors/memory_errors.rs
@@ -20,4 +20,6 @@ pub enum MemoryError {
     Relocation,
     #[error("Could not cast arguments")]
     WriteArg,
+    #[error("Memory addresses mustn't be in a TemporarySegment, segment: {0}")]
+    AddressInTemporarySegment(isize),
 }

--- a/src/vm/errors/runner_errors.rs
+++ b/src/vm/errors/runner_errors.rs
@@ -30,6 +30,8 @@ pub enum RunnerError {
     MemoryInitializationError(MemoryError),
     #[error("Memory addresses must be relocatable")]
     NonRelocatableAddress,
+    #[error("Runner base mustn't be in a TemporarySegment, segment: {0}")]
+    RunnerInTemporarySegment(isize),
     #[error("Failed to convert string to FieldElement")]
     FailedStringConversion,
     #[error("Expected integer at address {0:?}")]

--- a/src/vm/errors/vm_errors.rs
+++ b/src/vm/errors/vm_errors.rs
@@ -109,9 +109,9 @@ pub enum VirtualMachineError {
     #[error("Variable {0} not present in current execution scope")]
     VariableNotInScopeError(String),
     #[error("DictManagerError: Tried to create tracker for a dictionary on segment: {0} when there is already a tracker for a dictionary on this segment")]
-    CantCreateDictionaryOnTakenSegment(usize),
+    CantCreateDictionaryOnTakenSegment(isize),
     #[error("Dict Error: No dict tracker found for segment {0}")]
-    NoDictTracker(usize),
+    NoDictTracker(isize),
     #[error("ict Error: No value found for key: {0}")]
     NoValueForKey(BigInt),
     #[error("Assertion failed, a = {0} % PRIME is not less than b = {1} % PRIME")]

--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -45,7 +45,9 @@ impl BuiltinRunner for BitwiseBuiltinRunner {
         Relocatable::from((self.base, 0))
     }
 
-    fn add_validation_rule(&self, _memory: &mut Memory) {}
+    fn add_validation_rule(&self, _memory: &mut Memory) -> Result<(), RunnerError> {
+        Ok(())
+    }
 
     fn deduce_memory_cell(
         &mut self,

--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -13,7 +13,7 @@ use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
 
 pub struct BitwiseBuiltinRunner {
     _ratio: usize,
-    pub base: usize,
+    pub base: isize,
     cells_per_instance: usize,
     _n_input_cells: usize,
     total_n_bits: u32,

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -13,7 +13,7 @@ use crate::{bigint, bigint_str};
 
 pub struct EcOpBuiltinRunner {
     _ratio: usize,
-    pub base: usize,
+    pub base: isize,
     cells_per_instance: usize,
     n_input_cells: usize,
     scalar_height: usize,

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -93,7 +93,9 @@ impl BuiltinRunner for EcOpBuiltinRunner {
     fn base(&self) -> Relocatable {
         Relocatable::from((self.base, 0))
     }
-    fn add_validation_rule(&self, _memory: &mut Memory) {}
+    fn add_validation_rule(&self, _memory: &mut Memory) -> Result<(), RunnerError> {
+        Ok(())
+    }
 
     fn deduce_memory_cell(
         &mut self,

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -11,7 +11,7 @@ use crate::vm::vm_memory::memory::Memory;
 use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
 
 pub struct HashBuiltinRunner {
-    pub base: usize,
+    pub base: isize,
     _ratio: usize,
     cells_per_instance: usize,
     _n_input_cells: usize,

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -46,7 +46,9 @@ impl BuiltinRunner for HashBuiltinRunner {
         Relocatable::from((self.base, 0))
     }
 
-    fn add_validation_rule(&self, _memory: &mut Memory) {}
+    fn add_validation_rule(&self, _memory: &mut Memory) -> Result<(), RunnerError> {
+        Ok(())
+    }
 
     fn deduce_memory_cell(
         &mut self,

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -23,7 +23,7 @@ pub trait BuiltinRunner {
     fn initial_stack(&self) -> Vec<MaybeRelocatable>;
     ///Returns the builtin's base
     fn base(&self) -> Relocatable;
-    fn add_validation_rule(&self, memory: &mut Memory);
+    fn add_validation_rule(&self, memory: &mut Memory) -> Result<(), RunnerError>;
     fn deduce_memory_cell(
         &mut self,
         address: &Relocatable,

--- a/src/vm/runners/builtin_runner/output.rs
+++ b/src/vm/runners/builtin_runner/output.rs
@@ -33,7 +33,9 @@ impl BuiltinRunner for OutputBuiltinRunner {
         Relocatable::from((self.base, 0))
     }
 
-    fn add_validation_rule(&self, _memory: &mut Memory) {}
+    fn add_validation_rule(&self, _memory: &mut Memory) -> Result<(), RunnerError> {
+        Ok(())
+    }
 
     fn deduce_memory_cell(
         &mut self,

--- a/src/vm/runners/builtin_runner/output.rs
+++ b/src/vm/runners/builtin_runner/output.rs
@@ -7,7 +7,7 @@ use crate::vm::vm_memory::memory::Memory;
 use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
 
 pub struct OutputBuiltinRunner {
-    base: usize,
+    base: isize,
     _stop_ptr: Option<Relocatable>,
 }
 

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -14,7 +14,7 @@ use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
 
 pub struct RangeCheckBuiltinRunner {
     _ratio: BigInt,
-    base: usize,
+    base: isize,
     _stop_ptr: Option<Relocatable>,
     _cells_per_instance: i32,
     _n_input_cells: i32,
@@ -67,7 +67,14 @@ impl BuiltinRunner for RangeCheckBuiltinRunner {
                 }
             },
         ));
-        memory.add_validation_rule(self.base, rule);
+
+        let segment_index: usize = self
+            .base
+            .try_into()
+            .map_err(|_| MemoryError::AddressInTemporarySegment(self.base))
+            .unwrap();
+
+        memory.add_validation_rule(segment_index, rule);
     }
 
     fn deduce_memory_cell(

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -51,7 +51,7 @@ impl BuiltinRunner for RangeCheckBuiltinRunner {
         Relocatable::from((self.base, 0))
     }
 
-    fn add_validation_rule(&self, memory: &mut Memory) {
+    fn add_validation_rule(&self, memory: &mut Memory) -> Result<(), RunnerError> {
         let rule: ValidationRule = ValidationRule(Box::new(
             |memory: &Memory,
              address: &MaybeRelocatable|
@@ -71,10 +71,11 @@ impl BuiltinRunner for RangeCheckBuiltinRunner {
         let segment_index: usize = self
             .base
             .try_into()
-            .map_err(|_| MemoryError::AddressInTemporarySegment(self.base))
-            .unwrap();
+            .map_err(|_| RunnerError::RunnerInTemporarySegment(self.base))?;
 
         memory.add_validation_rule(segment_index, rule);
+
+        Ok(())
     }
 
     fn deduce_memory_cell(

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -389,8 +389,13 @@ impl<'a> CairoRunner<'a> {
             if vm.segments.segment_used_sizes == None {
                 vm.segments.compute_effective_sizes(&vm.memory);
             }
+
+            let segment_index: usize = base
+                .segment_index
+                .try_into()
+                .map_err(|_| RunnerError::RunnerInTemporarySegment(base.segment_index))?;
             // See previous comment, the unwrap below is safe.
-            for i in 0..vm.segments.segment_used_sizes.as_ref().unwrap()[base.segment_index] {
+            for i in 0..vm.segments.segment_used_sizes.as_ref().unwrap()[segment_index] {
                 let value = vm.memory.get_integer(&(base.clone() + i)).map_err(|_| {
                     RunnerError::MemoryGet(MaybeRelocatable::from(base.clone() + i))
                 })?;

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -219,7 +219,7 @@ impl<'a> CairoRunner<'a> {
             self.program_base.as_ref().ok_or(RunnerError::NoProgBase)?,
         ));
         for (_, builtin) in vm.builtin_runners.iter() {
-            builtin.add_validation_rule(&mut vm.memory);
+            builtin.add_validation_rule(&mut vm.memory)?;
         }
         vm.memory
             .validate_existing_memory()

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -618,10 +618,12 @@ impl VirtualMachine {
     ///Makes sure that all assigned memory cells are consistent with their auto deduction rules.
     pub fn verify_auto_deductions(&mut self) -> Result<(), VirtualMachineError> {
         for (name, builtin) in self.builtin_runners.iter_mut() {
-            let index = builtin.base().segment_index;
+            let index: usize = builtin.base().segment_index.try_into().map_err(|_| {
+                MemoryError::AddressInTemporarySegment(builtin.base().segment_index)
+            })?;
             for (offset, value) in self.memory.data[index].iter().enumerate() {
                 if let Some(deduced_memory_cell) = builtin
-                    .deduce_memory_cell(&Relocatable::from((index, offset)), &self.memory)
+                    .deduce_memory_cell(&Relocatable::from((index as isize, offset)), &self.memory)
                     .map_err(VirtualMachineError::RunnerError)?
                 {
                     if Some(&deduced_memory_cell) != value.as_ref() && value != &None {

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -122,7 +122,7 @@ impl Memory {
         if let &MaybeRelocatable::RelocatableValue(ref rel_addr) = address {
             if !self.validated_addresses.contains(address) {
                 for (index, validation_rule) in self.validation_rules.iter() {
-                    if &rel_addr.segment_index == index {
+                    if rel_addr.segment_index == *index as isize {
                         self.validated_addresses
                             .insert(validation_rule.0(self, address)?);
                     }
@@ -138,7 +138,7 @@ impl Memory {
     pub fn validate_existing_memory(&mut self) -> Result<(), MemoryError> {
         for i in 0..self.data.len() {
             for j in 0..self.data[i].len() {
-                self.validate_memory_cell(&MaybeRelocatable::from((i, j)))?;
+                self.validate_memory_cell(&MaybeRelocatable::from((i as isize, j)))?;
             }
         }
         Ok(())

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -339,7 +339,7 @@ mod memory_tests {
         let mut segments = MemorySegmentManager::new();
         let mut memory = Memory::new();
         builtin.initialize_segments(&mut segments, &mut memory);
-        builtin.add_validation_rule(&mut memory);
+        assert_eq!(builtin.add_validation_rule(&mut memory), Ok(()));
         for _ in 0..3 {
             segments.add(&mut memory);
         }
@@ -369,7 +369,7 @@ mod memory_tests {
                 &MaybeRelocatable::from(bigint!(-10)),
             )
             .unwrap();
-        builtin.add_validation_rule(&mut memory);
+        assert_eq!(builtin.add_validation_rule(&mut memory), Ok(()));
         let error = memory.validate_existing_memory();
         assert_eq!(error, Err(MemoryError::NumOutOfBounds));
         assert_eq!(
@@ -392,7 +392,7 @@ mod memory_tests {
                 &MaybeRelocatable::from((1, 4)),
             )
             .unwrap();
-        builtin.add_validation_rule(&mut memory);
+        assert_eq!(builtin.add_validation_rule(&mut memory), Ok(()));
         let error = memory.validate_existing_memory();
         assert_eq!(error, Err(MemoryError::FoundNonInt));
         assert_eq!(
@@ -414,7 +414,7 @@ mod memory_tests {
                 &MaybeRelocatable::from(bigint!(-45)),
             )
             .unwrap();
-        builtin.add_validation_rule(&mut memory);
+        assert_eq!(builtin.add_validation_rule(&mut memory), Ok(()));
         assert_eq!(memory.validate_existing_memory(), Ok(()));
     }
 

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -36,7 +36,7 @@ impl Memory {
             .try_into()
             .map_err(|_| MemoryError::AddressNotRelocatable)?;
         let val = MaybeRelocatable::from(val);
-        let (value_index, value_offset) = from_relocatable_to_indexes(relocatable.clone());
+        let (value_index, value_offset) = from_relocatable_to_indexes(relocatable.clone())?;
         let data_len = self.data.len();
         let segment = self
             .data
@@ -71,7 +71,7 @@ impl Memory {
         let relocatable: Relocatable = key
             .try_into()
             .map_err(|_| MemoryError::AddressNotRelocatable)?;
-        let (i, j) = from_relocatable_to_indexes(relocatable);
+        let (i, j) = from_relocatable_to_indexes(relocatable)?;
         if self.data.len() > i && self.data[i].len() > j {
             if let Some(ref element) = self.data[i][j] {
                 return Ok(Some(element));

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -11,6 +11,7 @@ pub struct ValidationRule(
 );
 pub struct Memory {
     pub data: Vec<Vec<Option<MaybeRelocatable>>>,
+    pub temp_data: Vec<Vec<Option<MaybeRelocatable>>>,
     pub validated_addresses: HashSet<MaybeRelocatable>,
     pub validation_rules: HashMap<usize, ValidationRule>,
 }
@@ -19,6 +20,7 @@ impl Memory {
     pub fn new() -> Memory {
         Memory {
             data: Vec::<Vec<Option<MaybeRelocatable>>>::new(),
+            temp_data: Vec::<Vec<Option<MaybeRelocatable>>>::new(),
             validated_addresses: HashSet::<MaybeRelocatable>::new(),
             validation_rules: HashMap::new(),
         }

--- a/src/vm/vm_memory/memory_segments.rs
+++ b/src/vm/vm_memory/memory_segments.rs
@@ -18,7 +18,7 @@ impl MemorySegmentManager {
         self.num_segments += 1;
         memory.data.push(Vec::new());
         Relocatable {
-            segment_index,
+            segment_index: segment_index as isize,
             offset: 0,
         }
     }


### PR DESCRIPTION
# Chenge Relocatable.segment_index field type to isize

* Change `Relocatable.segment_index` field type from `usize` to `isize`, so we can deal with TemporarySegments
* Change `Builtiins.base` field type from `usize` to `isize`
* Change DictManager.trackers field type from HashMap<usize, DictTracker> to HashMap<isize, DictTracker>,

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
