### PR TITLE
Refactor Memory methods to handle Temporary segment cases

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -853,4 +853,13 @@ mod test {
         assert_eq!(data[2], mayberelocatable!(49128305));
         assert_eq!(data[3], mayberelocatable!(997130409));
     }
+    #[test]
+    fn from_relocatable_to_indexes_test() {
+        let reloc_1 = relocatable!(1, 5);
+        let reloc_2 = relocatable!(0, 5);
+        let reloc_3 = relocatable!(-1, 5);
+        assert_eq!((1, 5), from_relocatable_to_indexes(&reloc_1));
+        assert_eq!((0, 5), from_relocatable_to_indexes(&reloc_2));
+        assert_eq!((0, 5), from_relocatable_to_indexes(&reloc_3));
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-use crate::{types::relocatable::Relocatable, vm::errors::memory_errors::MemoryError};
+use crate::types::relocatable::Relocatable;
 use num_bigint::BigInt;
 use num_integer::Integer;
 use std::ops::Shr;
@@ -48,15 +48,8 @@ pub fn is_subsequence<T: PartialEq>(subsequence: &[T], mut sequence: &[T]) -> bo
     true
 }
 
-pub fn from_relocatable_to_indexes(
-    relocatable: Relocatable,
-) -> Result<(usize, usize), MemoryError> {
-    let segment_index: usize = relocatable
-        .segment_index
-        .try_into()
-        .map_err(|_| MemoryError::AddressInTemporarySegment(relocatable.segment_index))?;
-
-    Ok((segment_index, relocatable.offset))
+pub fn from_relocatable_to_indexes(relocatable: &Relocatable) -> (usize, usize) {
+    (relocatable.segment_index.abs() as usize, relocatable.offset)
 }
 
 ///Converts val to an integer in the range (-prime/2, prime/2) which is

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -49,7 +49,14 @@ pub fn is_subsequence<T: PartialEq>(subsequence: &[T], mut sequence: &[T]) -> bo
 }
 
 pub fn from_relocatable_to_indexes(relocatable: &Relocatable) -> (usize, usize) {
-    (relocatable.segment_index.abs() as usize, relocatable.offset)
+    if relocatable.segment_index.is_negative() {
+        (
+            (relocatable.segment_index.abs() - 1) as usize,
+            relocatable.offset,
+        )
+    } else {
+        (relocatable.segment_index as usize, relocatable.offset)
+    }
 }
 
 ///Converts val to an integer in the range (-prime/2, prime/2) which is

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -41,9 +41,15 @@ impl Memory {
             .map_err(|_| MemoryError::AddressNotRelocatable)?;
         let val = MaybeRelocatable::from(val);
         let (value_index, value_offset) = from_relocatable_to_indexes(&relocatable);
-        let data_len = self.data.len();
-        let segment = self
-            .data
+
+        let data = if relocatable.segment_index.is_negative() {
+            &mut self.temp_data
+        } else {
+            &mut self.data
+        };
+
+        let data_len = data.len();
+        let segment = data
             .get_mut(value_index)
             .ok_or(MemoryError::UnallocatedSegment(value_index, data_len))?;
         //Check if the element is inserted next to the last one on the segment

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -235,6 +235,19 @@ mod memory_tests {
     }
 
     #[test]
+    fn insert_and_get_from_temp_segment_succesful() {
+        let key = MaybeRelocatable::from((-1, 0));
+        let val = MaybeRelocatable::from(bigint!(5));
+        let mut memory = Memory::new();
+        memory.temp_data.push(Vec::new());
+        memory.insert(&key, &val).unwrap();
+        assert_eq!(
+            memory.get(&key).unwrap(),
+            Some(&MaybeRelocatable::from(bigint!(5)))
+        );
+    }
+
+    #[test]
     fn get_non_allocated_memory() {
         let key = MaybeRelocatable::from((0, 0));
         let memory = Memory::new();

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -11,6 +11,7 @@ pub struct ValidationRule(
 );
 pub struct Memory {
     pub data: Vec<Vec<Option<MaybeRelocatable>>>,
+    pub temp_data: Vec<Vec<Option<MaybeRelocatable>>>,
     pub validated_addresses: HashSet<MaybeRelocatable>,
     pub validation_rules: HashMap<usize, ValidationRule>,
 }
@@ -19,6 +20,7 @@ impl Memory {
     pub fn new() -> Memory {
         Memory {
             data: Vec::<Vec<Option<MaybeRelocatable>>>::new(),
+            temp_data: Vec::<Vec<Option<MaybeRelocatable>>>::new(),
             validated_addresses: HashSet::<MaybeRelocatable>::new(),
             validation_rules: HashMap::new(),
         }

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -14,6 +14,7 @@ pub struct Memory {
     pub temp_data: Vec<Vec<Option<MaybeRelocatable>>>,
     pub validated_addresses: HashSet<MaybeRelocatable>,
     pub validation_rules: HashMap<usize, ValidationRule>,
+    pub relocation_rules: HashMap<isize, Relocatable>,
 }
 
 impl Memory {
@@ -23,6 +24,7 @@ impl Memory {
             temp_data: Vec::<Vec<Option<MaybeRelocatable>>>::new(),
             validated_addresses: HashSet::<MaybeRelocatable>::new(),
             validation_rules: HashMap::new(),
+            relocation_rules: HashMap::new(),
         }
     }
     ///Inserts an MaybeRelocatable value into an address given by a MaybeRelocatable::Relocatable

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -40,7 +40,7 @@ impl Memory {
             .try_into()
             .map_err(|_| MemoryError::AddressNotRelocatable)?;
         let val = MaybeRelocatable::from(val);
-        let (value_index, value_offset) = from_relocatable_to_indexes(relocatable.clone())?;
+        let (value_index, value_offset) = from_relocatable_to_indexes(&relocatable);
         let data_len = self.data.len();
         let segment = self
             .data
@@ -80,7 +80,7 @@ impl Memory {
         } else {
             &self.data
         };
-        let (i, j) = (relocatable.segment_index.abs() as usize, relocatable.offset);
+        let (i, j) = from_relocatable_to_indexes(&relocatable);
         if data.len() > i && data[i].len() > j {
             if let Some(ref element) = data[i][j] {
                 return Ok(Some(element));

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -75,9 +75,14 @@ impl Memory {
         let relocatable: Relocatable = key
             .try_into()
             .map_err(|_| MemoryError::AddressNotRelocatable)?;
-        let (i, j) = from_relocatable_to_indexes(relocatable)?;
-        if self.data.len() > i && self.data[i].len() > j {
-            if let Some(ref element) = self.data[i][j] {
+        let data = if relocatable.segment_index.is_negative() {
+            &self.temp_data
+        } else {
+            &self.data
+        };
+        let (i, j) = (relocatable.segment_index.abs() as usize, relocatable.offset);
+        if data.len() > i && data[i].len() > j {
+            if let Some(ref element) = data[i][j] {
                 return Ok(Some(element));
             }
         }

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -198,6 +198,7 @@ impl Default for Memory {
 mod memory_tests {
     use crate::{
         bigint,
+        utils::test_utils::mayberelocatable,
         vm::{
             runners::builtin_runner::{BuiltinRunner, RangeCheckBuiltinRunner},
             vm_memory::memory_segments::MemorySegmentManager,
@@ -234,6 +235,15 @@ mod memory_tests {
         );
     }
 
+    #[test]
+    fn get_from_temp_segment_succesful() {
+        let mut memory = Memory::new();
+        memory.temp_data = vec![vec![None, None, Some(mayberelocatable!(8))]];
+        assert_eq!(
+            memory.get(&mayberelocatable!(-1, 2)),
+            Ok(Some(&mayberelocatable!(8)))
+        );
+    }
     #[test]
     fn insert_and_get_from_temp_segment_succesful() {
         let key = MaybeRelocatable::from((-1, 0));

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -236,7 +236,7 @@ mod memory_tests {
     }
 
     #[test]
-    fn get_from_temp_segment_succesful() {
+    fn get_valuef_from_temp_segment() {
         let mut memory = Memory::new();
         memory.temp_data = vec![vec![None, None, Some(mayberelocatable!(8))]];
         assert_eq!(
@@ -244,6 +244,20 @@ mod memory_tests {
             Ok(Some(&mayberelocatable!(8)))
         );
     }
+
+    #[test]
+    fn insert_value_in_temp_segment() {
+        let key = MaybeRelocatable::from((-1, 3));
+        let val = MaybeRelocatable::from(bigint!(8));
+        let mut memory = Memory::new();
+        memory.temp_data.push(Vec::new());
+        memory.insert(&key, &val).unwrap();
+        assert_eq!(
+            memory.temp_data[0][3],
+            Some(MaybeRelocatable::from(bigint!(8)))
+        );
+    }
+
     #[test]
     fn insert_and_get_from_temp_segment_succesful() {
         let key = MaybeRelocatable::from((-1, 0));
@@ -254,6 +268,21 @@ mod memory_tests {
         assert_eq!(
             memory.get(&key).unwrap(),
             Some(&MaybeRelocatable::from(bigint!(5)))
+        );
+    }
+
+    #[test]
+    fn insert_and_get_from_temp_segment_failed() {
+        let key = mayberelocatable!(-1, 1);
+        let mut memory = Memory::new();
+        memory.temp_data = vec![vec![None, Some(mayberelocatable!(8))]];
+        assert_eq!(
+            memory.insert(&key, &mayberelocatable!(5)),
+            Err(MemoryError::InconsistentMemory(
+                mayberelocatable!(-1, 1),
+                mayberelocatable!(8),
+                mayberelocatable!(5)
+            ))
         );
     }
 

--- a/src/vm/vm_memory/memory_segments.rs
+++ b/src/vm/vm_memory/memory_segments.rs
@@ -8,6 +8,7 @@ use crate::vm::vm_memory::memory::Memory;
 
 pub struct MemorySegmentManager {
     pub num_segments: usize,
+    pub num_temp_segments: usize,
     pub segment_used_sizes: Option<Vec<usize>>,
 }
 
@@ -38,6 +39,7 @@ impl MemorySegmentManager {
     pub fn new() -> MemorySegmentManager {
         MemorySegmentManager {
             num_segments: 0,
+            num_temp_segments: 0,
             segment_used_sizes: None,
         }
     }

--- a/src/vm/vm_memory/memory_segments.rs
+++ b/src/vm/vm_memory/memory_segments.rs
@@ -23,6 +23,18 @@ impl MemorySegmentManager {
             offset: 0,
         }
     }
+
+    ///Adds a new temporary segment and returns its starting location as a RelocatableValue.
+    ///Negative segment_index indicates its refer to a temporary segment
+    pub fn add_temporary_segment(&mut self, memory: &mut Memory) -> Relocatable {
+        self.num_temp_segments += 1;
+        memory.temp_data.push(Vec::new());
+        Relocatable {
+            segment_index: -(self.num_temp_segments as isize),
+            offset: 0,
+        }
+    }
+
     ///Writes data into the memory at address ptr and returns the first address after the data.
     pub fn load_data(
         &mut self,
@@ -146,6 +158,31 @@ mod tests {
             }
         );
         assert_eq!(segments.num_segments, 2);
+    }
+
+    #[test]
+    fn add_one_temporary_segment() {
+        let mut segments = MemorySegmentManager::new();
+        let mut memory = Memory::new();
+        let base = segments.add_temporary_segment(&mut memory);
+        assert_eq!(base, relocatable!(-1, 0));
+        assert_eq!(segments.num_temp_segments, 1);
+    }
+
+    #[test]
+    fn add_two_temporary_segments() {
+        let mut segments = MemorySegmentManager::new();
+        let mut memory = Memory::new();
+        let mut _base = segments.add_temporary_segment(&mut memory);
+        _base = segments.add_temporary_segment(&mut memory);
+        assert_eq!(
+            _base,
+            Relocatable {
+                segment_index: -2,
+                offset: 0
+            }
+        );
+        assert_eq!(segments.num_temp_segments, 2);
     }
 
     #[test]


### PR DESCRIPTION
# Refactor Memory methods to handle Temporary segment cases

* Refactor `Memory.get` method to get values from Temporary Segments
* Refactor `Memory.insert` method to insert values in Temporary Segments
* Refactor fn `from_relocatable_to_indexes`
* Add `Memory.relocation_rules` field

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
