### PR TITLE
Fix nom parser to output the entire cairo type string

### DIFF
--- a/src/serde/deserialize_utils.rs
+++ b/src/serde/deserialize_utils.rs
@@ -159,10 +159,7 @@ pub fn parse_value(input: &str) -> IResult<&str, ValueAddress> {
         opt(offset),
     ))(input)?;
 
-    let (_, (_, type_)) = tuple((
-        take_till(|c: char| c.is_alphanumeric()),
-        take_till(|c: char| c == '*'),
-    ))(second_arg)?;
+    let (_, (_, type_)) = tuple((tag(", "), take_till(|c: char| c == '*')))(second_arg)?;
 
     // check if there was any register and offset to be parsed
     let (inner_deref, reg, offs1) = if let Some((inner_deref, reg, offs1)) = inner_deref {
@@ -375,7 +372,7 @@ mod tests {
 
     #[test]
     fn parse_value_with_inner_deref_and_offset2() {
-        let value = "[cast([ap] + 1, felt*)]";
+        let value = "[cast([ap] + 1, __main__.felt*)]";
         let parsed = parse_value(value);
 
         assert_eq!(
@@ -389,7 +386,7 @@ mod tests {
                     immediate: None,
                     dereference: true,
                     inner_dereference: true,
-                    value_type: "felt".to_string(),
+                    value_type: "__main__.felt".to_string(),
                 }
             ))
         );


### PR DESCRIPTION
This PR fixes the nom parsing to get the complete name of the Cairo type from the compiled program.
An example of this:
The struct `LoopLocals` from the `pow` module, appears in the compiled Cairo program as
```
"__main__.pow.LoopLocals*"
```

The cairo type that was being parsed from that was
```
"main__.pow.LoopLocals"
```

This was due to the `c.is_alphanumeric()` method call in the parser. Since the first `__` are not alphanumeric, they were not being captured.

With this change, the `pow` test from `cairo-rs-py` should run
