### PR TITLE
Convert `BuiltinRunner` from trait into enum

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -199,7 +199,7 @@ pub mod test_utils {
             );
             vm.builtin_runners = vec![(
                 "range_check".to_string(),
-                Box::new(RangeCheckBuiltinRunner::new(bigint!(8), 8)),
+                RangeCheckBuiltinRunner::new(bigint!(8), 8).into(),
             )];
             vm
         }};

--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::ops::Shl;
 
 use num_bigint::BigInt;
@@ -7,7 +6,6 @@ use num_integer::Integer;
 use crate::bigint;
 use crate::types::relocatable::{MaybeRelocatable, Relocatable};
 use crate::vm::errors::runner_errors::RunnerError;
-use crate::vm::runners::builtin_runner::BuiltinRunner;
 use crate::vm::vm_memory::memory::Memory;
 use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
 
@@ -30,26 +28,28 @@ impl BitwiseBuiltinRunner {
             total_n_bits: 251,
         }
     }
-}
 
-impl BuiltinRunner for BitwiseBuiltinRunner {
-    fn initialize_segments(&mut self, segments: &mut MemorySegmentManager, memory: &mut Memory) {
+    pub fn initialize_segments(
+        &mut self,
+        segments: &mut MemorySegmentManager,
+        memory: &mut Memory,
+    ) {
         self.base = segments.add(memory).segment_index
     }
 
-    fn initial_stack(&self) -> Vec<MaybeRelocatable> {
+    pub fn initial_stack(&self) -> Vec<MaybeRelocatable> {
         vec![MaybeRelocatable::from((self.base, 0))]
     }
 
-    fn base(&self) -> Relocatable {
+    pub fn base(&self) -> Relocatable {
         Relocatable::from((self.base, 0))
     }
 
-    fn add_validation_rule(&self, _memory: &mut Memory) -> Result<(), RunnerError> {
+    pub fn add_validation_rule(&self, _memory: &mut Memory) -> Result<(), RunnerError> {
         Ok(())
     }
 
-    fn deduce_memory_cell(
+    pub fn deduce_memory_cell(
         &mut self,
         address: &Relocatable,
         memory: &Memory,
@@ -91,10 +91,6 @@ impl BuiltinRunner for BitwiseBuiltinRunner {
             return Ok(res);
         }
         Ok(None)
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::borrow::Cow;
 
 use num_bigint::BigInt;
@@ -7,7 +6,6 @@ use num_integer::Integer;
 use crate::math_utils::{ec_add, ec_double};
 use crate::types::relocatable::{MaybeRelocatable, Relocatable};
 use crate::vm::errors::runner_errors::RunnerError;
-use crate::vm::runners::builtin_runner::BuiltinRunner;
 use crate::vm::vm_memory::memory::Memory;
 use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
 use crate::{bigint, bigint_str};
@@ -80,25 +78,27 @@ impl EcOpBuiltinRunner {
         }
         Ok(partial_sum)
     }
-}
 
-impl BuiltinRunner for EcOpBuiltinRunner {
-    fn initialize_segments(&mut self, segments: &mut MemorySegmentManager, memory: &mut Memory) {
+    pub fn initialize_segments(
+        &mut self,
+        segments: &mut MemorySegmentManager,
+        memory: &mut Memory,
+    ) {
         self.base = segments.add(memory).segment_index
     }
 
-    fn initial_stack(&self) -> Vec<MaybeRelocatable> {
+    pub fn initial_stack(&self) -> Vec<MaybeRelocatable> {
         vec![MaybeRelocatable::from((self.base, 0))]
     }
 
-    fn base(&self) -> Relocatable {
+    pub fn base(&self) -> Relocatable {
         Relocatable::from((self.base, 0))
     }
-    fn add_validation_rule(&self, _memory: &mut Memory) -> Result<(), RunnerError> {
+    pub fn add_validation_rule(&self, _memory: &mut Memory) -> Result<(), RunnerError> {
         Ok(())
     }
 
-    fn deduce_memory_cell(
+    pub fn deduce_memory_cell(
         &mut self,
         address: &Relocatable,
         memory: &Memory,
@@ -181,10 +181,6 @@ impl BuiltinRunner for EcOpBuiltinRunner {
             _ => Ok(Some(MaybeRelocatable::Int(result.1))),
             //Default case corresponds to 1, as there are no other possible cases
         }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -1,12 +1,9 @@
-use std::any::Any;
-
 use num_bigint::{BigInt, Sign};
 use num_integer::Integer;
 use starknet_crypto::{pedersen_hash, FieldElement};
 
 use crate::types::relocatable::{MaybeRelocatable, Relocatable};
 use crate::vm::errors::runner_errors::RunnerError;
-use crate::vm::runners::builtin_runner::BuiltinRunner;
 use crate::vm::vm_memory::memory::Memory;
 use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
 
@@ -31,26 +28,28 @@ impl HashBuiltinRunner {
             verified_addresses: Vec::new(),
         }
     }
-}
 
-impl BuiltinRunner for HashBuiltinRunner {
-    fn initialize_segments(&mut self, segments: &mut MemorySegmentManager, memory: &mut Memory) {
+    pub fn initialize_segments(
+        &mut self,
+        segments: &mut MemorySegmentManager,
+        memory: &mut Memory,
+    ) {
         self.base = segments.add(memory).segment_index
     }
 
-    fn initial_stack(&self) -> Vec<MaybeRelocatable> {
+    pub fn initial_stack(&self) -> Vec<MaybeRelocatable> {
         vec![MaybeRelocatable::from((self.base, 0))]
     }
 
-    fn base(&self) -> Relocatable {
+    pub fn base(&self) -> Relocatable {
         Relocatable::from((self.base, 0))
     }
 
-    fn add_validation_rule(&self, _memory: &mut Memory) -> Result<(), RunnerError> {
+    pub fn add_validation_rule(&self, _memory: &mut Memory) -> Result<(), RunnerError> {
         Ok(())
     }
 
-    fn deduce_memory_cell(
+    pub fn deduce_memory_cell(
         &mut self,
         address: &Relocatable,
         memory: &Memory,
@@ -93,10 +92,6 @@ impl BuiltinRunner for HashBuiltinRunner {
             return Ok(Some(MaybeRelocatable::from(result)));
         }
         Ok(None)
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -1,5 +1,3 @@
-use std::any::Any;
-
 use crate::types::relocatable::{MaybeRelocatable, Relocatable};
 use crate::vm::errors::runner_errors::RunnerError;
 use crate::vm::vm_memory::memory::Memory;
@@ -17,17 +15,116 @@ pub use hash::HashBuiltinRunner;
 pub use output::OutputBuiltinRunner;
 pub use range_check::RangeCheckBuiltinRunner;
 
-pub trait BuiltinRunner {
+/* NB: this enum is no accident: we may need (and cairo-rs-py *does* need)
+ * structs containing this to be `Send`. The only two ways to achieve that
+ * are either storing a `dyn Trait` inside an `Arc<Mutex<&dyn Trait>>` or
+ * making the type itself `Send`. We opted for not complicating the user nor
+ * moving the guarantees to runtime by using an `enum` rather than a `Trait`.
+ * This works under the assumption that we don't expect downstream users to
+ * extend Cairo by adding new builtin runners.
+ */
+pub enum BuiltinRunner {
+    Bitwise(BitwiseBuiltinRunner),
+    EcOp(EcOpBuiltinRunner),
+    Hash(HashBuiltinRunner),
+    Output(OutputBuiltinRunner),
+    RangeCheck(RangeCheckBuiltinRunner),
+}
+
+impl BuiltinRunner {
     ///Creates the necessary segments for the builtin in the MemorySegmentManager and stores the first address on the builtin's base
-    fn initialize_segments(&mut self, segments: &mut MemorySegmentManager, memory: &mut Memory);
-    fn initial_stack(&self) -> Vec<MaybeRelocatable>;
+    pub fn initialize_segments(
+        &mut self,
+        segments: &mut MemorySegmentManager,
+        memory: &mut Memory,
+    ) {
+        match *self {
+            BuiltinRunner::Bitwise(ref mut bitwise) => {
+                bitwise.initialize_segments(segments, memory)
+            }
+            BuiltinRunner::EcOp(ref mut ec) => ec.initialize_segments(segments, memory),
+            BuiltinRunner::Hash(ref mut hash) => hash.initialize_segments(segments, memory),
+            BuiltinRunner::Output(ref mut output) => output.initialize_segments(segments, memory),
+            BuiltinRunner::RangeCheck(ref mut range_check) => {
+                range_check.initialize_segments(segments, memory)
+            }
+        }
+    }
+
+    pub fn initial_stack(&self) -> Vec<MaybeRelocatable> {
+        match *self {
+            BuiltinRunner::Bitwise(ref bitwise) => bitwise.initial_stack(),
+            BuiltinRunner::EcOp(ref ec) => ec.initial_stack(),
+            BuiltinRunner::Hash(ref hash) => hash.initial_stack(),
+            BuiltinRunner::Output(ref output) => output.initial_stack(),
+            BuiltinRunner::RangeCheck(ref range_check) => range_check.initial_stack(),
+        }
+    }
+
     ///Returns the builtin's base
-    fn base(&self) -> Relocatable;
-    fn add_validation_rule(&self, memory: &mut Memory) -> Result<(), RunnerError>;
-    fn deduce_memory_cell(
+    pub fn base(&self) -> Relocatable {
+        match *self {
+            BuiltinRunner::Bitwise(ref bitwise) => bitwise.base(),
+            BuiltinRunner::EcOp(ref ec) => ec.base(),
+            BuiltinRunner::Hash(ref hash) => hash.base(),
+            BuiltinRunner::Output(ref output) => output.base(),
+            BuiltinRunner::RangeCheck(ref range_check) => range_check.base(),
+        }
+    }
+
+    pub fn add_validation_rule(&self, memory: &mut Memory) -> Result<(), RunnerError> {
+        match *self {
+            BuiltinRunner::Bitwise(ref bitwise) => bitwise.add_validation_rule(memory),
+            BuiltinRunner::EcOp(ref ec) => ec.add_validation_rule(memory),
+            BuiltinRunner::Hash(ref hash) => hash.add_validation_rule(memory),
+            BuiltinRunner::Output(ref output) => output.add_validation_rule(memory),
+            BuiltinRunner::RangeCheck(ref range_check) => range_check.add_validation_rule(memory),
+        }
+    }
+
+    pub fn deduce_memory_cell(
         &mut self,
         address: &Relocatable,
         memory: &Memory,
-    ) -> Result<Option<MaybeRelocatable>, RunnerError>;
-    fn as_any(&self) -> &dyn Any;
+    ) -> Result<Option<MaybeRelocatable>, RunnerError> {
+        match *self {
+            BuiltinRunner::Bitwise(ref mut bitwise) => bitwise.deduce_memory_cell(address, memory),
+            BuiltinRunner::EcOp(ref mut ec) => ec.deduce_memory_cell(address, memory),
+            BuiltinRunner::Hash(ref mut hash) => hash.deduce_memory_cell(address, memory),
+            BuiltinRunner::Output(ref mut output) => output.deduce_memory_cell(address, memory),
+            BuiltinRunner::RangeCheck(ref mut range_check) => {
+                range_check.deduce_memory_cell(address, memory)
+            }
+        }
+    }
+}
+
+impl From<BitwiseBuiltinRunner> for BuiltinRunner {
+    fn from(runner: BitwiseBuiltinRunner) -> Self {
+        BuiltinRunner::Bitwise(runner)
+    }
+}
+
+impl From<EcOpBuiltinRunner> for BuiltinRunner {
+    fn from(runner: EcOpBuiltinRunner) -> Self {
+        BuiltinRunner::EcOp(runner)
+    }
+}
+
+impl From<HashBuiltinRunner> for BuiltinRunner {
+    fn from(runner: HashBuiltinRunner) -> Self {
+        BuiltinRunner::Hash(runner)
+    }
+}
+
+impl From<OutputBuiltinRunner> for BuiltinRunner {
+    fn from(runner: OutputBuiltinRunner) -> Self {
+        BuiltinRunner::Output(runner)
+    }
+}
+
+impl From<RangeCheckBuiltinRunner> for BuiltinRunner {
+    fn from(runner: RangeCheckBuiltinRunner) -> Self {
+        BuiltinRunner::RangeCheck(runner)
+    }
 }

--- a/src/vm/runners/builtin_runner/output.rs
+++ b/src/vm/runners/builtin_runner/output.rs
@@ -1,8 +1,5 @@
-use std::any::Any;
-
 use crate::types::relocatable::{MaybeRelocatable, Relocatable};
 use crate::vm::errors::runner_errors::RunnerError;
-use crate::vm::runners::builtin_runner::BuiltinRunner;
 use crate::vm::vm_memory::memory::Memory;
 use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
 
@@ -18,35 +15,33 @@ impl OutputBuiltinRunner {
             _stop_ptr: None,
         }
     }
-}
 
-impl BuiltinRunner for OutputBuiltinRunner {
-    fn initialize_segments(&mut self, segments: &mut MemorySegmentManager, memory: &mut Memory) {
+    pub fn initialize_segments(
+        &mut self,
+        segments: &mut MemorySegmentManager,
+        memory: &mut Memory,
+    ) {
         self.base = segments.add(memory).segment_index
     }
 
-    fn initial_stack(&self) -> Vec<MaybeRelocatable> {
+    pub fn initial_stack(&self) -> Vec<MaybeRelocatable> {
         vec![MaybeRelocatable::from((self.base, 0))]
     }
 
-    fn base(&self) -> Relocatable {
+    pub fn base(&self) -> Relocatable {
         Relocatable::from((self.base, 0))
     }
 
-    fn add_validation_rule(&self, _memory: &mut Memory) -> Result<(), RunnerError> {
+    pub fn add_validation_rule(&self, _memory: &mut Memory) -> Result<(), RunnerError> {
         Ok(())
     }
 
-    fn deduce_memory_cell(
+    pub fn deduce_memory_cell(
         &mut self,
         _address: &Relocatable,
         _memory: &Memory,
     ) -> Result<Option<MaybeRelocatable>, RunnerError> {
         Ok(None)
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::borrow::Cow;
 use std::ops::Shl;
 
@@ -9,7 +8,6 @@ use crate::bigint;
 use crate::types::relocatable::{MaybeRelocatable, Relocatable};
 use crate::vm::errors::memory_errors::MemoryError;
 use crate::vm::errors::runner_errors::RunnerError;
-use crate::vm::runners::builtin_runner::BuiltinRunner;
 use crate::vm::vm_memory::memory::{Memory, ValidationRule};
 use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
 
@@ -38,21 +36,24 @@ impl RangeCheckBuiltinRunner {
             _n_parts: n_parts,
         }
     }
-}
-impl BuiltinRunner for RangeCheckBuiltinRunner {
-    fn initialize_segments(&mut self, segments: &mut MemorySegmentManager, memory: &mut Memory) {
+
+    pub fn initialize_segments(
+        &mut self,
+        segments: &mut MemorySegmentManager,
+        memory: &mut Memory,
+    ) {
         self.base = segments.add(memory).segment_index
     }
 
-    fn initial_stack(&self) -> Vec<MaybeRelocatable> {
+    pub fn initial_stack(&self) -> Vec<MaybeRelocatable> {
         vec![MaybeRelocatable::from((self.base, 0))]
     }
 
-    fn base(&self) -> Relocatable {
+    pub fn base(&self) -> Relocatable {
         Relocatable::from((self.base, 0))
     }
 
-    fn add_validation_rule(&self, memory: &mut Memory) -> Result<(), RunnerError> {
+    pub fn add_validation_rule(&self, memory: &mut Memory) -> Result<(), RunnerError> {
         let rule: ValidationRule = ValidationRule(Box::new(
             |memory: &Memory,
              address: &MaybeRelocatable|
@@ -81,16 +82,12 @@ impl BuiltinRunner for RangeCheckBuiltinRunner {
         Ok(())
     }
 
-    fn deduce_memory_cell(
+    pub fn deduce_memory_cell(
         &mut self,
         _address: &Relocatable,
         _memory: &Memory,
     ) -> Result<Option<MaybeRelocatable>, RunnerError> {
         Ok(None)
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -77,31 +77,28 @@ impl CairoRunner {
         if !is_subsequence(&self.program.builtins, &builtin_ordered_list) {
             return Err(RunnerError::DisorderedBuiltins);
         };
-        let mut builtin_runners = Vec::<(String, Box<dyn BuiltinRunner>)>::new();
+        let mut builtin_runners = Vec::<(String, BuiltinRunner)>::new();
         for builtin_name in self.program.builtins.iter() {
             if builtin_name == "output" {
-                builtin_runners.push((builtin_name.clone(), Box::new(OutputBuiltinRunner::new())));
+                builtin_runners.push((builtin_name.clone(), OutputBuiltinRunner::new().into()));
             }
 
             if builtin_name == "pedersen" {
-                builtin_runners.push((builtin_name.clone(), Box::new(HashBuiltinRunner::new(8))));
+                builtin_runners.push((builtin_name.clone(), HashBuiltinRunner::new(8).into()));
             }
 
             if builtin_name == "range_check" {
                 //Information for Buitin info taken from here https://github.com/starkware-libs/cairo-lang/blob/b614d1867c64f3fb2cf4a4879348cfcf87c3a5a7/src/starkware/cairo/lang/instances.py#L115
                 builtin_runners.push((
                     builtin_name.clone(),
-                    Box::new(RangeCheckBuiltinRunner::new(bigint!(8), 8)),
+                    RangeCheckBuiltinRunner::new(bigint!(8), 8).into(),
                 ));
             }
             if builtin_name == "bitwise" {
-                builtin_runners.push((
-                    builtin_name.clone(),
-                    Box::new(BitwiseBuiltinRunner::new(256)),
-                ));
+                builtin_runners.push((builtin_name.clone(), BitwiseBuiltinRunner::new(256).into()));
             }
             if builtin_name == "ec_op" {
-                builtin_runners.push((builtin_name.clone(), Box::new(EcOpBuiltinRunner::new(256))));
+                builtin_runners.push((builtin_name.clone(), EcOpBuiltinRunner::new(256).into()));
             }
         }
         vm.builtin_runners = builtin_runners;

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -43,7 +43,7 @@ pub struct HintData {
 pub struct VirtualMachine {
     pub(crate) run_context: RunContext,
     pub(crate) prime: BigInt,
-    pub(crate) builtin_runners: Vec<(String, Box<dyn BuiltinRunner>)>,
+    pub(crate) builtin_runners: Vec<(String, BuiltinRunner)>,
     pub(crate) segments: MemorySegmentManager,
     pub(crate) _program_base: Option<MaybeRelocatable>,
     pub(crate) memory: Memory,
@@ -685,7 +685,7 @@ impl VirtualMachine {
     }
 
     /// Returns a reference to the vector with all builtins present in the virtual machine
-    pub fn get_builtin_runners(&self) -> &Vec<(String, Box<dyn BuiltinRunner>)> {
+    pub fn get_builtin_runners(&self) -> &Vec<(String, BuiltinRunner)> {
         &self.builtin_runners
     }
 
@@ -739,9 +739,7 @@ impl VirtualMachine {
     pub fn get_range_check_builtin(&self) -> Result<&RangeCheckBuiltinRunner, VirtualMachineError> {
         for (name, builtin) in &self.builtin_runners {
             if name == &String::from("range_check") {
-                if let Some(range_check_builtin) =
-                    builtin.as_any().downcast_ref::<RangeCheckBuiltinRunner>()
-                {
+                if let BuiltinRunner::RangeCheck(range_check_builtin) = builtin {
                     return Ok(range_check_builtin);
                 };
             }
@@ -2667,7 +2665,7 @@ mod tests {
         let mut vm = vm!();
         let builtin = HashBuiltinRunner::new(8);
         vm.builtin_runners
-            .push((String::from("pedersen"), Box::new(builtin)));
+            .push((String::from("pedersen"), builtin.into()));
         vm.memory = memory![((0, 3), 32), ((0, 4), 72), ((0, 5), 0)];
         assert_eq!(
             vm.deduce_memory_cell(&Relocatable::from((0, 5))),
@@ -2721,7 +2719,7 @@ mod tests {
         let mut vm = vm!();
         vm.accessed_addresses = Some(Vec::new());
         vm.builtin_runners
-            .push((String::from("pedersen"), Box::new(builtin)));
+            .push((String::from("pedersen"), builtin.into()));
         run_context!(vm, 0, 13, 12);
 
         //Insert values into memory (excluding those from the program segment (instructions))
@@ -2771,7 +2769,7 @@ mod tests {
         let mut vm = vm!();
         let builtin = BitwiseBuiltinRunner::new(8);
         vm.builtin_runners
-            .push((String::from("bitwise"), Box::new(builtin)));
+            .push((String::from("bitwise"), builtin.into()));
         vm.memory = memory![((0, 5), 10), ((0, 6), 12), ((0, 7), 0)];
         assert_eq!(
             vm.deduce_memory_cell(&Relocatable::from((0, 7))),
@@ -2814,7 +2812,7 @@ mod tests {
 
         vm.accessed_addresses = Some(Vec::new());
         vm.builtin_runners
-            .push((String::from("bitwise"), Box::new(builtin)));
+            .push((String::from("bitwise"), builtin.into()));
         run_context!(vm, 0, 9, 8);
 
         //Insert values into memory (excluding those from the program segment (instructions))
@@ -2853,7 +2851,7 @@ mod tests {
         let mut vm = vm!();
         let builtin = EcOpBuiltinRunner::new(256);
         vm.builtin_runners
-            .push((String::from("ec_op"), Box::new(builtin)));
+            .push((String::from("ec_op"), builtin.into()));
 
         vm.memory = memory![
             (
@@ -2925,7 +2923,7 @@ mod tests {
         builtin.base = 3;
         let mut vm = vm!();
         vm.builtin_runners
-            .push((String::from("ec_op"), Box::new(builtin)));
+            .push((String::from("ec_op"), builtin.into()));
         vm.memory = memory![
             (
                 (3, 0),
@@ -2973,7 +2971,7 @@ mod tests {
         builtin.base = 3;
         let mut vm = vm!();
         vm.builtin_runners
-            .push((String::from("ec_op"), Box::new(builtin)));
+            .push((String::from("ec_op"), builtin.into()));
         vm.memory = memory![
             (
                 (3, 0),
@@ -3046,7 +3044,7 @@ mod tests {
         builtin.base = 2;
         let mut vm = vm!();
         vm.builtin_runners
-            .push((String::from("bitwise"), Box::new(builtin)));
+            .push((String::from("bitwise"), builtin.into()));
         vm.memory = memory![((2, 0), 12), ((2, 1), 10)];
         assert_eq!(vm.verify_auto_deductions(), Ok(()));
     }
@@ -3080,7 +3078,7 @@ mod tests {
         builtin.base = 3;
         let mut vm = vm!();
         vm.builtin_runners
-            .push((String::from("pedersen"), Box::new(builtin)));
+            .push((String::from("pedersen"), builtin.into()));
         vm.memory = memory![((3, 0), 32), ((3, 1), 72)];
         assert_eq!(vm.verify_auto_deductions(), Ok(()));
     }
@@ -3193,9 +3191,9 @@ mod tests {
         let hash_builtin = HashBuiltinRunner::new(8);
         let bitwise_builtin = BitwiseBuiltinRunner::new(8);
         vm.builtin_runners
-            .push((String::from("pedersen"), Box::new(hash_builtin)));
+            .push((String::from("pedersen"), hash_builtin.into()));
         vm.builtin_runners
-            .push((String::from("bitwise"), Box::new(bitwise_builtin)));
+            .push((String::from("bitwise"), bitwise_builtin.into()));
 
         let builtins = vm.get_builtin_runners();
 

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -264,7 +264,7 @@ mod memory_tests {
         bigint,
         utils::test_utils::mayberelocatable,
         vm::{
-            runners::builtin_runner::{BuiltinRunner, RangeCheckBuiltinRunner},
+            runners::builtin_runner::RangeCheckBuiltinRunner,
             vm_memory::memory_segments::MemorySegmentManager,
         },
     };


### PR DESCRIPTION
Implementing BuiltinRunner as trait meant storing `&dyn trait` fields in `VirtualMachine`, which makes it `!Send`, in turn making it impossible to release the GIL in `cairo-rs-py` without wrapping it into `Arc<Mutex<_>>` in `cairo-rs`, losing some of the compile-time benefits of Rust and making it inconvenient to use for downstream projects. Under the assumption that no runners will be added outside of the scope of `cairo-rs` it was, thus, decided to just use an enum that forwards the calls to its variants.