### PR TITLE
CairoRunner::check_memory_usage()

### DIFF
--- a/src/vm/errors/vm_errors.rs
+++ b/src/vm/errors/vm_errors.rs
@@ -162,6 +162,8 @@ pub enum VirtualMachineError {
     BigintToU64Fail,
     #[error("Couldn't convert BigInt to u32")]
     BigintToU32Fail,
+    #[error("Couldn't convert usize to u32")]
+    UsizeToU32Fail,
     #[error("usort() can only be used with input_len<={0}. Got: input_len={1}.")]
     UsortOutOfRange(u64, BigInt),
     #[error("unexpected usort fail: positions_dict or key value pair not found")]

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -446,7 +446,7 @@ mod tests {
             identifiers: HashMap::new(),
         };
 
-        let mut cairo_runner = CairoRunner::new(&program, &"all".to_string()).unwrap();
+        let mut cairo_runner = cairo_runner!(program);
 
         let hint_processor = BuiltinHintProcessor::new_empty();
 
@@ -496,7 +496,7 @@ mod tests {
             identifiers: HashMap::new(),
         };
 
-        let mut cairo_runner = CairoRunner::new(&program, &"all".to_string()).unwrap();
+        let mut cairo_runner = cairo_runner!(program);
 
         let hint_processor = BuiltinHintProcessor::new_empty();
 

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -780,10 +780,8 @@ impl CairoRunner {
 
         let builtins_memory_units = builtins_memory_units as u32;
 
-        let vm_current_step_u32 = match ToPrimitive::to_u32(&vm.current_step) {
-            Some(current_step_u32) => Ok(current_step_u32),
-            None => Err(VirtualMachineError::UsizeToU32Fail),
-        }?;
+        let vm_current_step_u32 =
+            ToPrimitive::to_u32(&vm.current_step).ok_or(VirtualMachineError::UsizeToU32Fail)?;
 
         // Out of the memory units available per step, a fraction is used for public memory, and
         // four are used for the instruction.

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -29,7 +29,6 @@ use crate::{
 use num_bigint::BigInt;
 use std::{
     any::Any,
-    array::try_from_fn,
     collections::{HashMap, HashSet},
     io,
 };

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -764,7 +764,7 @@ impl CairoRunner {
     }
 
     // Checks that there are enough trace cells to fill the entire memory range.
-    pub fn check_memory_usage(&self, vm: &VirtualMachine) -> Result<(), MemoryError> {
+    pub fn check_memory_usage(&self, vm: &VirtualMachine) -> Result<(), VirtualMachineError> {
         let instance = &self.layout;
 
         let builtins_memory_units: usize = vm
@@ -785,8 +785,8 @@ impl CairoRunner {
         let public_memory_units = safe_div(
             &bigint!(total_memory_units),
             &bigint!(instance._public_memory_fraction),
-        )
-        .unwrap();
+        )?;
+
         let instruction_memory_units = 4 * vm.current_step as u32;
         let unused_memory_units = total_memory_units
             - (public_memory_units + instruction_memory_units + builtins_memory_units);
@@ -883,7 +883,9 @@ mod tests {
         vm.segments.segment_used_sizes = Some(vec![4, 12]);
         assert_eq!(
             cairo_runner.check_memory_usage(&vm),
-            Err(MemoryError::InsufficientAllocatedCells)
+            Err(VirtualMachineError::MemoryError(
+                MemoryError::InsufficientAllocatedCells
+            ))
         );
     }
 


### PR DESCRIPTION
# CairoRunner::check_memory_usage()

## Description

Add check_memory_usage method for Cairo Runner, and get_allocated_memory_units for Builtins.

