### PR TITLE
feat: enable the skip_instruction_exectution for hints

### DIFF
--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -469,9 +469,12 @@ impl VirtualMachine {
     }
 
     pub fn step_instruction(&mut self) -> Result<(), VirtualMachineError> {
-        let instruction = self.decode_current_instruction()?;
-        self.run_instruction(instruction)?;
-        self.skip_instruction_execution = false;
+        if !self.skip_instruction_execution {
+            let instruction = self.decode_current_instruction()?;
+            self.run_instruction(instruction)?;
+        } else {
+            self.skip_instruction_execution = false;
+        }
         Ok(())
     }
 
@@ -800,6 +803,10 @@ impl VirtualMachine {
     }
     pub fn disable_trace(&mut self) {
         self.trace = None
+    }
+
+    pub fn skip_next_instruction_execution(&mut self) {
+        self.skip_instruction_execution = true;
     }
 
     #[doc(hidden)]


### PR DESCRIPTION
the feature making hints able to disable next instruction executions was disabled