### PR TITLE
feat: remove unnecessary Result in Relocatable.add signature

### DIFF
--- a/src/hint_processor/builtin_hint_processor/cairo_keccak/keccak_hints.rs
+++ b/src/hint_processor/builtin_hint_processor/cairo_keccak/keccak_hints.rs
@@ -11,6 +11,7 @@ use num_bigint::BigInt;
 use num_traits::ToPrimitive;
 use std::borrow::Cow;
 use std::collections::HashMap;
+use std::ops::Add;
 
 // Constants in package "starkware.cairo.common.cairo_keccak.keccak".
 const BYTES_IN_WORD: &str = "starkware.cairo.common.cairo_keccak.keccak.BYTES_IN_WORD";
@@ -47,7 +48,7 @@ pub fn keccak_write_args(
     vm.write_arg(&inputs_ptr, &low_args.to_vec())
         .map_err(VirtualMachineError::MemoryError)?;
 
-    vm.write_arg(&inputs_ptr.add(2)?, &high_args.to_vec())
+    vm.write_arg(&inputs_ptr.add(2), &high_args.to_vec())
         .map_err(VirtualMachineError::MemoryError)?;
 
     Ok(())

--- a/src/types/relocatable.rs
+++ b/src/types/relocatable.rs
@@ -128,11 +128,6 @@ impl Relocatable {
         Ok(relocatable!(self.segment_index, new_offset))
     }
 
-    pub fn add(&self, other: usize) -> Result<Self, VirtualMachineError> {
-        let new_offset = self.offset + other;
-        Ok(relocatable!(self.segment_index, new_offset))
-    }
-
     ///Adds a bigint to self, then performs mod prime
     pub fn add_int_mod(
         &self,


### PR DESCRIPTION
method was never failing