### PR TITLE
Fix VirtualMachine::get_maybe() return type

### DIFF
--- a/src/hint_processor/builtin_hint_processor/math_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/math_utils.rs
@@ -129,8 +129,8 @@ pub fn assert_not_equal(
     //Check that the ids are in memory
     match (vm.get_maybe(&a_addr), vm.get_maybe(&b_addr)) {
         (Ok(Some(maybe_rel_a)), Ok(Some(maybe_rel_b))) => {
-            let maybe_rel_a = maybe_rel_a.into_owned();
-            let maybe_rel_b = maybe_rel_b.into_owned();
+            let maybe_rel_a = maybe_rel_a;
+            let maybe_rel_b = maybe_rel_b;
             match (maybe_rel_a, maybe_rel_b) {
                 (MaybeRelocatable::Int(a), MaybeRelocatable::Int(b)) => {
                     if (&a - &b).is_multiple_of(vm.get_prime()) {

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -671,11 +671,15 @@ impl VirtualMachine {
     pub fn get_maybe<'a, 'b: 'a, K: 'a>(
         &'b self,
         key: &'a K,
-    ) -> Result<Option<Cow<MaybeRelocatable>>, MemoryError>
+    ) -> Result<Option<MaybeRelocatable>, MemoryError>
     where
         Relocatable: TryFrom<&'a K>,
     {
-        self.memory.get(key)
+        match self.memory.get(key) {
+            Ok(Some(cow)) => Ok(Some(cow.into_owned())),
+            Ok(None) => Ok(None),
+            Err(error) => Err(error),
+        }
     }
 
     /// Returns a reference to the vector with all builtins present in the virtual machine


### PR DESCRIPTION
Changes` VirtualMachine::get_maybe()` method back to `Result<Option<MaybeRelocatable>` in order to hide Cow use from public api and restore compatibility with cairo-rs-py