### PR TITLE
Fix inconsistencies in BuiltinRunners::get_used_cells_and_allocated_sizes()

### DIFF
--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -15,8 +15,6 @@ use crate::vm::vm_core::VirtualMachine;
 use crate::vm::vm_memory::memory::Memory;
 use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
 
-use super::BuiltinRunner;
-
 pub struct BitwiseBuiltinRunner {
     _ratio: u32,
     pub base: isize,
@@ -119,8 +117,18 @@ impl BitwiseBuiltinRunner {
         ("bitwise", (self.base, self.stop_ptr))
     }
 
+    pub fn get_used_cells(&self, vm: &VirtualMachine) -> Result<usize, MemoryError> {
+        let base = self.base();
+        vm.segments
+            .get_segment_used_size(
+                base.try_into()
+                    .map_err(|_| MemoryError::AddressInTemporarySegment(base))?,
+            )
+            .ok_or(MemoryError::MissingSegmentUsedSizes)
+    }
+
     pub fn get_used_cells_and_allocated_size(
-        self,
+        &self,
         vm: &VirtualMachine,
     ) -> Result<(usize, usize), MemoryError> {
         let ratio = self._ratio as usize;
@@ -129,8 +137,7 @@ impl BitwiseBuiltinRunner {
         if vm.current_step < min_step {
             Err(MemoryError::InsufficientAllocatedCells)
         } else {
-            let builtin = BuiltinRunner::Bitwise(self);
-            let used = builtin.get_used_cells(vm)?;
+            let used = self.get_used_cells(vm)?;
             let size = (cells_per_instance
                 * safe_div(&bigint!(vm.current_step), &bigint!(ratio))
                     .map_err(|_| MemoryError::InsufficientAllocatedCells)?)
@@ -368,8 +375,7 @@ mod tests {
 
     #[test]
     fn get_used_cells_missing_segment_used_sizes() {
-        let builtin =
-            BuiltinRunner::Bitwise(BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default()));
+        let builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default());
         let vm = vm!();
 
         assert_eq!(
@@ -380,8 +386,7 @@ mod tests {
 
     #[test]
     fn get_used_cells_empty() {
-        let builtin =
-            BuiltinRunner::Bitwise(BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default()));
+        let builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default());
         let mut vm = vm!();
 
         vm.segments.segment_used_sizes = Some(vec![0]);
@@ -390,8 +395,7 @@ mod tests {
 
     #[test]
     fn get_used_cells() {
-        let builtin =
-            BuiltinRunner::Bitwise(BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default()));
+        let builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default());
         let mut vm = vm!();
 
         vm.segments.segment_used_sizes = Some(vec![4]);

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -206,7 +206,7 @@ impl EcOpBuiltinRunner {
     pub fn get_used_cells_and_allocated_size(
         self,
         vm: &VirtualMachine,
-    ) -> Result<(usize, BigInt), MemoryError> {
+    ) -> Result<(usize, usize), MemoryError> {
         let ratio = self._ratio as usize;
         let cells_per_instance = self.cells_per_instance;
         let min_step = ratio * self.instances_per_component as usize;
@@ -215,9 +215,11 @@ impl EcOpBuiltinRunner {
         } else {
             let builtin = BuiltinRunner::EcOp(self);
             let used = builtin.get_used_cells(vm)?;
-            let size = cells_per_instance
+            let size = (cells_per_instance
                 * safe_div(&bigint!(vm.current_step), &bigint!(ratio))
-                    .map_err(|_| MemoryError::InsufficientAllocatedCells)?;
+                    .map_err(|_| MemoryError::InsufficientAllocatedCells)?)
+            .to_usize()
+            .ok_or(MemoryError::InsufficientAllocatedCells)?;
             Ok((used, size))
         }
     }
@@ -290,7 +292,7 @@ mod tests {
 
         assert_eq!(
             builtin.get_used_cells_and_allocated_size(&vm),
-            Ok((0_usize, bigint!(7)))
+            Ok((0_usize, 7))
         );
     }
 

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -124,7 +124,7 @@ impl HashBuiltinRunner {
     pub fn get_used_cells_and_allocated_size(
         self,
         vm: &VirtualMachine,
-    ) -> Result<(usize, BigInt), MemoryError> {
+    ) -> Result<(usize, usize), MemoryError> {
         let ratio = self._ratio as usize;
         let cells_per_instance = self.cells_per_instance;
         let min_step = ratio * self.instances_per_component as usize;
@@ -133,9 +133,11 @@ impl HashBuiltinRunner {
         } else {
             let builtin = BuiltinRunner::Hash(self);
             let used = builtin.get_used_cells(vm)?;
-            let size = cells_per_instance
+            let size = (cells_per_instance
                 * safe_div(&bigint!(vm.current_step), &bigint!(ratio))
-                    .map_err(|_| MemoryError::InsufficientAllocatedCells)?;
+                    .map_err(|_| MemoryError::InsufficientAllocatedCells)?)
+            .to_usize()
+            .ok_or(MemoryError::InsufficientAllocatedCells)?;
             Ok((used, size))
         }
     }
@@ -208,7 +210,7 @@ mod tests {
 
         assert_eq!(
             builtin.get_used_cells_and_allocated_size(&vm),
-            Ok((0_usize, bigint!(3)))
+            Ok((0_usize, 3))
         );
     }
 

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -15,8 +15,6 @@ use crate::vm::vm_core::VirtualMachine;
 use crate::vm::vm_memory::memory::Memory;
 use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
 
-use super::BuiltinRunner;
-
 pub struct HashBuiltinRunner {
     pub base: isize,
     _ratio: u32,
@@ -121,8 +119,18 @@ impl HashBuiltinRunner {
         ("pedersen", (self.base, self.stop_ptr))
     }
 
+    pub fn get_used_cells(&self, vm: &VirtualMachine) -> Result<usize, MemoryError> {
+        let base = self.base();
+        vm.segments
+            .get_segment_used_size(
+                base.try_into()
+                    .map_err(|_| MemoryError::AddressInTemporarySegment(base))?,
+            )
+            .ok_or(MemoryError::MissingSegmentUsedSizes)
+    }
+
     pub fn get_used_cells_and_allocated_size(
-        self,
+        &self,
         vm: &VirtualMachine,
     ) -> Result<(usize, usize), MemoryError> {
         let ratio = self._ratio as usize;
@@ -131,8 +139,7 @@ impl HashBuiltinRunner {
         if vm.current_step < min_step {
             Err(MemoryError::InsufficientAllocatedCells)
         } else {
-            let builtin = BuiltinRunner::Hash(self);
-            let used = builtin.get_used_cells(vm)?;
+            let used = self.get_used_cells(vm)?;
             let size = (cells_per_instance
                 * safe_div(&bigint!(vm.current_step), &bigint!(ratio))
                     .map_err(|_| MemoryError::InsufficientAllocatedCells)?)
@@ -353,7 +360,7 @@ mod tests {
 
     #[test]
     fn get_used_cells_missing_segment_used_sizes() {
-        let builtin = BuiltinRunner::Hash(HashBuiltinRunner::new(256));
+        let builtin = HashBuiltinRunner::new(256);
         let vm = vm!();
 
         assert_eq!(
@@ -364,7 +371,7 @@ mod tests {
 
     #[test]
     fn get_used_cells_empty() {
-        let builtin = BuiltinRunner::Hash(HashBuiltinRunner::new(256));
+        let builtin = HashBuiltinRunner::new(256);
         let mut vm = vm!();
 
         vm.segments.segment_used_sizes = Some(vec![0]);
@@ -373,7 +380,7 @@ mod tests {
 
     #[test]
     fn get_used_cells() {
-        let builtin = BuiltinRunner::Hash(HashBuiltinRunner::new(256));
+        let builtin = HashBuiltinRunner::new(256);
         let mut vm = vm!();
 
         vm.segments.segment_used_sizes = Some(vec![4]);

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -262,6 +262,21 @@ impl BuiltinRunner {
 
         Ok(())
     }
+
+    pub fn get_used_cells_and_allocated_size(
+        &self,
+        vm: &VirtualMachine,
+    ) -> Result<(usize, usize), MemoryError> {
+        match self {
+            BuiltinRunner::Bitwise(ref bitwise) => bitwise.get_used_cells_and_allocated_size(vm),
+            BuiltinRunner::EcOp(ref ec) => ec.get_used_cells_and_allocated_size(vm),
+            BuiltinRunner::Hash(ref hash) => hash.get_used_cells_and_allocated_size(vm),
+            BuiltinRunner::Output(ref output) => output.get_used_cells_and_allocated_size(vm),
+            BuiltinRunner::RangeCheck(ref range_check) => {
+                range_check.get_used_cells_and_allocated_size(vm)
+            }
+        }
+    }
 }
 
 impl From<BitwiseBuiltinRunner> for BuiltinRunner {

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -133,13 +133,13 @@ impl BuiltinRunner {
     }
 
     pub fn get_used_cells(&self, vm: &VirtualMachine) -> Result<usize, MemoryError> {
-        let base = self.base();
-        vm.segments
-            .get_segment_used_size(
-                base.try_into()
-                    .map_err(|_| MemoryError::AddressInTemporarySegment(base))?,
-            )
-            .ok_or(MemoryError::MissingSegmentUsedSizes)
+        match self {
+            BuiltinRunner::Bitwise(ref bitwise) => bitwise.get_used_cells(vm),
+            BuiltinRunner::EcOp(ref ec) => ec.get_used_cells(vm),
+            BuiltinRunner::Hash(ref hash) => hash.get_used_cells(vm),
+            BuiltinRunner::Output(ref output) => output.get_used_cells(vm),
+            BuiltinRunner::RangeCheck(ref range_check) => range_check.get_used_cells(vm),
+        }
     }
 
     pub fn get_used_instances(&self, vm: &VirtualMachine) -> Result<usize, MemoryError> {

--- a/src/vm/runners/builtin_runner/output.rs
+++ b/src/vm/runners/builtin_runner/output.rs
@@ -1,6 +1,3 @@
-use num_bigint::BigInt;
-
-use crate::bigint;
 use crate::types::relocatable::{MaybeRelocatable, Relocatable};
 use crate::vm::errors::memory_errors::MemoryError;
 use crate::vm::errors::runner_errors::RunnerError;
@@ -62,10 +59,10 @@ impl OutputBuiltinRunner {
     pub fn get_used_cells_and_allocated_size(
         self,
         vm: &VirtualMachine,
-    ) -> Result<(usize, BigInt), MemoryError> {
+    ) -> Result<(usize, usize), MemoryError> {
         let builtin = BuiltinRunner::Output(self);
         let used = builtin.get_used_cells(vm)?;
-        Ok((used, bigint!(used)))
+        Ok((used, used))
     }
 }
 
@@ -97,7 +94,7 @@ mod tests {
 
         assert_eq!(
             builtin.get_used_cells_and_allocated_size(&vm),
-            Ok((0_usize, bigint!(0)))
+            Ok((0_usize, 0))
         );
     }
 

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -15,8 +15,6 @@ use crate::vm::vm_core::VirtualMachine;
 use crate::vm::vm_memory::memory::{Memory, ValidationRule};
 use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
 
-use super::BuiltinRunner;
-
 pub struct RangeCheckBuiltinRunner {
     ratio: u32,
     base: isize,
@@ -111,8 +109,18 @@ impl RangeCheckBuiltinRunner {
         ("range_check", (self.base, self.stop_ptr))
     }
 
+    pub fn get_used_cells(&self, vm: &VirtualMachine) -> Result<usize, MemoryError> {
+        let base = self.base();
+        vm.segments
+            .get_segment_used_size(
+                base.try_into()
+                    .map_err(|_| MemoryError::AddressInTemporarySegment(base))?,
+            )
+            .ok_or(MemoryError::MissingSegmentUsedSizes)
+    }
+
     pub fn get_used_cells_and_allocated_size(
-        self,
+        &self,
         vm: &VirtualMachine,
     ) -> Result<(usize, usize), MemoryError> {
         let ratio = self.ratio as usize;
@@ -121,8 +129,7 @@ impl RangeCheckBuiltinRunner {
         if vm.current_step < min_step {
             Err(MemoryError::InsufficientAllocatedCells)
         } else {
-            let builtin = BuiltinRunner::RangeCheck(self);
-            let used = builtin.get_used_cells(vm)?;
+            let used = self.get_used_cells(vm)?;
             let size = (cells_per_instance
                 * safe_div(&bigint!(vm.current_step), &bigint!(ratio))
                     .map_err(|_| MemoryError::InsufficientAllocatedCells)?)


### PR DESCRIPTION
- Fix inconsistencies on the return type of each builtin runner's implementation of `get_used_cells_and_allocated_sizes()`
- Implement `get_used_cells_and_allocated_sizes()` for the enum` BuiltinRunner`
- Change `self` argument to `&self`
- Implement `get_used_cells` for each enum variant in order to achieve above goal