### PR TITLE
Avoid unnecessary clones

### DIFF
--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -688,7 +688,7 @@ impl VirtualMachine {
     pub fn load_data(
         &mut self,
         ptr: &MaybeRelocatable,
-        data: Vec<MaybeRelocatable>,
+        data: impl IntoIterator<Item = MaybeRelocatable>,
     ) -> Result<MaybeRelocatable, MemoryError> {
         self.segments.load_data(&mut self.memory, ptr, data)
     }

--- a/src/vm/vm_memory/memory_segments.rs
+++ b/src/vm/vm_memory/memory_segments.rs
@@ -27,12 +27,14 @@ impl MemorySegmentManager {
         &mut self,
         memory: &mut Memory,
         ptr: &MaybeRelocatable,
-        data: Vec<MaybeRelocatable>,
+        data: impl IntoIterator<Item = MaybeRelocatable>,
     ) -> Result<MaybeRelocatable, MemoryError> {
-        for (num, value) in data.iter().enumerate() {
-            memory.insert(&ptr.add_usize_mod(num, None), value)?;
+        let mut count = 0;
+        for (num, value) in data.into_iter().enumerate() {
+            memory.insert(ptr.add_usize_mod(num, None), value)?;
+            count += 1;
         }
-        Ok(ptr.add_usize_mod(data.len(), None))
+        Ok(ptr.add_usize_mod(count, None))
     }
 
     pub fn new() -> MemorySegmentManager {


### PR DESCRIPTION
# Avoid unnecessary clones

## Description

Modify `VirtualMachine::load_data`, `MemorySegmentManager::load_data`, `Memory::insert` and `Memory::insert_value` to avoid unnecessary `.clone()` invocations.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
