### PR TITLE
Make execution scopes methods generic

### DIFF
--- a/src/hint_processor/builtin_hint_processor/find_element_hint.rs
+++ b/src/hint_processor/builtin_hint_processor/find_element_hint.rs
@@ -26,7 +26,7 @@ pub fn find_element(
     let elm_size_bigint = get_integer_from_var_name("elm_size", vm, ids_data, ap_tracking)?;
     let n_elms = get_integer_from_var_name("n_elms", vm, ids_data, ap_tracking)?;
     let array_start = get_ptr_from_var_name("array_ptr", vm, ids_data, ap_tracking)?;
-    let find_element_index = exec_scopes.get_int("find_element_index").ok();
+    let find_element_index = exec_scopes.get::<BigInt>("find_element_index").ok();
     let elm_size = elm_size_bigint
         .to_usize()
         .ok_or_else(|| VirtualMachineError::ValueOutOfRange(elm_size_bigint.as_ref().clone()))?;
@@ -89,7 +89,7 @@ pub fn search_sorted_lower(
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), VirtualMachineError> {
-    let find_element_max_size = exec_scopes.get_int("find_element_max_size");
+    let find_element_max_size = exec_scopes.get::<BigInt>("find_element_max_size");
     let n_elms = get_integer_from_var_name("n_elms", vm, ids_data, ap_tracking)?;
     let rel_array_ptr = get_relocatable_from_var_name("array_ptr", vm, ids_data, ap_tracking)?;
     let elm_size = get_integer_from_var_name("elm_size", vm, ids_data, ap_tracking)?;

--- a/src/hint_processor/builtin_hint_processor/find_element_hint.rs
+++ b/src/hint_processor/builtin_hint_processor/find_element_hint.rs
@@ -57,7 +57,7 @@ pub fn find_element(
             return Err(VirtualMachineError::ValueOutOfRange(n_elms.into_owned()));
         }
 
-        if let Ok(find_element_max_size) = exec_scopes.get_int_ref("find_element_max_size") {
+        if let Ok(find_element_max_size) = exec_scopes.get_ref::<BigInt>("find_element_max_size") {
             if n_elms.as_ref() > find_element_max_size {
                 return Err(VirtualMachineError::FindElemMaxSize(
                     find_element_max_size.clone(),

--- a/src/hint_processor/builtin_hint_processor/keccak_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/keccak_utils.rs
@@ -50,7 +50,7 @@ pub fn unsafe_keccak(
 ) -> Result<(), VirtualMachineError> {
     let length = get_integer_from_var_name("length", vm, ids_data, ap_tracking)?;
 
-    if let Ok(keccak_max_size) = exec_scopes.get_int("__keccak_max_size") {
+    if let Ok(keccak_max_size) = exec_scopes.get::<BigInt>("__keccak_max_size") {
         if length.as_ref() > &keccak_max_size {
             return Err(VirtualMachineError::KeccakMaxSize(
                 length.into_owned(),

--- a/src/hint_processor/builtin_hint_processor/memcpy_hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/memcpy_hint_utils.rs
@@ -60,7 +60,7 @@ pub fn memcpy_continue_copying(
     ap_tracking: &ApTracking,
 ) -> Result<(), VirtualMachineError> {
     // get `n` variable from vm scope
-    let n = exec_scopes.get_int_ref("n")?;
+    let n = exec_scopes.get_ref::<BigInt>("n")?;
     // this variable will hold the value of `n - 1`
     let new_n = n - 1_i32;
     // if it is positive, insert 1 in the address of `continue_copying`

--- a/src/hint_processor/builtin_hint_processor/memset_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/memset_utils.rs
@@ -41,7 +41,7 @@ pub fn memset_continue_loop(
     ap_tracking: &ApTracking,
 ) -> Result<(), VirtualMachineError> {
     // get `n` variable from vm scope
-    let n = exec_scopes.get_int_ref("n")?;
+    let n = exec_scopes.get_ref::<BigInt>("n")?;
     // this variable will hold the value of `n - 1`
     let new_n = n - 1_i32;
     // if `new_n` is positive, insert 1 in the address of `continue_loop`

--- a/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
@@ -30,7 +30,7 @@ pub fn nondet_bigint3(
     constants: &HashMap<String, BigInt>,
 ) -> Result<(), VirtualMachineError> {
     let res_reloc = get_relocatable_from_var_name("res", vm, ids_data, ap_tracking)?;
-    let value = exec_scopes.get_int_ref("value")?;
+    let value = exec_scopes.get_ref::<BigInt>("value")?;
     let arg: Vec<MaybeRelocatable> = split(value, constants)?
         .into_iter()
         .map(MaybeRelocatable::from)

--- a/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
@@ -261,10 +261,10 @@ pub fn ec_double_assign_new_y(
 
     //Get variables from vm scope
     let (slope, x, new_x, y) = (
-        exec_scopes.get_int("slope")?,
-        exec_scopes.get_int("x")?,
-        exec_scopes.get_int("new_x")?,
-        exec_scopes.get_int("y")?,
+        exec_scopes.get::<BigInt>("slope")?,
+        exec_scopes.get::<BigInt>("x")?,
+        exec_scopes.get::<BigInt>("new_x")?,
+        exec_scopes.get::<BigInt>("y")?,
     );
 
     let value = (slope * (x - new_x) - y).mod_floor(&secp_p);
@@ -380,10 +380,10 @@ pub fn fast_ec_add_assign_new_y(
 
     //Get variables from vm scope
     let (slope, x0, new_x, y0) = (
-        exec_scopes.get_int("slope")?,
-        exec_scopes.get_int("x0")?,
-        exec_scopes.get_int("new_x")?,
-        exec_scopes.get_int("y0")?,
+        exec_scopes.get::<BigInt>("slope")?,
+        exec_scopes.get::<BigInt>("x0")?,
+        exec_scopes.get::<BigInt>("new_x")?,
+        exec_scopes.get::<BigInt>("y0")?,
     );
     let value = (slope * (x0 - new_x) - y0).mod_floor(&secp_p);
     exec_scopes.insert_value("value", value.clone());
@@ -462,7 +462,7 @@ mod tests {
         );
         //Check 'value' is defined in the vm scope
         assert_eq!(
-            exec_scopes.get_int("value"),
+            exec_scopes.get::<BigInt>("value"),
             Ok(bigint_str!(
                 b"115792089237316195423569751828682367333329274433232027476421668138471189901786"
             ))

--- a/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
@@ -112,7 +112,7 @@ pub fn is_zero_nondet(
     exec_scopes: &mut ExecutionScopes,
 ) -> Result<(), VirtualMachineError> {
     //Get `x` variable from vm scope
-    let x = exec_scopes.get_int("x")?;
+    let x = exec_scopes.get::<BigInt>("x")?;
 
     let value = bigint!(x.is_zero() as usize);
     insert_value_into_ap(vm, value)
@@ -137,7 +137,7 @@ pub fn is_zero_assign_scope_variables(
             .ok_or(VirtualMachineError::MissingConstant(SECP_REM))?;
 
     //Get `x` variable from vm scope
-    let x = exec_scopes.get_int("x")?;
+    let x = exec_scopes.get::<BigInt>("x")?;
 
     let value = div_mod(&bigint!(1), &x, &secp_p);
     exec_scopes.insert_value("value", value.clone());
@@ -329,7 +329,7 @@ mod tests {
 
         //Check 'value' is defined in the vm scope
         assert_eq!(
-            exec_scopes.get_int("value"),
+            exec_scopes.get::<BigInt>("value"),
             Ok(bigint_str!(
                 b"59863107065205964761754162760883789350782881856141750"
             ))
@@ -610,7 +610,7 @@ mod tests {
 
         //Check 'value' is defined in the vm scope
         assert_eq!(
-            exec_scopes.get_int("value"),
+            exec_scopes.get::<BigInt>("value"),
             Ok(bigint_str!(
                 b"19429627790501903254364315669614485084365347064625983303617500144471999752609"
             ))
@@ -618,7 +618,7 @@ mod tests {
 
         //Check 'x_inv' is defined in the vm scope
         assert_eq!(
-            exec_scopes.get_int("x_inv"),
+            exec_scopes.get::<BigInt>("x_inv"),
             Ok(bigint_str!(
                 b"19429627790501903254364315669614485084365347064625983303617500144471999752609"
             ))

--- a/src/hint_processor/builtin_hint_processor/secp/signature.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/signature.rs
@@ -64,9 +64,9 @@ pub fn div_mod_n_safe_div(
     exec_scopes: &mut ExecutionScopes,
     constants: &HashMap<String, BigInt>,
 ) -> Result<(), VirtualMachineError> {
-    let a = exec_scopes.get_int_ref("a")?;
-    let b = exec_scopes.get_int_ref("b")?;
-    let res = exec_scopes.get_int_ref("res")?;
+    let a = exec_scopes.get_ref::<BigInt>("a")?;
+    let b = exec_scopes.get_ref::<BigInt>("b")?;
+    let res = exec_scopes.get_ref::<BigInt>("res")?;
 
     let n = {
         let base = constants

--- a/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
@@ -73,7 +73,7 @@ pub fn squash_dict_inner_skip_loop(
     ap_tracking: &ApTracking,
 ) -> Result<(), VirtualMachineError> {
     //Check that current_access_indices is in scope
-    let current_access_indices = exec_scopes.get_list("current_access_indices")?;
+    let current_access_indices = exec_scopes.get_list_ref::<BigInt>("current_access_indices")?;
     //Main Logic
     let should_skip_loop = if current_access_indices.is_empty() {
         bigint!(1)
@@ -102,7 +102,8 @@ pub fn squash_dict_inner_check_access_index(
 ) -> Result<(), VirtualMachineError> {
     //Check that current_access_indices and current_access_index are in scope
     let current_access_index = exec_scopes.get_int("current_access_index")?;
-    let current_access_indices = exec_scopes.get_mut_list_ref("current_access_indices")?;
+    let current_access_indices =
+        exec_scopes.get_mut_list_ref::<BigInt>("current_access_indices")?;
     //Main Logic
     let new_access_index = current_access_indices
         .pop()
@@ -127,7 +128,7 @@ pub fn squash_dict_inner_continue_loop(
     //Get addr for ids variables
     let loop_temps_addr = get_relocatable_from_var_name("loop_temps", vm, ids_data, ap_tracking)?;
     //Check that current_access_indices is in scope
-    let current_access_indices = exec_scopes.get_list_ref("current_access_indices")?;
+    let current_access_indices = exec_scopes.get_list_ref::<BigInt>("current_access_indices")?;
     //Main Logic
     let should_continue = if current_access_indices.is_empty() {
         bigint!(0)
@@ -145,7 +146,7 @@ pub fn squash_dict_inner_len_assert(
     exec_scopes: &mut ExecutionScopes,
 ) -> Result<(), VirtualMachineError> {
     //Check that current_access_indices is in scope
-    let current_access_indices = exec_scopes.get_list_ref("current_access_indices")?;
+    let current_access_indices = exec_scopes.get_list_ref::<BigInt>("current_access_indices")?;
     if !current_access_indices.is_empty() {
         return Err(VirtualMachineError::CurrentAccessIndicesNotEmpty);
     }
@@ -182,7 +183,7 @@ pub fn squash_dict_inner_assert_len_keys(
     exec_scopes: &mut ExecutionScopes,
 ) -> Result<(), VirtualMachineError> {
     //Check that current_access_indices is in scope
-    let keys = exec_scopes.get_list_ref("keys")?;
+    let keys = exec_scopes.get_list_ref::<BigInt>("keys")?;
     if !keys.is_empty() {
         return Err(VirtualMachineError::KeysNotEmpty);
     };
@@ -199,7 +200,7 @@ pub fn squash_dict_inner_next_key(
     ap_tracking: &ApTracking,
 ) -> Result<(), VirtualMachineError> {
     //Check that current_access_indices is in scope
-    let keys = exec_scopes.get_mut_list_ref("keys")?;
+    let keys = exec_scopes.get_mut_list_ref::<BigInt>("keys")?;
     let next_key = keys.pop().ok_or(VirtualMachineError::EmptyKeys)?;
     //Insert next_key into ids.next_keys
     insert_value_from_var_name("next_key", next_key.clone(), vm, ids_data, ap_tracking)?;
@@ -821,8 +822,8 @@ mod tests {
                 ("key", bigint!(1))
             ]
         );
-        let keys = exec_scopes.get_list("keys").unwrap();
-        assert_eq!(keys, vec![bigint!(2)]);
+        let keys = exec_scopes.get_list_ref::<BigInt>("keys").unwrap();
+        assert_eq!(*keys, vec![bigint!(2)]);
         //Check ids variables
         check_memory![vm.memory, ((1, 1), 0), ((1, 2), 1)];
     }

--- a/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
@@ -44,7 +44,7 @@ pub fn squash_dict_inner_first_iteration(
     ap_tracking: &ApTracking,
 ) -> Result<(), VirtualMachineError> {
     //Check that access_indices and key are in scope
-    let key = exec_scopes.get_int("key")?;
+    let key = exec_scopes.get::<BigInt>("key")?;
     let range_check_ptr = get_ptr_from_var_name("range_check_ptr", vm, ids_data, ap_tracking)?;
     let access_indices = get_access_indices(exec_scopes)?;
     //Get current_indices from access_indices
@@ -101,7 +101,7 @@ pub fn squash_dict_inner_check_access_index(
     ap_tracking: &ApTracking,
 ) -> Result<(), VirtualMachineError> {
     //Check that current_access_indices and current_access_index are in scope
-    let current_access_index = exec_scopes.get_int("current_access_index")?;
+    let current_access_index = exec_scopes.get::<BigInt>("current_access_index")?;
     let current_access_indices =
         exec_scopes.get_mut_list_ref::<BigInt>("current_access_indices")?;
     //Main Logic
@@ -160,7 +160,7 @@ pub fn squash_dict_inner_used_accesses_assert(
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), VirtualMachineError> {
-    let key = exec_scopes.get_int("key")?;
+    let key = exec_scopes.get::<BigInt>("key")?;
     let n_used_accesses = get_integer_from_var_name("n_used_accesses", vm, ids_data, ap_tracking)?;
     let access_indices = get_access_indices(exec_scopes)?;
     //Main Logic
@@ -247,7 +247,7 @@ pub fn squash_dict(
     if ptr_diff.mod_floor(&bigint!(DICT_ACCESS_SIZE)) != bigint!(0) {
         return Err(VirtualMachineError::PtrDiffNotDivisibleByDictAccessSize);
     }
-    let squash_dict_max_size = exec_scopes.get_int("__squash_dict_max_size");
+    let squash_dict_max_size = exec_scopes.get::<BigInt>("__squash_dict_max_size");
     if let Ok(max_size) = squash_dict_max_size {
         if n_accesses.as_ref() > &max_size {
             return Err(VirtualMachineError::SquashDictMaxSizeExceeded(

--- a/src/hint_processor/builtin_hint_processor/usort.rs
+++ b/src/hint_processor/builtin_hint_processor/usort.rs
@@ -107,7 +107,7 @@ pub fn verify_usort(
 pub fn verify_multiplicity_assert(
     exec_scopes: &mut ExecutionScopes,
 ) -> Result<(), VirtualMachineError> {
-    let positions_len = exec_scopes.get_listu64_ref("positions")?.len();
+    let positions_len = exec_scopes.get_list_ref::<u64>("positions")?.len();
     if positions_len == 0 {
         Ok(())
     } else {
@@ -122,7 +122,7 @@ pub fn verify_multiplicity_body(
     ap_tracking: &ApTracking,
 ) -> Result<(), VirtualMachineError> {
     let current_pos = exec_scopes
-        .get_mut_listu64_ref("positions")?
+        .get_mut_list_ref::<u64>("positions")?
         .pop()
         .ok_or(VirtualMachineError::CouldntPopPositions)?;
     let pos_diff = bigint!(current_pos) - exec_scopes.get_int("last_pos")?;

--- a/src/hint_processor/builtin_hint_processor/usort.rs
+++ b/src/hint_processor/builtin_hint_processor/usort.rs
@@ -95,7 +95,7 @@ pub fn verify_usort(
 ) -> Result<(), VirtualMachineError> {
     let value = get_integer_from_var_name("value", vm, ids_data, ap_tracking)?.clone();
     let mut positions = exec_scopes
-        .get_mut_dict_int_list_u64_ref("positions_dict")?
+        .get_mut_dict_ref::<BigInt, Vec<u64>>("positions_dict")?
         .remove(&value)
         .ok_or(VirtualMachineError::UnexpectedPositionsDictFail)?;
     positions.reverse();

--- a/src/hint_processor/builtin_hint_processor/usort.rs
+++ b/src/hint_processor/builtin_hint_processor/usort.rs
@@ -16,7 +16,7 @@ use num_traits::ToPrimitive;
 use std::{any::Any, collections::HashMap};
 
 pub fn usort_enter_scope(exec_scopes: &mut ExecutionScopes) -> Result<(), VirtualMachineError> {
-    if let Ok(usort_max_size) = exec_scopes.get_int("usort_max_size") {
+    if let Ok(usort_max_size) = exec_scopes.get::<BigInt>("usort_max_size") {
         let boxed_max_size: Box<dyn Any> = Box::new(usort_max_size);
         exec_scopes.enter_scope(HashMap::from([(
             "usort_max_size".to_string(),
@@ -125,7 +125,7 @@ pub fn verify_multiplicity_body(
         .get_mut_list_ref::<u64>("positions")?
         .pop()
         .ok_or(VirtualMachineError::CouldntPopPositions)?;
-    let pos_diff = bigint!(current_pos) - exec_scopes.get_int("last_pos")?;
+    let pos_diff = bigint!(current_pos) - exec_scopes.get::<BigInt>("last_pos")?;
     insert_value_from_var_name("next_item_index", pos_diff, vm, ids_data, ap_tracking)?;
     exec_scopes.insert_value("last_pos", bigint!(current_pos + 1));
     Ok(())

--- a/src/hint_processor/builtin_hint_processor/usort.rs
+++ b/src/hint_processor/builtin_hint_processor/usort.rs
@@ -35,7 +35,7 @@ pub fn usort_body(
     ap_tracking: &ApTracking,
 ) -> Result<(), VirtualMachineError> {
     let input_ptr = get_ptr_from_var_name("input", vm, ids_data, ap_tracking)?;
-    let usort_max_size = exec_scopes.get_u64("usort_max_size");
+    let usort_max_size = exec_scopes.get::<u64>("usort_max_size");
     let input_len = get_integer_from_var_name("input_len", vm, ids_data, ap_tracking)?;
     let input_len_u64 = input_len
         .to_u64()

--- a/src/types/exec_scope.rs
+++ b/src/types/exec_scope.rs
@@ -121,10 +121,10 @@ impl ExecutionScopes {
     }
 
     ///Returns the value in the current execution scope that matches the name and is of type List
-    pub fn get_list(&self, name: &str) -> Result<Vec<BigInt>, VirtualMachineError> {
-        let mut val: Option<Vec<BigInt>> = None;
+    pub fn get_list<T: Any + Clone>(&self, name: &str) -> Result<Vec<T>, VirtualMachineError> {
+        let mut val: Option<Vec<T>> = None;
         if let Some(variable) = self.get_local_variables()?.get(name) {
-            if let Some(list) = variable.downcast_ref::<Vec<BigInt>>() {
+            if let Some(list) = variable.downcast_ref::<Vec<T>>() {
                 val = Some(list.clone());
             }
         }
@@ -132,10 +132,10 @@ impl ExecutionScopes {
     }
 
     ///Returns a reference to the value in the current execution scope that matches the name and is of type List
-    pub fn get_list_ref(&self, name: &str) -> Result<&Vec<BigInt>, VirtualMachineError> {
-        let mut val: Option<&Vec<BigInt>> = None;
+    pub fn get_list_ref<T: Any>(&self, name: &str) -> Result<&Vec<T>, VirtualMachineError> {
+        let mut val: Option<&Vec<T>> = None;
         if let Some(variable) = self.get_local_variables()?.get(name) {
-            if let Some(list) = variable.downcast_ref::<Vec<BigInt>>() {
+            if let Some(list) = variable.downcast_ref::<Vec<T>>() {
                 val = Some(list);
             }
         }
@@ -143,13 +143,13 @@ impl ExecutionScopes {
     }
 
     ///Returns a mutable reference to the value in the current execution scope that matches the name and is of type List
-    pub fn get_mut_list_ref(
+    pub fn get_mut_list_ref<T: Any>(
         &mut self,
         name: &str,
-    ) -> Result<&mut Vec<BigInt>, VirtualMachineError> {
-        let mut val: Option<&mut Vec<BigInt>> = None;
+    ) -> Result<&mut Vec<T>, VirtualMachineError> {
+        let mut val: Option<&mut Vec<T>> = None;
         if let Some(variable) = self.get_local_variables_mut()?.get_mut(name) {
-            if let Some(list) = variable.downcast_mut::<Vec<BigInt>>() {
+            if let Some(list) = variable.downcast_mut::<Vec<T>>() {
                 val = Some(list);
             }
         }

--- a/src/types/exec_scope.rs
+++ b/src/types/exec_scope.rs
@@ -156,39 +156,6 @@ impl ExecutionScopes {
         val.ok_or_else(|| VirtualMachineError::VariableNotInScopeError(name.to_string()))
     }
 
-    ///Returns the value in the current execution scope that matches the name and is of type U64
-    pub fn get_u64(&self, name: &str) -> Result<u64, VirtualMachineError> {
-        let mut val: Option<u64> = None;
-        if let Some(variable) = self.get_local_variables()?.get(name) {
-            if let Some(num) = variable.downcast_ref::<u64>() {
-                val = Some(*num);
-            }
-        }
-        val.ok_or_else(|| VirtualMachineError::VariableNotInScopeError(name.to_string()))
-    }
-
-    ///Returns a reference to the value in the current execution scope that matches the name and is of type U64
-    pub fn get_u64_ref(&self, name: &str) -> Result<&u64, VirtualMachineError> {
-        let mut val: Option<&u64> = None;
-        if let Some(variable) = self.get_local_variables()?.get(name) {
-            if let Some(num) = variable.downcast_ref::<u64>() {
-                val = Some(num);
-            }
-        }
-        val.ok_or_else(|| VirtualMachineError::VariableNotInScopeError(name.to_string()))
-    }
-
-    ///Returns a mutable reference to the value in the current execution scope that matches the name and is of type U64
-    pub fn get_mut_u64_ref(&mut self, name: &str) -> Result<&mut u64, VirtualMachineError> {
-        let mut val: Option<&mut u64> = None;
-        if let Some(variable) = self.get_local_variables_mut()?.get_mut(name) {
-            if let Some(num) = variable.downcast_mut::<u64>() {
-                val = Some(num);
-            }
-        }
-        val.ok_or_else(|| VirtualMachineError::VariableNotInScopeError(name.to_string()))
-    }
-
     ///Returns the value in the dict manager
     pub fn get_dict_manager(&self) -> Result<Rc<RefCell<DictManager>>, VirtualMachineError> {
         let mut val: Option<Rc<RefCell<DictManager>>> = None;
@@ -424,10 +391,10 @@ mod tests {
 
         scopes.insert_box("list_u64", list_u64);
 
-        assert_eq!(scopes.get_listu64("list_u64"), Ok(vec![20_u64, 18_u64]));
+        assert_eq!(scopes.get_list::<u64>("list_u64"), Ok(vec![20_u64, 18_u64]));
 
         assert_eq!(
-            scopes.get_listu64("no_variable"),
+            scopes.get_list::<u64>("no_variable"),
             Err(VirtualMachineError::VariableNotInScopeError(
                 "no_variable".to_string()
             ))
@@ -442,17 +409,17 @@ mod tests {
 
         scopes.assign_or_update_variable("u64", u64);
 
-        assert_eq!(scopes.get_u64_ref("u64"), Ok(&9_u64));
-        assert_eq!(scopes.get_mut_u64_ref("u64"), Ok(&mut 9_u64));
+        assert_eq!(scopes.get_ref::<u64>("u64"), Ok(&9_u64));
+        assert_eq!(scopes.get_mut_ref::<u64>("u64"), Ok(&mut 9_u64));
 
         assert_eq!(
-            scopes.get_mut_u64_ref("no_variable"),
+            scopes.get_mut_ref::<u64>("no_variable"),
             Err(VirtualMachineError::VariableNotInScopeError(
                 "no_variable".to_string()
             ))
         );
         assert_eq!(
-            scopes.get_u64_ref("no_variable"),
+            scopes.get_ref::<u64>("no_variable"),
             Err(VirtualMachineError::VariableNotInScopeError(
                 "no_variable".to_string()
             ))
@@ -466,7 +433,7 @@ mod tests {
         let mut scopes = ExecutionScopes::new();
         scopes.assign_or_update_variable("bigint", bigint);
 
-        assert_eq!(scopes.get_mut_int_ref("bigint"), Ok(&mut bigint!(12)));
+        assert_eq!(scopes.get_mut_ref::<BigInt>("bigint"), Ok(&mut bigint!(12)));
     }
 
     #[test]

--- a/src/types/exec_scope.rs
+++ b/src/types/exec_scope.rs
@@ -76,10 +76,10 @@ impl ExecutionScopes {
     }
 
     ///Returns a reference to the value in the current execution scope that matches the name and is of the given generic type
-    pub fn get_int_ref(&self, name: &str) -> Result<&BigInt, VirtualMachineError> {
-        let mut val: Option<&BigInt> = None;
+    pub fn get_ref<T: Any>(&self, name: &str) -> Result<&T, VirtualMachineError> {
+        let mut val: Option<&T> = None;
         if let Some(variable) = self.get_local_variables()?.get(name) {
-            if let Some(int) = variable.downcast_ref::<BigInt>() {
+            if let Some(int) = variable.downcast_ref::<T>() {
                 val = Some(int);
             }
         }

--- a/src/types/exec_scope.rs
+++ b/src/types/exec_scope.rs
@@ -87,10 +87,10 @@ impl ExecutionScopes {
     }
 
     ///Returns a mutable reference to the value in the current execution scope that matches the name and is of the given generic type
-    pub fn get_mut_int_ref(&mut self, name: &str) -> Result<&mut BigInt, VirtualMachineError> {
-        let mut val: Option<&mut BigInt> = None;
+    pub fn get_mut_ref<T: Any>(&mut self, name: &str) -> Result<&mut T, VirtualMachineError> {
+        let mut val: Option<&mut T> = None;
         if let Some(variable) = self.get_local_variables_mut()?.get_mut(name) {
-            if let Some(int) = variable.downcast_mut::<BigInt>() {
+            if let Some(int) = variable.downcast_mut::<T>() {
                 val = Some(int);
             }
         }

--- a/src/types/exec_scope.rs
+++ b/src/types/exec_scope.rs
@@ -156,43 +156,7 @@ impl ExecutionScopes {
         val.ok_or_else(|| VirtualMachineError::VariableNotInScopeError(name.to_string()))
     }
 
-    ///Returns the value in the current execution scope that matches the name and is of type ListU64
-    pub fn get_listu64(&self, name: &str) -> Result<Vec<u64>, VirtualMachineError> {
-        let mut val: Option<Vec<u64>> = None;
-        if let Some(variable) = self.get_local_variables()?.get(name) {
-            if let Some(list) = variable.downcast_ref::<Vec<u64>>() {
-                val = Some(list.clone());
-            }
-        }
-        val.ok_or_else(|| VirtualMachineError::VariableNotInScopeError(name.to_string()))
-    }
-
-    ///Returns a reference to the value in the current execution scope that matches the name and is of type ListU64
-    pub fn get_listu64_ref(&self, name: &str) -> Result<&Vec<u64>, VirtualMachineError> {
-        let mut val: Option<&Vec<u64>> = None;
-        if let Some(variable) = self.get_local_variables()?.get(name) {
-            if let Some(list) = variable.downcast_ref::<Vec<u64>>() {
-                val = Some(list);
-            }
-        }
-        val.ok_or_else(|| VirtualMachineError::VariableNotInScopeError(name.to_string()))
-    }
-
-    ///Returns a mutable reference to the value in the current execution scope that matches the name and is of type ListU64
-    pub fn get_mut_listu64_ref(
-        &mut self,
-        name: &str,
-    ) -> Result<&mut Vec<u64>, VirtualMachineError> {
-        let mut val: Option<&mut Vec<u64>> = None;
-        if let Some(variable) = self.get_local_variables_mut()?.get_mut(name) {
-            if let Some(list) = variable.downcast_mut::<Vec<u64>>() {
-                val = Some(list);
-            }
-        }
-        val.ok_or_else(|| VirtualMachineError::VariableNotInScopeError(name.to_string()))
-    }
-
-    ///Returns the value in the current execution scope that matches the name and is of type ListU64
+    ///Returns the value in the current execution scope that matches the name and is of type U64
     pub fn get_u64(&self, name: &str) -> Result<u64, VirtualMachineError> {
         let mut val: Option<u64> = None;
         if let Some(variable) = self.get_local_variables()?.get(name) {

--- a/src/types/exec_scope.rs
+++ b/src/types/exec_scope.rs
@@ -3,7 +3,6 @@ use crate::{
     hint_processor::builtin_hint_processor::dict_manager::DictManager,
     vm::errors::{exec_scope_errors::ExecScopeError, vm_errors::VirtualMachineError},
 };
-use num_bigint::BigInt;
 use std::{any::Any, cell::RefCell, collections::HashMap, rc::Rc};
 
 pub struct ExecutionScopes {
@@ -167,14 +166,14 @@ impl ExecutionScopes {
         val.ok_or_else(|| VirtualMachineError::VariableNotInScopeError("dict_manager".to_string()))
     }
 
-    ///Returns a mutable reference to the value in the current execution scope that matches the name and is of type DictBigIntListU64
-    pub fn get_mut_dict_int_list_u64_ref(
+    ///Returns a mutable reference to the value in the current execution scope that matches the name and is of the given type
+    pub fn get_mut_dict_ref<K: Any, V: Any>(
         &mut self,
         name: &str,
-    ) -> Result<&mut HashMap<BigInt, Vec<u64>>, VirtualMachineError> {
-        let mut val: Option<&mut HashMap<BigInt, Vec<u64>>> = None;
+    ) -> Result<&mut HashMap<K, V>, VirtualMachineError> {
+        let mut val: Option<&mut HashMap<K, V>> = None;
         if let Some(variable) = self.get_local_variables_mut()?.get_mut(name) {
-            if let Some(dict) = variable.downcast_mut::<HashMap<BigInt, Vec<u64>>>() {
+            if let Some(dict) = variable.downcast_mut::<HashMap<K, V>>() {
                 val = Some(dict);
             }
         }

--- a/src/types/exec_scope.rs
+++ b/src/types/exec_scope.rs
@@ -64,12 +64,34 @@ impl ExecutionScopes {
         }
     }
 
-    ///Returns the value in the current execution scope that matches the name and is of type BigInt
-    pub fn get_int(&self, name: &str) -> Result<BigInt, VirtualMachineError> {
-        let mut val: Option<BigInt> = None;
+    ///Returns the value in the current execution scope that matches the name and is of the given generic type
+    pub fn get<T: Any + Clone>(&self, name: &str) -> Result<T, VirtualMachineError> {
+        let mut val: Option<T> = None;
+        if let Some(variable) = self.get_local_variables()?.get(name) {
+            if let Some(int) = variable.downcast_ref::<T>() {
+                val = Some(int.clone());
+            }
+        }
+        val.ok_or_else(|| VirtualMachineError::VariableNotInScopeError(name.to_string()))
+    }
+
+    ///Returns a reference to the value in the current execution scope that matches the name and is of the given generic type
+    pub fn get_int_ref(&self, name: &str) -> Result<&BigInt, VirtualMachineError> {
+        let mut val: Option<&BigInt> = None;
         if let Some(variable) = self.get_local_variables()?.get(name) {
             if let Some(int) = variable.downcast_ref::<BigInt>() {
-                val = Some(int.clone());
+                val = Some(int);
+            }
+        }
+        val.ok_or_else(|| VirtualMachineError::VariableNotInScopeError(name.to_string()))
+    }
+
+    ///Returns a mutable reference to the value in the current execution scope that matches the name and is of the given generic type
+    pub fn get_mut_int_ref(&mut self, name: &str) -> Result<&mut BigInt, VirtualMachineError> {
+        let mut val: Option<&mut BigInt> = None;
+        if let Some(variable) = self.get_local_variables_mut()?.get_mut(name) {
+            if let Some(int) = variable.downcast_mut::<BigInt>() {
+                val = Some(int);
             }
         }
         val.ok_or_else(|| VirtualMachineError::VariableNotInScopeError(name.to_string()))
@@ -96,28 +118,6 @@ impl ExecutionScopes {
         Err(VirtualMachineError::VariableNotInScopeError(
             name.to_string(),
         ))
-    }
-
-    ///Returns a reference to the value in the current execution scope that matches the name and is of type BigInt
-    pub fn get_int_ref(&self, name: &str) -> Result<&BigInt, VirtualMachineError> {
-        let mut val: Option<&BigInt> = None;
-        if let Some(variable) = self.get_local_variables()?.get(name) {
-            if let Some(int) = variable.downcast_ref::<BigInt>() {
-                val = Some(int);
-            }
-        }
-        val.ok_or_else(|| VirtualMachineError::VariableNotInScopeError(name.to_string()))
-    }
-
-    ///Returns a mutable reference to the value in the current execution scope that matches the name and is of type BigInt
-    pub fn get_mut_int_ref(&mut self, name: &str) -> Result<&mut BigInt, VirtualMachineError> {
-        let mut val: Option<&mut BigInt> = None;
-        if let Some(variable) = self.get_local_variables_mut()?.get_mut(name) {
-            if let Some(int) = variable.downcast_mut::<BigInt>() {
-                val = Some(int);
-            }
-        }
-        val.ok_or_else(|| VirtualMachineError::VariableNotInScopeError(name.to_string()))
     }
 
     ///Returns the value in the current execution scope that matches the name and is of type List


### PR DESCRIPTION
All those getters are reimplemented multiple times, for each type.
That a perfect usecase for Rust generic types