### PR TITLE
separate bench workflows for not require write premission in PRs

### DIFF
--- a/.github/workflows/bench_pull_request.yml
+++ b/.github/workflows/bench_pull_request.yml
@@ -1,4 +1,4 @@
-name: benchmark 
+name: benchmark_pr 
 
 on:
   pull_request:

--- a/.github/workflows/bench_pull_request.yml
+++ b/.github/workflows/bench_pull_request.yml
@@ -1,14 +1,8 @@
 name: benchmark 
 
 on:
-  push:
-    branches: [ main ]
-
-permissions:
-  # deployments permission to deploy GitHub pages website
-  deployments: write
-  # contents permission to update benchmark contents in gh-pages branch
-  contents: write
+  pull_request:
+    branches: [ '*' ]
 
 jobs:
   build:
@@ -37,8 +31,6 @@ jobs:
         benchmark-data-dir-path: "."
         # Access token to deploy GitHub Pages branch
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        # Push and deploy GitHub pages branch automatically
-        auto-push: true
         alert-threshold: '130%'
         comment-on-alert: true
         alert-comment-cc-users: '@unbalancedparentheses'


### PR DESCRIPTION
# Separate PRs and merge bench workflows 

## Description

In order to not requiring write permissions when sending a pr, this pr separates the workflows.
Now the benchs will be uploaded only when pushing to main