### PR TITLE
Regex hint processor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ark-ff"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,6 +156,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "parse-hyperlinks",
+ "regex",
  "rusty-hook",
  "serde",
  "serde_bytes",
@@ -867,6 +877,8 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ generic-array = "0.14.6"
 # https://github.com/Geal/nom/issues/1253
 keccak = "0.1.2"
 parse-hyperlinks = { path = "./deps/parse-hyperlinks" }
+regex = "1.6.0"
 
 [dev-dependencies.rusty-hook]
 version = "0.11"

--- a/src/hint_processor/mod.rs
+++ b/src/hint_processor/mod.rs
@@ -1,3 +1,4 @@
 pub mod builtin_hint_processor;
 pub mod hint_processor_definition;
 pub mod hint_processor_utils;
+pub mod regex_hint_processor;

--- a/src/hint_processor/regex_hint_processor/mod.rs
+++ b/src/hint_processor/regex_hint_processor/mod.rs
@@ -1,0 +1,86 @@
+use regex::Regex;
+use std::any::Any;
+use std::collections::HashMap;
+
+use crate::{
+    any_box,
+    serde::deserialize_program::ApTracking,
+    types::exec_scope::ExecutionScopes,
+    vm::{errors::vm_errors::VirtualMachineError, vm_core::VirtualMachine},
+};
+
+use super::hint_processor_definition::HintProcessor;
+
+pub struct HintFunc(
+    pub  Box<
+        dyn Fn(
+            &mut VirtualMachine,
+            &mut ExecutionScopes,
+            Vec<String>,
+        ) -> Result<(), VirtualMachineError>,
+    >,
+);
+
+pub struct HintProcessorData {
+    pub code: String,
+}
+
+pub struct RegexHintProcessor {
+    hints: HashMap<String, HintFunc>,
+}
+
+impl RegexHintProcessor {
+    pub fn new() -> Self {
+        Self {
+            hints: HashMap::new(),
+        }
+    }
+
+    pub fn add_hint(&mut self, hint_code_regex: String, func: HintFunc) {
+        self.hints.insert(hint_code_regex, func);
+    }
+}
+
+impl HintProcessor for RegexHintProcessor {
+    fn compile_hint(
+        &self,
+        hint_code: &str,
+        _ap_tracking: &ApTracking,
+        _reference_ids: &HashMap<String, usize>,
+        _references: &HashMap<usize, super::hint_processor_definition::HintReference>,
+    ) -> Result<Box<dyn std::any::Any>, VirtualMachineError> {
+        Ok(any_box!(HintProcessorData {
+            code: hint_code.to_string()
+        }))
+    }
+
+    fn execute_hint(
+        &self,
+        vm: &mut crate::vm::vm_core::VirtualMachine,
+        exec_scopes: &mut crate::types::exec_scope::ExecutionScopes,
+        hint_data: &Box<dyn std::any::Any>,
+        _constants: &std::collections::HashMap<String, num_bigint::BigInt>,
+    ) -> Result<(), VirtualMachineError> {
+        let hint_data = hint_data
+            .downcast_ref::<HintProcessorData>()
+            .ok_or(VirtualMachineError::WrongHintData)?;
+
+        for hint_regex_string in self.hints.keys() {
+            let hint_regex = Regex::new(hint_regex_string.as_str())
+                .map_err(|_| VirtualMachineError::WrongHintData)?;
+            if hint_regex.is_match(&hint_data.code) {
+                for captures in hint_regex.captures_iter(&hint_data.code) {
+                    let args: Vec<String> = captures
+                        .iter()
+                        .map(|x| x.unwrap().as_str().to_string())
+                        .collect();
+                    match self.hints.get(hint_regex_string) {
+                        Some(func) => return func.0(vm, exec_scopes, args),
+                        None => {}
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/hint_processor/regex_hint_processor/mod.rs
+++ b/src/hint_processor/regex_hint_processor/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+mod tests;
 use regex::Regex;
 use std::any::Any;
 use std::collections::HashMap;
@@ -59,7 +61,7 @@ impl HintProcessor for RegexHintProcessor {
         vm: &mut crate::vm::vm_core::VirtualMachine,
         exec_scopes: &mut crate::types::exec_scope::ExecutionScopes,
         hint_data: &Box<dyn std::any::Any>,
-        _constants: &std::collections::HashMap<String, num_bigint::BigInt>,
+        _constants: &HashMap<String, num_bigint::BigInt>,
     ) -> Result<(), VirtualMachineError> {
         let hint_data = hint_data
             .downcast_ref::<HintProcessorData>()
@@ -72,6 +74,7 @@ impl HintProcessor for RegexHintProcessor {
                 for captures in hint_regex.captures_iter(&hint_data.code) {
                     let args: Vec<String> = captures
                         .iter()
+                        .skip(1) // skip the first capture, which is the whole match
                         .map(|x| x.unwrap().as_str().to_string())
                         .collect();
                     match self.hints.get(hint_regex_string) {

--- a/src/hint_processor/regex_hint_processor/mod.rs
+++ b/src/hint_processor/regex_hint_processor/mod.rs
@@ -13,6 +13,7 @@ use crate::{
 
 use super::hint_processor_definition::HintProcessor;
 
+#[allow(clippy::type_complexity)]
 pub struct HintFunc(
     pub  Box<
         dyn Fn(
@@ -32,10 +33,8 @@ pub struct RegexHintProcessor {
 }
 
 impl RegexHintProcessor {
-    pub fn new() -> Self {
-        Self {
-            hints: HashMap::new(),
-        }
+    pub fn new(hints: HashMap<String, HintFunc>) -> Self {
+        Self { hints }
     }
 
     pub fn add_hint(&mut self, hint_code_regex: String, func: HintFunc) {
@@ -85,5 +84,11 @@ impl HintProcessor for RegexHintProcessor {
             }
         }
         Ok(())
+    }
+}
+
+impl Default for RegexHintProcessor {
+    fn default() -> Self {
+        Self::new(HashMap::new())
     }
 }

--- a/src/hint_processor/regex_hint_processor/tests.rs
+++ b/src/hint_processor/regex_hint_processor/tests.rs
@@ -1,0 +1,53 @@
+use std::collections::HashMap;
+
+use crate::{
+    hint_processor::regex_hint_processor::HintFunc,
+    types::exec_scope::ExecutionScopes,
+    vm::{errors::vm_errors::VirtualMachineError, vm_core::VirtualMachine},
+};
+
+#[deny(unused_imports)]
+use super::HintProcessor;
+use super::RegexHintProcessor;
+use regex::Regex;
+
+const REGEX: &str = r#"expect_revert\('([\w ]+)'\)"#;
+const MY_HINT_CODE: &str = "expect_revert('This should revert')";
+
+#[test]
+fn test_hint_regex() {
+    let regex = Regex::new(REGEX).unwrap();
+    assert!(regex.is_match(MY_HINT_CODE));
+}
+
+#[test]
+fn test_custom_regex_hints() {
+    let mut hint_processor = RegexHintProcessor::new();
+    fn hint_func(
+        _vm: &mut VirtualMachine,
+        _exec_scopes: &mut ExecutionScopes,
+        args: Vec<String>,
+    ) -> Result<(), VirtualMachineError> {
+        assert_eq!(args[0], "This should revert");
+        Ok(())
+    }
+    hint_processor.add_hint(REGEX.to_string(), HintFunc(Box::new(hint_func)));
+
+    let hint_data = hint_processor
+        .compile_hint(
+            MY_HINT_CODE,
+            &Default::default(),
+            &Default::default(),
+            &Default::default(),
+        )
+        .unwrap();
+
+    hint_processor
+        .execute_hint(
+            &mut VirtualMachine::new(Default::default(), true),
+            &mut ExecutionScopes::new(),
+            &hint_data,
+            &HashMap::new(),
+        )
+        .unwrap();
+}

--- a/src/hint_processor/regex_hint_processor/tests.rs
+++ b/src/hint_processor/regex_hint_processor/tests.rs
@@ -22,7 +22,7 @@ fn test_hint_regex() {
 
 #[test]
 fn test_custom_regex_hints() {
-    let mut hint_processor = RegexHintProcessor::new();
+    let mut hint_processor = RegexHintProcessor::default();
     fn hint_func(
         _vm: &mut VirtualMachine,
         _exec_scopes: &mut ExecutionScopes,


### PR DESCRIPTION
# Regex hint processer

## Description

Linked to #523.

Implements a `RegexHintProcessor`, which only holds custom hints. The hints match the code based on a regex.

This processor does not have any builtin, using it can be done in conjonction with the `BuiltinHintProcessor` with a composite pattern for example. This is left to the user project of the vm.

## Checklist
- [x] Linked to Github Issue
- [x] Unit tests added
- [x] Integration tests added.
