### PR TITLE
add get_return_values method

### DIFF
--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -733,13 +733,15 @@ impl VirtualMachine {
     pub fn get_return_values(
         &self,
         n_ret: usize,
-    ) -> Result<Vec<Option<Cow<MaybeRelocatable>>>, MemoryError> {
+    ) -> Result<Vec<Option<MaybeRelocatable>>, MemoryError> {
         let addr = &self
             .run_context
             .get_ap()
             .sub(n_ret)
             .map_err(|_| MemoryError::NumOutOfBounds)?;
-        self.memory.get_range(&addr.into(), n_ret)
+        self.memory.get_range(&addr.into(), n_ret).iter()
+            .map(|x| x.map(|val| val.to_owned()))
+            .collect()
     }
 
     ///Gets n elements from memory starting from addr (n being size)

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -739,11 +739,13 @@ impl VirtualMachine {
             .get_ap()
             .sub(n_ret)
             .map_err(|_| MemoryError::NumOutOfBounds)?;
-        self.memory
-            .get_range(&addr.into(), n_ret)
-            .iter()
-            .map(|x| x.map(|val| val.to_owned()))
-            .collect()
+        let values: Vec<Option<MaybeRelocatable>> = self
+            .memory
+            .get_range(&addr.into(), n_ret)?
+            .into_iter()
+            .map(|x| x.map(|val| val.into_owned()))
+            .collect();
+        Ok(values)
     }
 
     ///Gets n elements from memory starting from addr (n being size)
@@ -3120,10 +3122,10 @@ mod tests {
         vm.set_ap(4);
         vm.memory = memory![((1, 0), 1), ((1, 1), 2), ((1, 2), 3), ((1, 3), 4)];
         let expected = vec![
-            Some(Cow::Owned(MaybeRelocatable::Int(1u32.into()))),
-            Some(Cow::Owned(MaybeRelocatable::Int(2u32.into()))),
-            Some(Cow::Owned(MaybeRelocatable::Int(3u32.into()))),
-            Some(Cow::Owned(MaybeRelocatable::Int(4u32.into()))),
+            Some(MaybeRelocatable::Int(1u32.into())),
+            Some(MaybeRelocatable::Int(2u32.into())),
+            Some(MaybeRelocatable::Int(3u32.into())),
+            Some(MaybeRelocatable::Int(4u32.into())),
         ];
         assert_eq!(vm.get_return_values(4).unwrap(), expected);
     }

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -3124,6 +3124,16 @@ mod tests {
         assert_eq!(vm.get_return_values(4).unwrap(), expected);
     }
 
+    #[test]
+    fn get_return_values_fails_when_ap_is_0() {
+        let mut vm = vm!();
+        vm.memory = memory![((1, 0), 1), ((1, 1), 2), ((1, 2), 3), ((1, 3), 4)];
+        assert!(matches!(
+            vm.get_return_values(3),
+            Err(MemoryError::NumOutOfBounds)
+        ));
+    }
+
     /*
     Program used for this test:
     from starkware.cairo.common.alloc import alloc

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -739,7 +739,9 @@ impl VirtualMachine {
             .get_ap()
             .sub(n_ret)
             .map_err(|_| MemoryError::NumOutOfBounds)?;
-        self.memory.get_range(&addr.into(), n_ret).iter()
+        self.memory
+            .get_range(&addr.into(), n_ret)
+            .iter()
             .map(|x| x.map(|val| val.to_owned()))
             .collect()
     }

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -3114,16 +3114,14 @@ mod tests {
     fn can_get_return_values() {
         let mut vm = vm!();
         vm.set_ap(4);
-        // vm.builtin_runners
-        //     .push((String::from("pedersen"), builtin.into()));
-        vm.memory = memory![
-            ((0, 0), 1),
-            ((0, 1), 2),
-            ((0, 2), 3),
-            ((0, 3), 4),
-            ((1, 0), 2)
+        vm.memory = memory![((1, 0), 1), ((1, 1), 2), ((1, 2), 3), ((1, 3), 4)];
+        let expected = vec![
+            Some(Cow::Owned(MaybeRelocatable::Int(1u32.into()))),
+            Some(Cow::Owned(MaybeRelocatable::Int(2u32.into()))),
+            Some(Cow::Owned(MaybeRelocatable::Int(3u32.into()))),
+            Some(Cow::Owned(MaybeRelocatable::Int(4u32.into()))),
         ];
-        assert_eq!(vm.get_return_values(2).unwrap(), vec![None, None]);
+        assert_eq!(vm.get_return_values(4).unwrap(), expected);
     }
 
     /*

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -729,6 +729,19 @@ impl VirtualMachine {
             .write_arg(&mut self.memory, ptr, arg, Some(&self.prime))
     }
 
+    ///Gets `n_ret` return values from memory
+    pub fn get_return_values(
+        &self,
+        n_ret: usize,
+    ) -> Result<Vec<Option<Cow<MaybeRelocatable>>>, MemoryError> {
+        let addr = &self
+            .run_context
+            .get_ap()
+            .sub(n_ret)
+            .map_err(|_| MemoryError::NumOutOfBounds)?;
+        self.memory.get_range(&addr.into(), n_ret)
+    }
+
     ///Gets n elements from memory starting from addr (n being size)
     pub fn get_range(
         &self,

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -3110,6 +3110,22 @@ mod tests {
         assert_eq!(vm.verify_auto_deductions(), Ok(()));
     }
 
+    #[test]
+    fn can_get_return_values() {
+        let mut vm = vm!();
+        vm.set_ap(4);
+        // vm.builtin_runners
+        //     .push((String::from("pedersen"), builtin.into()));
+        vm.memory = memory![
+            ((0, 0), 1),
+            ((0, 1), 2),
+            ((0, 2), 3),
+            ((0, 3), 4),
+            ((1, 0), 2)
+        ];
+        assert_eq!(vm.get_return_values(2).unwrap(), vec![None, None]);
+    }
+
     /*
     Program used for this test:
     from starkware.cairo.common.alloc import alloc


### PR DESCRIPTION
# Add `get_return_values` to VirtualMachine

## Description

This PR adds the [`get_return_values`](https://github.com/starkware-libs/cairo-lang/blob/0ba3ff59c1c86f2a30adc8fd144eaacb22c48ce9/src/starkware/cairo/common/cairo_function_runner.py#L267) method to VirtualMachine. This is needed since we need to export it to Python land because it is used [here](https://github.com/starkware-libs/cairo-lang/blob/55a26f4228dcff9c51d3d6bfd5e6638bafe63101/src/starkware/starknet/business_logic/utils.py#L50).

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
