### PR TITLE
feat: make BuiltinHintProcessor Sync by requiring HintFunc to be so

### DIFF
--- a/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -83,12 +83,13 @@ impl HintProcessorData {
 pub struct HintFunc(
     pub  Box<
         dyn Fn(
-            &mut VirtualMachine,
-            &mut ExecutionScopes,
-            &HashMap<String, HintReference>,
-            &ApTracking,
-            &HashMap<String, BigInt>,
-        ) -> Result<(), VirtualMachineError>,
+                &mut VirtualMachine,
+                &mut ExecutionScopes,
+                &HashMap<String, HintReference>,
+                &ApTracking,
+                &HashMap<String, BigInt>,
+            ) -> Result<(), VirtualMachineError>
+            + Sync,
     >,
 );
 pub struct BuiltinHintProcessor {


### PR DESCRIPTION
I want to run multiple `cairo_run` in parallel, with the same hint executor.
To do so it has to be Sync, so the functions boxed into HintFunc must be Sync too.