### PR TITLE
Change unnecessary `&x.to_string()` into `x`.

### DIFF
--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -213,7 +213,7 @@ mod tests {
             identifiers: HashMap::new(),
         };
 
-        let mut cairo_runner = CairoRunner::new(&program, &"all".to_string()).unwrap();
+        let mut cairo_runner = CairoRunner::new(&program, "all").unwrap();
 
         let hint_processor = BuiltinHintProcessor::new_empty();
 
@@ -263,7 +263,7 @@ mod tests {
             identifiers: HashMap::new(),
         };
 
-        let mut cairo_runner = CairoRunner::new(&program, &"all".to_string()).unwrap();
+        let mut cairo_runner = CairoRunner::new(&program, "all").unwrap();
 
         let hint_processor = BuiltinHintProcessor::new_empty();
 

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -278,7 +278,7 @@ mod tests {
             },
             identifiers: HashMap::new(),
         };
-        let mut cairo_runner = CairoRunner::new(&program, &"all".to_string()).unwrap();
+        let mut cairo_runner = CairoRunner::new(&program, "all").unwrap();
 
         let hint_processor = BuiltinHintProcessor::new_empty();
 
@@ -331,7 +331,7 @@ mod tests {
             identifiers: HashMap::new(),
         };
 
-        let mut cairo_runner = CairoRunner::new(&program, &"all".to_string()).unwrap();
+        let mut cairo_runner = CairoRunner::new(&program, "all").unwrap();
 
         let hint_processor = BuiltinHintProcessor::new_empty();
 

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -196,7 +196,7 @@ mod tests {
             identifiers: HashMap::new(),
         };
 
-        let mut cairo_runner = CairoRunner::new(&program, &"all".to_string()).unwrap();
+        let mut cairo_runner = CairoRunner::new(&program, "all").unwrap();
 
         let hint_processor = BuiltinHintProcessor::new_empty();
 

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -211,7 +211,7 @@ mod tests {
             identifiers: HashMap::new(),
         };
 
-        let mut cairo_runner = CairoRunner::new(&program, &"all".to_string()).unwrap();
+        let mut cairo_runner = CairoRunner::new(&program, "all").unwrap();
 
         let hint_processor = BuiltinHintProcessor::new_empty();
 

--- a/wasm_example/src/lib.rs
+++ b/wasm_example/src/lib.rs
@@ -31,7 +31,7 @@ pub fn run_cairo_program() -> Result<(), JsError> {
     const PROGRAM_JSON: &str = include_str!("./array_sum.json");
 
     let program = Program::from_reader(Cursor::new(PROGRAM_JSON), "main")?;
-    let mut runner = CairoRunner::new(&program, "all".to_string())?;
+    let mut runner = CairoRunner::new(&program, "all")?;
     let mut vm = VirtualMachine::new(program.prime, false);
     let hint_processor = BuiltinHintProcessor::new_empty();
 


### PR DESCRIPTION
# Change unnecessary `&x.to_string()` into `x`

## Description

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
