### PR TITLE
Implement `CairoRunner::mark_as_accessed()`.

### DIFF
--- a/src/vm/errors/vm_errors.rs
+++ b/src/vm/errors/vm_errors.rs
@@ -218,4 +218,6 @@ pub enum VirtualMachineError {
     CustomHint(String),
     #[error("Missing constant: {0}")]
     MissingConstant(&'static str),
+    #[error("Current run is not ended")]
+    RunIsNotEnded,
 }

--- a/src/vm/errors/vm_errors.rs
+++ b/src/vm/errors/vm_errors.rs
@@ -218,6 +218,6 @@ pub enum VirtualMachineError {
     CustomHint(String),
     #[error("Missing constant: {0}")]
     MissingConstant(&'static str),
-    #[error("accessed_addresses is None")]
-    MissingAccessedAddresses,
+    #[error("Current run is not finished")]
+    RunNotFinished,
 }

--- a/src/vm/errors/vm_errors.rs
+++ b/src/vm/errors/vm_errors.rs
@@ -218,6 +218,6 @@ pub enum VirtualMachineError {
     CustomHint(String),
     #[error("Missing constant: {0}")]
     MissingConstant(&'static str),
-    #[error("Current run is not ended")]
-    RunIsNotEnded,
+    #[error("accessed_addresses is None")]
+    MissingAccessedAddresses,
 }

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -306,7 +306,7 @@ impl CairoRunner {
     ) -> Result<(), VirtualMachineError> {
         let accessed_addressess = match &mut vm.accessed_addresses {
             Some(x) => x,
-            None => return Err(VirtualMachineError::RunIsNotEnded),
+            None => return Err(VirtualMachineError::MissingAccessedAddresses),
         };
 
         accessed_addressess.extend((0..size).map(|i| &address + i));

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -2313,6 +2313,26 @@ mod tests {
             cairo_runner.mark_as_accessed((0, 0).into(), 3),
             Err(VirtualMachineError::RunNotFinished),
         );
+    }
+
+    #[test]
+    fn mark_as_accessed_missing_accessed_addresses() {
+        let program = Program {
+            builtins: Vec::new(),
+            prime: bigint_str!(
+                b"3618502788666131213697322783095070105623107215331596699973092056135872020481"
+            ),
+            data: Vec::new(),
+            constants: HashMap::new(),
+            main: None,
+            hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
+            identifiers: HashMap::new(),
+        };
+
+        let mut cairo_runner = CairoRunner::new(&program).unwrap();
 
         cairo_runner.accessed_addresses = Some(HashSet::new());
         cairo_runner.mark_as_accessed((0, 0).into(), 3).unwrap();

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -2308,15 +2308,18 @@ mod tests {
         };
 
         let mut cairo_runner = CairoRunner::new(&program).unwrap();
-        let mut vm = vm!();
 
-        vm.accessed_addresses = Some(HashSet::new());
+        assert_eq!(
+            cairo_runner.mark_as_accessed((0, 0).into(), 3),
+            Err(VirtualMachineError::RunNotFinished),
+        );
+
+        cairo_runner.accessed_addresses = Some(HashSet::new());
         cairo_runner.mark_as_accessed((0, 0).into(), 3).unwrap();
         cairo_runner.mark_as_accessed((0, 10).into(), 2).unwrap();
         cairo_runner.mark_as_accessed((1, 1).into(), 1).unwrap();
-        println!("{:?}", vm.accessed_addresses);
         assert_eq!(
-            vm.accessed_addresses.unwrap(),
+            cairo_runner.accessed_addresses.unwrap(),
             [
                 (0, 0).into(),
                 (0, 1).into(),

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -24,7 +24,11 @@ use crate::{
     },
 };
 use num_bigint::BigInt;
-use std::{any::Any, collections::HashMap, io};
+use std::{
+    any::Any,
+    collections::{HashMap, HashSet},
+    io,
+};
 
 pub struct CairoRunner {
     program: Program,
@@ -35,6 +39,7 @@ pub struct CairoRunner {
     initial_ap: Option<Relocatable>,
     initial_fp: Option<Relocatable>,
     initial_pc: Option<Relocatable>,
+    accessed_addresses: Option<HashSet<Relocatable>>,
     pub relocated_memory: Vec<Option<BigInt>>,
     pub relocated_trace: Option<Vec<RelocatedTraceEntry>>,
     pub exec_scopes: ExecutionScopes,
@@ -51,6 +56,7 @@ impl CairoRunner {
             initial_ap: None,
             initial_fp: None,
             initial_pc: None,
+            accessed_addresses: None,
             relocated_memory: Vec::new(),
             relocated_trace: None,
             exec_scopes: ExecutionScopes::new(),
@@ -302,11 +308,10 @@ impl CairoRunner {
         &mut self,
         address: Relocatable,
         size: usize,
-        vm: &mut VirtualMachine,
     ) -> Result<(), VirtualMachineError> {
-        let accessed_addressess = match &mut vm.accessed_addresses {
+        let accessed_addressess = match &mut self.accessed_addresses {
             Some(x) => x,
-            None => return Err(VirtualMachineError::MissingAccessedAddresses),
+            None => return Err(VirtualMachineError::RunNotFinished),
         };
 
         accessed_addressess.extend((0..size).map(|i| &address + i));
@@ -2306,15 +2311,9 @@ mod tests {
         let mut vm = vm!();
 
         vm.accessed_addresses = Some(HashSet::new());
-        cairo_runner
-            .mark_as_accessed((0, 0).into(), 3, &mut vm)
-            .unwrap();
-        cairo_runner
-            .mark_as_accessed((0, 10).into(), 2, &mut vm)
-            .unwrap();
-        cairo_runner
-            .mark_as_accessed((1, 1).into(), 1, &mut vm)
-            .unwrap();
+        cairo_runner.mark_as_accessed((0, 0).into(), 3).unwrap();
+        cairo_runner.mark_as_accessed((0, 10).into(), 2).unwrap();
+        cairo_runner.mark_as_accessed((1, 1).into(), 1).unwrap();
         println!("{:?}", vm.accessed_addresses);
         assert_eq!(
             vm.accessed_addresses.unwrap(),

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -19,11 +19,7 @@ use crate::{
 use num_bigint::BigInt;
 use num_integer::Integer;
 use num_traits::{ToPrimitive, Zero};
-use std::{
-    any::Any,
-    borrow::Cow,
-    collections::{HashMap, HashSet},
-};
+use std::{any::Any, borrow::Cow, collections::HashMap};
 
 #[derive(PartialEq, Debug)]
 pub struct Operands {
@@ -51,7 +47,7 @@ pub struct VirtualMachine {
     pub(crate) segments: MemorySegmentManager,
     pub(crate) _program_base: Option<MaybeRelocatable>,
     pub(crate) memory: Memory,
-    pub(crate) accessed_addresses: Option<HashSet<Relocatable>>,
+    accessed_addresses: Option<Vec<Relocatable>>,
     pub(crate) trace: Option<Vec<TraceEntry>>,
     current_step: usize,
     skip_instruction_execution: bool,
@@ -2082,7 +2078,7 @@ mod tests {
         };
 
         let mut vm = vm!();
-        vm.accessed_addresses = Some(HashSet::new());
+        vm.accessed_addresses = Some(Vec::new());
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory);
         }
@@ -2137,7 +2133,7 @@ mod tests {
         for _ in 0..2 {
             vm.segments.add(&mut vm.memory);
         }
-        vm.accessed_addresses = Some(HashSet::new());
+        vm.accessed_addresses = Some(Vec::new());
         vm.memory.data.push(Vec::new());
         let dst_addr = mayberelocatable!(1, 0);
         let dst_addr_value = mayberelocatable!(6);
@@ -2185,7 +2181,7 @@ mod tests {
         };
 
         let mut vm = vm!();
-        vm.accessed_addresses = Some(HashSet::new());
+        vm.accessed_addresses = Some(Vec::new());
         vm.memory = memory![
             ((0, 0), 0x206800180018001_i64),
             ((1, 1), 0x4),
@@ -2401,7 +2397,7 @@ mod tests {
     /// PC 0:0
     fn test_step_for_preset_memory() {
         let mut vm = vm!(true);
-        vm.accessed_addresses = Some(HashSet::new());
+        vm.accessed_addresses = Some(Vec::new());
 
         let hint_processor = BuiltinHintProcessor::new_empty();
 
@@ -2468,7 +2464,7 @@ mod tests {
     */
     fn test_step_for_preset_memory_function_call() {
         let mut vm = vm!(true);
-        vm.accessed_addresses = Some(HashSet::new());
+        vm.accessed_addresses = Some(Vec::new());
 
         run_context!(vm, 3, 2, 2);
 
@@ -2723,7 +2719,7 @@ mod tests {
         let mut builtin = HashBuiltinRunner::new(8);
         builtin.base = 3;
         let mut vm = vm!();
-        vm.accessed_addresses = Some(HashSet::new());
+        vm.accessed_addresses = Some(Vec::new());
         vm.builtin_runners
             .push((String::from("pedersen"), Box::new(builtin)));
         run_context!(vm, 0, 13, 12);
@@ -2816,7 +2812,7 @@ mod tests {
         builtin.base = 2;
         let mut vm = vm!();
 
-        vm.accessed_addresses = Some(HashSet::new());
+        vm.accessed_addresses = Some(Vec::new());
         vm.builtin_runners
             .push((String::from("bitwise"), Box::new(builtin)));
         run_context!(vm, 0, 9, 8);


### PR DESCRIPTION
# Implement `CairoRunner::mark_as_accessed()`.

## Description

Implementation `CairoRunner::mark_as_accessed()`.

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [x] This change requires new documentation.
  - [x] Documentation has been added/updated.
