### PR TITLE
Change deserialization type from `BigInt` to `usize`

### DIFF
--- a/src/cairo_run.rs
+++ b/src/cairo_run.rs
@@ -135,9 +135,9 @@ mod tests {
     use num_bigint::Sign;
     use std::io::Read;
 
-    fn run_test_program<'a>(
+    fn run_test_program(
         program_path: &Path,
-        hint_processor: &'a dyn HintProcessor,
+        hint_processor: &dyn HintProcessor,
     ) -> Result<(CairoRunner, VirtualMachine), CairoRunError> {
         let program = Program::new(program_path, "main").map_err(CairoRunError::Program)?;
 

--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -72,8 +72,7 @@ pub struct Identifier {
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 pub struct Member {
     pub cairo_type: Option<String>,
-    #[serde(deserialize_with = "bigint_from_number")]
-    pub offset: Option<BigInt>,
+    pub offset: Option<usize>,
 }
 
 fn bigint_from_number<'de, D>(deserializer: D) -> Result<Option<BigInt>, D::Error>


### PR DESCRIPTION
# Change deserialization type from `BigInt` to `usize`

## Description

Fix deserialization type according to issue #497.

## Checklist
- [x] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
