### PR TITLE
make initial_fp public

### DIFF
--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -33,7 +33,7 @@ pub struct CairoRunner<'a> {
     program_base: Option<Relocatable>,
     execution_base: Option<Relocatable>,
     initial_ap: Option<Relocatable>,
-    initial_fp: Option<Relocatable>,
+    pub initial_fp: Option<Relocatable>,
     initial_pc: Option<Relocatable>,
     pub relocated_memory: Vec<Option<BigInt>>,
     pub relocated_trace: Option<Vec<RelocatedTraceEntry>>,


### PR DESCRIPTION
# Make initial_fp (CairoRunner field) public

## Description
In order to export it to Python land we need to first make it public here.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
