### PR TITLE
Implement `BuiltinRunner::get_memory_accesses()`

### DIFF
--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -102,7 +102,11 @@ impl BuiltinRunner for BitwiseBuiltinRunner {
     fn get_memory_accesses(&self, vm: &VirtualMachine) -> Result<Vec<Relocatable>, MemoryError> {
         let segment_size = vm
             .segments
-            .get_segment_size(self.base as _)
+            .get_segment_size(
+                self.base
+                    .try_into()
+                    .map_err(|_| MemoryError::AddressInTemporarySegment(self.base))?,
+            )
             .ok_or(MemoryError::MissingSegmentUsedSizes)?;
 
         Ok((0..segment_size).map(|i| (self.base, i).into()).collect())
@@ -114,6 +118,7 @@ mod tests {
     use super::*;
     use crate::utils::test_utils::*;
     use crate::vm::errors::memory_errors::MemoryError;
+    use num_bigint::Sign;
 
     #[test]
     fn deduce_memory_cell_bitwise_for_preset_memory_valid_and() {
@@ -153,5 +158,30 @@ mod tests {
         let mut builtin = BitwiseBuiltinRunner::new(256);
         let result = builtin.deduce_memory_cell(&Relocatable::from((0, 5)), &memory);
         assert_eq!(result, Ok(None));
+    }
+
+    #[test]
+    fn get_memory_accesses() {
+        let builtin = BitwiseBuiltinRunner::new(256);
+        let mut vm = vm!();
+
+        assert_eq!(
+            builtin.get_memory_accesses(&vm),
+            Err(MemoryError::MissingSegmentUsedSizes),
+        );
+
+        vm.segments.segment_used_sizes = Some(vec![0]);
+        assert_eq!(builtin.get_memory_accesses(&vm), Ok(vec![]));
+
+        vm.segments.segment_used_sizes = Some(vec![4]);
+        assert_eq!(
+            builtin.get_memory_accesses(&vm),
+            Ok(vec![
+                (builtin.base, 0).into(),
+                (builtin.base, 1).into(),
+                (builtin.base, 2).into(),
+                (builtin.base, 3).into(),
+            ]),
+        );
     }
 }

--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -172,12 +172,18 @@ mod tests {
     }
 
     #[test]
-    fn get_memory_accesses() {
+    fn get_memory_accesses_empty() {
         let builtin = BitwiseBuiltinRunner::new(256);
         let mut vm = vm!();
 
         vm.segments.segment_used_sizes = Some(vec![0]);
         assert_eq!(builtin.get_memory_accesses(&vm), Ok(vec![]));
+    }
+
+    #[test]
+    fn get_memory_accesses() {
+        let builtin = BitwiseBuiltinRunner::new(256);
+        let mut vm = vm!();
 
         vm.segments.segment_used_sizes = Some(vec![4]);
         assert_eq!(

--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -161,14 +161,20 @@ mod tests {
     }
 
     #[test]
-    fn get_memory_accesses() {
+    fn get_memory_accesses_missing_segment_used_sizes() {
         let builtin = BitwiseBuiltinRunner::new(256);
-        let mut vm = vm!();
+        let vm = vm!();
 
         assert_eq!(
             builtin.get_memory_accesses(&vm),
             Err(MemoryError::MissingSegmentUsedSizes),
         );
+    }
+
+    #[test]
+    fn get_memory_accesses() {
+        let builtin = BitwiseBuiltinRunner::new(256);
+        let mut vm = vm!();
 
         vm.segments.segment_used_sizes = Some(vec![0]);
         assert_eq!(builtin.get_memory_accesses(&vm), Ok(vec![]));

--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -6,9 +6,10 @@ use num_integer::Integer;
 
 use crate::bigint;
 use crate::types::relocatable::{MaybeRelocatable, Relocatable};
+use crate::vm::errors::memory_errors::MemoryError;
 use crate::vm::errors::runner_errors::RunnerError;
 use crate::vm::runners::builtin_runner::BuiltinRunner;
-use crate::vm::runners::cairo_runner::CairoRunner;
+use crate::vm::vm_core::VirtualMachine;
 use crate::vm::vm_memory::memory::Memory;
 use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
 
@@ -98,8 +99,13 @@ impl BuiltinRunner for BitwiseBuiltinRunner {
         self
     }
 
-    fn get_memory_accesses(&self, _runner: &CairoRunner) -> std::collections::HashSet<Relocatable> {
-        todo!()
+    fn get_memory_accesses(&self, vm: &VirtualMachine) -> Result<Vec<Relocatable>, MemoryError> {
+        let segment_size = vm
+            .segments
+            .get_segment_size(self.base as _)
+            .ok_or(MemoryError::MissingSegmentUsedSizes)?;
+
+        Ok((0..segment_size).map(|i| (self.base, i).into()).collect())
     }
 }
 

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -622,14 +622,20 @@ mod tests {
     }
 
     #[test]
-    fn get_memory_accesses() {
+    fn get_memory_accesses_missing_segment_used_sizes() {
         let builtin = EcOpBuiltinRunner::new(256);
-        let mut vm = vm!();
+        let vm = vm!();
 
         assert_eq!(
             builtin.get_memory_accesses(&vm),
             Err(MemoryError::MissingSegmentUsedSizes),
         );
+    }
+
+    #[test]
+    fn get_memory_accesses() {
+        let builtin = EcOpBuiltinRunner::new(256);
+        let mut vm = vm!();
 
         vm.segments.segment_used_sizes = Some(vec![0]);
         assert_eq!(builtin.get_memory_accesses(&vm), Ok(vec![]));

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -6,9 +6,10 @@ use num_integer::Integer;
 
 use crate::math_utils::{ec_add, ec_double};
 use crate::types::relocatable::{MaybeRelocatable, Relocatable};
+use crate::vm::errors::memory_errors::MemoryError;
 use crate::vm::errors::runner_errors::RunnerError;
 use crate::vm::runners::builtin_runner::BuiltinRunner;
-use crate::vm::runners::cairo_runner::CairoRunner;
+use crate::vm::vm_core::VirtualMachine;
 use crate::vm::vm_memory::memory::Memory;
 use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
 use crate::{bigint, bigint_str};
@@ -188,8 +189,13 @@ impl BuiltinRunner for EcOpBuiltinRunner {
         self
     }
 
-    fn get_memory_accesses(&self, _runner: &CairoRunner) -> std::collections::HashSet<Relocatable> {
-        todo!()
+    fn get_memory_accesses(&self, vm: &VirtualMachine) -> Result<Vec<Relocatable>, MemoryError> {
+        let segment_size = vm
+            .segments
+            .get_segment_size(self.base as _)
+            .ok_or(MemoryError::MissingSegmentUsedSizes)?;
+
+        Ok((0..segment_size).map(|i| (self.base, i).into()).collect())
     }
 }
 

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -633,12 +633,18 @@ mod tests {
     }
 
     #[test]
-    fn get_memory_accesses() {
+    fn get_memory_accesses_empty() {
         let builtin = EcOpBuiltinRunner::new(256);
         let mut vm = vm!();
 
         vm.segments.segment_used_sizes = Some(vec![0]);
         assert_eq!(builtin.get_memory_accesses(&vm), Ok(vec![]));
+    }
+
+    #[test]
+    fn get_memory_accesses() {
+        let builtin = EcOpBuiltinRunner::new(256);
+        let mut vm = vm!();
 
         vm.segments.segment_used_sizes = Some(vec![4]);
         assert_eq!(

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -163,14 +163,20 @@ mod tests {
     }
 
     #[test]
-    fn get_memory_accesses() {
+    fn get_memory_accesses_missing_segment_used_sizes() {
         let builtin = HashBuiltinRunner::new(256);
-        let mut vm = vm!();
+        let vm = vm!();
 
         assert_eq!(
             builtin.get_memory_accesses(&vm),
             Err(MemoryError::MissingSegmentUsedSizes),
         );
+    }
+
+    #[test]
+    fn get_memory_accesses() {
+        let builtin = HashBuiltinRunner::new(256);
+        let mut vm = vm!();
 
         vm.segments.segment_used_sizes = Some(vec![0]);
         assert_eq!(builtin.get_memory_accesses(&vm), Ok(vec![]));

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -174,12 +174,18 @@ mod tests {
     }
 
     #[test]
-    fn get_memory_accesses() {
+    fn get_memory_accesses_empty() {
         let builtin = HashBuiltinRunner::new(256);
         let mut vm = vm!();
 
         vm.segments.segment_used_sizes = Some(vec![0]);
         assert_eq!(builtin.get_memory_accesses(&vm), Ok(vec![]));
+    }
+
+    #[test]
+    fn get_memory_accesses() {
+        let builtin = HashBuiltinRunner::new(256);
+        let mut vm = vm!();
 
         vm.segments.segment_used_sizes = Some(vec![4]);
         assert_eq!(

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -5,9 +5,10 @@ use num_integer::Integer;
 use starknet_crypto::{pedersen_hash, FieldElement};
 
 use crate::types::relocatable::{MaybeRelocatable, Relocatable};
+use crate::vm::errors::memory_errors::MemoryError;
 use crate::vm::errors::runner_errors::RunnerError;
 use crate::vm::runners::builtin_runner::BuiltinRunner;
-use crate::vm::runners::cairo_runner::CairoRunner;
+use crate::vm::vm_core::VirtualMachine;
 use crate::vm::vm_memory::memory::Memory;
 use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
 
@@ -100,8 +101,13 @@ impl BuiltinRunner for HashBuiltinRunner {
         self
     }
 
-    fn get_memory_accesses(&self, _runner: &CairoRunner) -> std::collections::HashSet<Relocatable> {
-        todo!()
+    fn get_memory_accesses(&self, vm: &VirtualMachine) -> Result<Vec<Relocatable>, MemoryError> {
+        let segment_size = vm
+            .segments
+            .get_segment_size(self.base as _)
+            .ok_or(MemoryError::MissingSegmentUsedSizes)?;
+
+        Ok((0..segment_size).map(|i| (self.base, i).into()).collect())
     }
 }
 

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -1,10 +1,10 @@
-use super::cairo_runner::CairoRunner;
 use crate::types::relocatable::{MaybeRelocatable, Relocatable};
+use crate::vm::errors::memory_errors::MemoryError;
 use crate::vm::errors::runner_errors::RunnerError;
+use crate::vm::vm_core::VirtualMachine;
 use crate::vm::vm_memory::memory::Memory;
 use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
 use std::any::Any;
-use std::collections::HashSet;
 
 mod bitwise;
 mod ec_op;
@@ -32,5 +32,5 @@ pub trait BuiltinRunner {
     ) -> Result<Option<MaybeRelocatable>, RunnerError>;
     fn as_any(&self) -> &dyn Any;
 
-    fn get_memory_accesses(&self, runner: &CairoRunner) -> HashSet<Relocatable>;
+    fn get_memory_accesses(&self, vm: &VirtualMachine) -> Result<Vec<Relocatable>, MemoryError>;
 }

--- a/src/vm/runners/builtin_runner/output.rs
+++ b/src/vm/runners/builtin_runner/output.rs
@@ -110,12 +110,18 @@ mod tests {
     }
 
     #[test]
-    fn get_memory_accesses() {
+    fn get_memory_accesses_empty() {
         let builtin = OutputBuiltinRunner::new();
         let mut vm = vm!();
 
         vm.segments.segment_used_sizes = Some(vec![0]);
         assert_eq!(builtin.get_memory_accesses(&vm), Ok(vec![]));
+    }
+
+    #[test]
+    fn get_memory_accesses() {
+        let builtin = OutputBuiltinRunner::new();
+        let mut vm = vm!();
 
         vm.segments.segment_used_sizes = Some(vec![4]);
         assert_eq!(

--- a/src/vm/runners/builtin_runner/output.rs
+++ b/src/vm/runners/builtin_runner/output.rs
@@ -1,9 +1,10 @@
 use std::any::Any;
 
 use crate::types::relocatable::{MaybeRelocatable, Relocatable};
+use crate::vm::errors::memory_errors::MemoryError;
 use crate::vm::errors::runner_errors::RunnerError;
 use crate::vm::runners::builtin_runner::BuiltinRunner;
-use crate::vm::runners::cairo_runner::CairoRunner;
+use crate::vm::vm_core::VirtualMachine;
 use crate::vm::vm_memory::memory::Memory;
 use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
 
@@ -50,8 +51,13 @@ impl BuiltinRunner for OutputBuiltinRunner {
         self
     }
 
-    fn get_memory_accesses(&self, _runner: &CairoRunner) -> std::collections::HashSet<Relocatable> {
-        todo!()
+    fn get_memory_accesses(&self, vm: &VirtualMachine) -> Result<Vec<Relocatable>, MemoryError> {
+        let segment_size = vm
+            .segments
+            .get_segment_size(self.base as _)
+            .ok_or(MemoryError::MissingSegmentUsedSizes)?;
+
+        Ok((0..segment_size).map(|i| (self.base, i).into()).collect())
     }
 }
 

--- a/src/vm/runners/builtin_runner/output.rs
+++ b/src/vm/runners/builtin_runner/output.rs
@@ -99,14 +99,20 @@ mod tests {
     }
 
     #[test]
-    fn get_memory_accesses() {
+    fn get_memory_accesses_missing_segment_used_sizes() {
         let builtin = OutputBuiltinRunner::new();
-        let mut vm = vm!();
+        let vm = vm!();
 
         assert_eq!(
             builtin.get_memory_accesses(&vm),
             Err(MemoryError::MissingSegmentUsedSizes),
         );
+    }
+
+    #[test]
+    fn get_memory_accesses() {
+        let builtin = OutputBuiltinRunner::new();
+        let mut vm = vm!();
 
         vm.segments.segment_used_sizes = Some(vec![0]);
         assert_eq!(builtin.get_memory_accesses(&vm), Ok(vec![]));

--- a/src/vm/runners/builtin_runner/output.rs
+++ b/src/vm/runners/builtin_runner/output.rs
@@ -54,7 +54,11 @@ impl BuiltinRunner for OutputBuiltinRunner {
     fn get_memory_accesses(&self, vm: &VirtualMachine) -> Result<Vec<Relocatable>, MemoryError> {
         let segment_size = vm
             .segments
-            .get_segment_size(self.base as _)
+            .get_segment_size(
+                self.base
+                    .try_into()
+                    .map_err(|_| MemoryError::AddressInTemporarySegment(self.base))?,
+            )
             .ok_or(MemoryError::MissingSegmentUsedSizes)?;
 
         Ok((0..segment_size).map(|i| (self.base, i).into()).collect())
@@ -70,6 +74,8 @@ impl Default for OutputBuiltinRunner {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::utils::test_utils::vm;
+    use num_bigint::{BigInt, Sign};
 
     #[test]
     fn initialize_segments_for_output() {
@@ -90,5 +96,30 @@ mod tests {
             MaybeRelocatable::RelocatableValue(builtin.base())
         );
         assert_eq!(initial_stack.len(), 1);
+    }
+
+    #[test]
+    fn get_memory_accesses() {
+        let builtin = OutputBuiltinRunner::new();
+        let mut vm = vm!();
+
+        assert_eq!(
+            builtin.get_memory_accesses(&vm),
+            Err(MemoryError::MissingSegmentUsedSizes),
+        );
+
+        vm.segments.segment_used_sizes = Some(vec![0]);
+        assert_eq!(builtin.get_memory_accesses(&vm), Ok(vec![]));
+
+        vm.segments.segment_used_sizes = Some(vec![4]);
+        assert_eq!(
+            builtin.get_memory_accesses(&vm),
+            Ok(vec![
+                (builtin.base, 0).into(),
+                (builtin.base, 1).into(),
+                (builtin.base, 2).into(),
+                (builtin.base, 3).into(),
+            ]),
+        );
     }
 }

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -10,7 +10,7 @@ use crate::types::relocatable::{MaybeRelocatable, Relocatable};
 use crate::vm::errors::memory_errors::MemoryError;
 use crate::vm::errors::runner_errors::RunnerError;
 use crate::vm::runners::builtin_runner::BuiltinRunner;
-use crate::vm::runners::cairo_runner::CairoRunner;
+use crate::vm::vm_core::VirtualMachine;
 use crate::vm::vm_memory::memory::{Memory, ValidationRule};
 use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
 
@@ -94,8 +94,13 @@ impl BuiltinRunner for RangeCheckBuiltinRunner {
         self
     }
 
-    fn get_memory_accesses(&self, _runner: &CairoRunner) -> std::collections::HashSet<Relocatable> {
-        todo!()
+    fn get_memory_accesses(&self, vm: &VirtualMachine) -> Result<Vec<Relocatable>, MemoryError> {
+        let segment_size = vm
+            .segments
+            .get_segment_size(self.base as _)
+            .ok_or(MemoryError::MissingSegmentUsedSizes)?;
+
+        Ok((0..segment_size).map(|i| (self.base, i).into()).collect())
     }
 }
 

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -136,14 +136,20 @@ mod tests {
     }
 
     #[test]
-    fn get_memory_accesses() {
+    fn get_memory_accesses_missing_segment_used_sizes() {
         let builtin = RangeCheckBuiltinRunner::new(bigint!(256), 8);
-        let mut vm = vm!();
+        let vm = vm!();
 
         assert_eq!(
             builtin.get_memory_accesses(&vm),
             Err(MemoryError::MissingSegmentUsedSizes),
         );
+    }
+
+    #[test]
+    fn get_memory_accesses() {
+        let builtin = RangeCheckBuiltinRunner::new(bigint!(256), 8);
+        let mut vm = vm!();
 
         vm.segments.segment_used_sizes = Some(vec![0]);
         assert_eq!(builtin.get_memory_accesses(&vm), Ok(vec![]));

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -147,12 +147,18 @@ mod tests {
     }
 
     #[test]
-    fn get_memory_accesses() {
+    fn get_memory_accesses_empty() {
         let builtin = RangeCheckBuiltinRunner::new(bigint!(256), 8);
         let mut vm = vm!();
 
         vm.segments.segment_used_sizes = Some(vec![0]);
         assert_eq!(builtin.get_memory_accesses(&vm), Ok(vec![]));
+    }
+
+    #[test]
+    fn get_memory_accesses() {
+        let builtin = RangeCheckBuiltinRunner::new(bigint!(256), 8);
+        let mut vm = vm!();
 
         vm.segments.segment_used_sizes = Some(vec![4]);
         assert_eq!(

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -318,17 +318,17 @@ impl CairoRunner {
         Ok(())
     }
 
+    /// Count the number of holes present in the segments.
     pub fn get_memory_holes(&self, vm: &VirtualMachine) -> Result<usize, MemoryError> {
         let accessed_addresses = self
             .accessed_addresses
             .as_ref()
             .ok_or(MemoryError::MissingAccessedAddresses)?;
 
-        let mut builtin_accessed_addresses = vm
-            .builtin_runners
-            .iter()
-            .flat_map(|(_, x)| x.get_memory_accesses(self).into_iter())
-            .collect::<HashSet<_>>();
+        let mut builtin_accessed_addresses = HashSet::new();
+        for (_, builtin_runner) in &vm.builtin_runners {
+            builtin_accessed_addresses.extend(builtin_runner.get_memory_accesses(vm)?.into_iter());
+        }
 
         builtin_accessed_addresses.extend(accessed_addresses.iter().cloned());
         vm.segments.get_memory_holes(&builtin_accessed_addresses)
@@ -2367,5 +2367,175 @@ mod tests {
             .into_iter()
             .collect(),
         );
+    }
+
+    #[test]
+    fn get_memory_holes_missing_accessed_addresses() {
+        let program = Program {
+            builtins: Vec::new(),
+            prime: bigint_str!(
+                b"3618502788666131213697322783095070105623107215331596699973092056135872020481"
+            ),
+            data: Vec::new(),
+            constants: HashMap::new(),
+            main: None,
+            hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
+            identifiers: HashMap::new(),
+        };
+
+        let cairo_runner = CairoRunner::new(&program).unwrap();
+        let vm = vm!();
+
+        assert_eq!(
+            cairo_runner.get_memory_holes(&vm),
+            Err(MemoryError::MissingAccessedAddresses),
+        );
+    }
+
+    #[test]
+    fn get_memory_holes_missing_segment_used_sizes() {
+        let program = Program {
+            builtins: Vec::new(),
+            prime: bigint_str!(
+                b"3618502788666131213697322783095070105623107215331596699973092056135872020481"
+            ),
+            data: Vec::new(),
+            constants: HashMap::new(),
+            main: None,
+            hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
+            identifiers: HashMap::new(),
+        };
+
+        let mut cairo_runner = CairoRunner::new(&program).unwrap();
+        let mut vm = vm!();
+
+        cairo_runner.accessed_addresses = Some(HashSet::new());
+        vm.builtin_runners = Vec::new();
+        assert_eq!(
+            cairo_runner.get_memory_holes(&vm),
+            Err(MemoryError::MissingSegmentUsedSizes),
+        );
+    }
+
+    #[test]
+    fn get_memory_holes_empty() {
+        let program = Program {
+            builtins: Vec::new(),
+            prime: bigint_str!(
+                b"3618502788666131213697322783095070105623107215331596699973092056135872020481"
+            ),
+            data: Vec::new(),
+            constants: HashMap::new(),
+            main: None,
+            hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
+            identifiers: HashMap::new(),
+        };
+
+        let mut cairo_runner = CairoRunner::new(&program).unwrap();
+        let mut vm = vm!();
+
+        cairo_runner.accessed_addresses = Some(HashSet::new());
+        vm.builtin_runners = Vec::new();
+        vm.segments.segment_used_sizes = Some(Vec::new());
+        assert_eq!(cairo_runner.get_memory_holes(&vm), Ok(0));
+    }
+
+    #[test]
+    fn get_memory_holes_empty_builtins() {
+        let program = Program {
+            builtins: Vec::new(),
+            prime: bigint_str!(
+                b"3618502788666131213697322783095070105623107215331596699973092056135872020481"
+            ),
+            data: Vec::new(),
+            constants: HashMap::new(),
+            main: None,
+            hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
+            identifiers: HashMap::new(),
+        };
+
+        let mut cairo_runner = CairoRunner::new(&program).unwrap();
+        let mut vm = vm!();
+
+        cairo_runner.accessed_addresses =
+            Some([(0, 0).into(), (0, 2).into()].into_iter().collect());
+        vm.builtin_runners = Vec::new();
+        vm.segments.segment_used_sizes = Some(vec![4]);
+        assert_eq!(cairo_runner.get_memory_holes(&vm), Ok(2));
+    }
+
+    #[test]
+    fn get_memory_holes_empty_accesses() {
+        let program = Program {
+            builtins: Vec::new(),
+            prime: bigint_str!(
+                b"3618502788666131213697322783095070105623107215331596699973092056135872020481"
+            ),
+            data: Vec::new(),
+            constants: HashMap::new(),
+            main: None,
+            hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
+            identifiers: HashMap::new(),
+        };
+
+        let mut cairo_runner = CairoRunner::new(&program).unwrap();
+        let mut vm = vm!();
+
+        cairo_runner.accessed_addresses = Some(HashSet::new());
+        vm.builtin_runners = vec![{
+            let mut builtin_runner = OutputBuiltinRunner::new();
+            builtin_runner.initialize_segments(&mut vm.segments, &mut vm.memory);
+
+            ("output".to_string(), Box::new(builtin_runner))
+        }];
+        vm.segments.segment_used_sizes = Some(vec![4]);
+        assert_eq!(cairo_runner.get_memory_holes(&vm), Ok(0));
+    }
+
+    #[test]
+    fn get_memory_holes() {
+        let program = Program {
+            builtins: Vec::new(),
+            prime: bigint_str!(
+                b"3618502788666131213697322783095070105623107215331596699973092056135872020481"
+            ),
+            data: Vec::new(),
+            constants: HashMap::new(),
+            main: None,
+            hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
+            identifiers: HashMap::new(),
+        };
+
+        let mut cairo_runner = CairoRunner::new(&program).unwrap();
+        let mut vm = vm!();
+
+        cairo_runner.accessed_addresses =
+            Some([(1, 0).into(), (1, 2).into()].into_iter().collect());
+        vm.builtin_runners = vec![{
+            let mut builtin_runner = OutputBuiltinRunner::new();
+            builtin_runner.initialize_segments(&mut vm.segments, &mut vm.memory);
+
+            ("output".to_string(), Box::new(builtin_runner))
+        }];
+        vm.segments.segment_used_sizes = Some(vec![4, 4]);
+        assert_eq!(cairo_runner.get_memory_holes(&vm), Ok(2));
     }
 }

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -307,11 +307,10 @@ impl CairoRunner {
             .as_ref()
             .ok_or(MemoryError::MissingAccessedAddresses)?;
 
-        let mut builtin_accessed_addresses = vm
-            .builtin_runners
-            .iter()
-            .flat_map(|(_, x)| x.get_memory_accesses(self).into_iter())
-            .collect::<HashSet<_>>();
+        let mut builtin_accessed_addresses = HashSet::new();
+        for (_, builtin_runner) in &vm.builtin_runners {
+            builtin_accessed_addresses.extend(builtin_runner.get_memory_accesses(vm)?.into_iter());
+        }
 
         builtin_accessed_addresses.extend(accessed_addresses.iter().cloned());
         vm.segments.get_memory_holes(&builtin_accessed_addresses)


### PR DESCRIPTION
# Implement `BuiltinRunner::get_memory_accesses()`

## Description

Implementation of the method `get_memory_accesses()` for the implementors of the trait `BuiltinRunner`.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
