### PR TITLE
Add temporary segments

### DIFF
--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -11,6 +11,7 @@ pub struct ValidationRule(
 );
 pub struct Memory {
     pub data: Vec<Vec<Option<MaybeRelocatable>>>,
+    pub temp_data: Vec<Vec<Option<MaybeRelocatable>>>,
     pub validated_addresses: HashSet<MaybeRelocatable>,
     pub validation_rules: HashMap<usize, ValidationRule>,
 }
@@ -19,6 +20,7 @@ impl Memory {
     pub fn new() -> Memory {
         Memory {
             data: Vec::<Vec<Option<MaybeRelocatable>>>::new(),
+            temp_data: Vec::<Vec<Option<MaybeRelocatable>>>::new(),
             validated_addresses: HashSet::<MaybeRelocatable>::new(),
             validation_rules: HashMap::new(),
         }

--- a/src/vm/vm_memory/memory_segments.rs
+++ b/src/vm/vm_memory/memory_segments.rs
@@ -8,6 +8,7 @@ use crate::vm::vm_memory::memory::Memory;
 
 pub struct MemorySegmentManager {
     pub num_segments: usize,
+    pub num_temp_segments: usize,
     pub segment_used_sizes: Option<Vec<usize>>,
 }
 
@@ -38,6 +39,7 @@ impl MemorySegmentManager {
     pub fn new() -> MemorySegmentManager {
         MemorySegmentManager {
             num_segments: 0,
+            num_temp_segments: 0,
             segment_used_sizes: None,
         }
     }

--- a/src/vm/vm_memory/memory_segments.rs
+++ b/src/vm/vm_memory/memory_segments.rs
@@ -23,6 +23,18 @@ impl MemorySegmentManager {
             offset: 0,
         }
     }
+
+    ///Adds a new temporary segment and returns its starting location as a RelocatableValue.
+    ///Negative segment_index indicates its refer to a temporary segment
+    pub fn add_temporary_segment(&mut self, memory: &mut Memory) -> Relocatable {
+        self.num_temp_segments += 1;
+        memory.temp_data.push(Vec::new());
+        Relocatable {
+            segment_index: -(self.num_temp_segments as isize),
+            offset: 0,
+        }
+    }
+
     ///Writes data into the memory at address ptr and returns the first address after the data.
     pub fn load_data(
         &mut self,
@@ -146,6 +158,31 @@ mod tests {
             }
         );
         assert_eq!(segments.num_segments, 2);
+    }
+
+    #[test]
+    fn add_one_temporary_segment() {
+        let mut segments = MemorySegmentManager::new();
+        let mut memory = Memory::new();
+        let base = segments.add_temporary_segment(&mut memory);
+        assert_eq!(base, relocatable!(-1, 0));
+        assert_eq!(segments.num_temp_segments, 1);
+    }
+
+    #[test]
+    fn add_two_temporary_segments() {
+        let mut segments = MemorySegmentManager::new();
+        let mut memory = Memory::new();
+        let mut _base = segments.add_temporary_segment(&mut memory);
+        _base = segments.add_temporary_segment(&mut memory);
+        assert_eq!(
+            _base,
+            Relocatable {
+                segment_index: -2,
+                offset: 0
+            }
+        );
+        assert_eq!(segments.num_temp_segments, 2);
     }
 
     #[test]


### PR DESCRIPTION
# Merge after #471 
# Add temporary segments

*  Add `Memory.temp_data: Vec<Vec<Option<MaybeRelocatable>>>` field, where temporary segments will be stored.
* Add `MemorySegmentManager.num_temp_segment` field.
* Add `MemorySegmentManager.add_temporary_segment` method.

## Description

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
