### PR TITLE
Implement `CairoRunner::check_diluted_check_usage()`

### DIFF
--- a/src/math_utils.rs
+++ b/src/math_utils.rs
@@ -40,6 +40,21 @@ pub fn safe_div(x: &BigInt, y: &BigInt) -> Result<BigInt, VirtualMachineError> {
     Ok(q)
 }
 
+/// Performs integer division between x and y; fails if x is not divisible by y.
+pub fn safe_div_usize(x: usize, y: usize) -> Result<usize, VirtualMachineError> {
+    if y.is_zero() {
+        return Err(VirtualMachineError::DividedByZero);
+    }
+
+    let (q, r) = x.div_mod_floor(&y);
+
+    if !r.is_zero() {
+        return Err(VirtualMachineError::SafeDivFailUsize(x, y));
+    }
+
+    Ok(q)
+}
+
 /// Returns the lift of the given field element, val, as an integer in the range (-prime/2, prime/2).
 pub fn as_int(val: &BigInt, prime: &BigInt) -> BigInt {
     //n.shr(1) = n.div_floor(2)
@@ -227,6 +242,27 @@ mod tests {
         let x = bigint!(25);
         let y = bigint!(0);
         assert_eq!(safe_div(&x, &y), Err(VirtualMachineError::DividedByZero));
+    }
+
+    #[test]
+    fn compute_safe_div_usize() {
+        assert_eq!(safe_div_usize(26, 13), Ok(2));
+    }
+
+    #[test]
+    fn compute_safe_div_usize_non_divisor() {
+        assert_eq!(
+            safe_div_usize(25, 4),
+            Err(VirtualMachineError::SafeDivFailUsize(25, 4))
+        );
+    }
+
+    #[test]
+    fn compute_safe_div_usize_by_zero() {
+        assert_eq!(
+            safe_div_usize(25, 0),
+            Err(VirtualMachineError::DividedByZero)
+        );
     }
 
     #[test]

--- a/src/types/instance_definitions/diluted_pool_instance_def.rs
+++ b/src/types/instance_definitions/diluted_pool_instance_def.rs
@@ -1,24 +1,24 @@
 #[derive(Debug, PartialEq)]
 pub(crate) struct DilutedPoolInstanceDef {
-    pub(crate) _units_per_step: u32,
-    pub(crate) _spacing: u32,
-    pub(crate) _n_bits: u32,
+    pub(crate) units_per_step: u32,
+    pub(crate) spacing: u32,
+    pub(crate) n_bits: u32,
 }
 
 impl DilutedPoolInstanceDef {
     pub(crate) fn default() -> Self {
         DilutedPoolInstanceDef {
-            _units_per_step: 16,
-            _spacing: 4,
-            _n_bits: 16,
+            units_per_step: 16,
+            spacing: 4,
+            n_bits: 16,
         }
     }
 
-    pub(crate) fn new(_units_per_step: u32, _spacing: u32, _n_bits: u32) -> Self {
+    pub(crate) fn new(units_per_step: u32, spacing: u32, n_bits: u32) -> Self {
         DilutedPoolInstanceDef {
-            _units_per_step,
-            _spacing,
-            _n_bits,
+            units_per_step,
+            spacing,
+            n_bits,
         }
     }
 }
@@ -30,16 +30,16 @@ mod tests {
     #[test]
     fn test_default() {
         let diluted_pool = DilutedPoolInstanceDef::default();
-        assert_eq!(diluted_pool._units_per_step, 16);
-        assert_eq!(diluted_pool._spacing, 4);
-        assert_eq!(diluted_pool._n_bits, 16);
+        assert_eq!(diluted_pool.units_per_step, 16);
+        assert_eq!(diluted_pool.spacing, 4);
+        assert_eq!(diluted_pool.n_bits, 16);
     }
 
     #[test]
     fn test_new() {
         let diluted_pool = DilutedPoolInstanceDef::new(1, 1, 1);
-        assert_eq!(diluted_pool._units_per_step, 1);
-        assert_eq!(diluted_pool._spacing, 1);
-        assert_eq!(diluted_pool._n_bits, 1);
+        assert_eq!(diluted_pool.units_per_step, 1);
+        assert_eq!(diluted_pool.spacing, 1);
+        assert_eq!(diluted_pool.n_bits, 1);
     }
 }

--- a/src/types/layout.rs
+++ b/src/types/layout.rs
@@ -11,7 +11,7 @@ pub(crate) struct CairoLayout {
     pub(crate) builtins: BuiltinsInstanceDef,
     pub(crate) _public_memory_fraction: u32,
     pub(crate) _memory_units_per_step: u32,
-    pub(crate) _diluted_pool_instance_def: Option<DilutedPoolInstanceDef>,
+    pub(crate) diluted_pool_instance_def: Option<DilutedPoolInstanceDef>,
     pub(crate) _n_trace_colums: u32,
     pub(crate) _cpu_instance_def: CpuInstanceDef,
 }
@@ -25,7 +25,7 @@ impl CairoLayout {
             builtins: BuiltinsInstanceDef::plain(),
             _public_memory_fraction: 4,
             _memory_units_per_step: 8,
-            _diluted_pool_instance_def: None,
+            diluted_pool_instance_def: None,
             _n_trace_colums: 8,
             _cpu_instance_def: CpuInstanceDef::default(),
         }
@@ -39,7 +39,7 @@ impl CairoLayout {
             builtins: BuiltinsInstanceDef::small(),
             _public_memory_fraction: 4,
             _memory_units_per_step: 8,
-            _diluted_pool_instance_def: None,
+            diluted_pool_instance_def: None,
             _n_trace_colums: 25,
             _cpu_instance_def: CpuInstanceDef::default(),
         }
@@ -53,7 +53,7 @@ impl CairoLayout {
             builtins: BuiltinsInstanceDef::dex(),
             _public_memory_fraction: 4,
             _memory_units_per_step: 8,
-            _diluted_pool_instance_def: None,
+            diluted_pool_instance_def: None,
             _n_trace_colums: 22,
             _cpu_instance_def: CpuInstanceDef::default(),
         }
@@ -67,7 +67,7 @@ impl CairoLayout {
             builtins: BuiltinsInstanceDef::perpetual_with_bitwise(),
             _public_memory_fraction: 4,
             _memory_units_per_step: 8,
-            _diluted_pool_instance_def: Some(DilutedPoolInstanceDef::new(2, 4, 16)),
+            diluted_pool_instance_def: Some(DilutedPoolInstanceDef::new(2, 4, 16)),
             _n_trace_colums: 10,
             _cpu_instance_def: CpuInstanceDef::default(),
         }
@@ -81,7 +81,7 @@ impl CairoLayout {
             builtins: BuiltinsInstanceDef::bitwise(),
             _public_memory_fraction: 8,
             _memory_units_per_step: 8,
-            _diluted_pool_instance_def: Some(DilutedPoolInstanceDef::default()),
+            diluted_pool_instance_def: Some(DilutedPoolInstanceDef::default()),
             _n_trace_colums: 10,
             _cpu_instance_def: CpuInstanceDef::default(),
         }
@@ -95,7 +95,7 @@ impl CairoLayout {
             builtins: BuiltinsInstanceDef::recursive(),
             _public_memory_fraction: 8,
             _memory_units_per_step: 8,
-            _diluted_pool_instance_def: Some(DilutedPoolInstanceDef::default()),
+            diluted_pool_instance_def: Some(DilutedPoolInstanceDef::default()),
             _n_trace_colums: 11,
             _cpu_instance_def: CpuInstanceDef::default(),
         }
@@ -109,7 +109,7 @@ impl CairoLayout {
             builtins: BuiltinsInstanceDef::all(),
             _public_memory_fraction: 8,
             _memory_units_per_step: 8,
-            _diluted_pool_instance_def: Some(DilutedPoolInstanceDef::default()),
+            diluted_pool_instance_def: Some(DilutedPoolInstanceDef::default()),
             _n_trace_colums: 27,
             _cpu_instance_def: CpuInstanceDef::default(),
         }
@@ -130,7 +130,7 @@ mod tests {
         assert_eq!(layout.builtins, builtins);
         assert_eq!(layout._public_memory_fraction, 4);
         assert_eq!(layout._memory_units_per_step, 8);
-        assert_eq!(layout._diluted_pool_instance_def, None);
+        assert_eq!(layout.diluted_pool_instance_def, None);
         assert_eq!(layout._n_trace_colums, 8);
         assert_eq!(layout._cpu_instance_def, CpuInstanceDef::default());
     }
@@ -145,7 +145,7 @@ mod tests {
         assert_eq!(layout.builtins, builtins);
         assert_eq!(layout._public_memory_fraction, 4);
         assert_eq!(layout._memory_units_per_step, 8);
-        assert_eq!(layout._diluted_pool_instance_def, None);
+        assert_eq!(layout.diluted_pool_instance_def, None);
         assert_eq!(layout._n_trace_colums, 25);
         assert_eq!(layout._cpu_instance_def, CpuInstanceDef::default());
     }
@@ -160,7 +160,7 @@ mod tests {
         assert_eq!(layout.builtins, builtins);
         assert_eq!(layout._public_memory_fraction, 4);
         assert_eq!(layout._memory_units_per_step, 8);
-        assert_eq!(layout._diluted_pool_instance_def, None);
+        assert_eq!(layout.diluted_pool_instance_def, None);
         assert_eq!(layout._n_trace_colums, 22);
         assert_eq!(layout._cpu_instance_def, CpuInstanceDef::default());
     }
@@ -176,7 +176,7 @@ mod tests {
         assert_eq!(layout._public_memory_fraction, 4);
         assert_eq!(layout._memory_units_per_step, 8);
         assert_eq!(
-            layout._diluted_pool_instance_def,
+            layout.diluted_pool_instance_def,
             Some(DilutedPoolInstanceDef::new(2, 4, 16))
         );
         assert_eq!(layout._n_trace_colums, 10);
@@ -194,7 +194,7 @@ mod tests {
         assert_eq!(layout._public_memory_fraction, 8);
         assert_eq!(layout._memory_units_per_step, 8);
         assert_eq!(
-            layout._diluted_pool_instance_def,
+            layout.diluted_pool_instance_def,
             Some(DilutedPoolInstanceDef::default())
         );
         assert_eq!(layout._n_trace_colums, 10);
@@ -212,7 +212,7 @@ mod tests {
         assert_eq!(layout._public_memory_fraction, 8);
         assert_eq!(layout._memory_units_per_step, 8);
         assert_eq!(
-            layout._diluted_pool_instance_def,
+            layout.diluted_pool_instance_def,
             Some(DilutedPoolInstanceDef::default())
         );
         assert_eq!(layout._n_trace_colums, 11);
@@ -230,7 +230,7 @@ mod tests {
         assert_eq!(layout._public_memory_fraction, 8);
         assert_eq!(layout._memory_units_per_step, 8);
         assert_eq!(
-            layout._diluted_pool_instance_def,
+            layout.diluted_pool_instance_def,
             Some(DilutedPoolInstanceDef::default())
         );
         assert_eq!(layout._n_trace_colums, 27);

--- a/src/vm/errors/vm_errors.rs
+++ b/src/vm/errors/vm_errors.rs
@@ -96,6 +96,8 @@ pub enum VirtualMachineError {
     SqrtNegative(BigInt),
     #[error("{0} is not divisible by {1}")]
     SafeDivFail(BigInt, BigInt),
+    #[error("{0} is not divisible by {1}")]
+    SafeDivFailUsize(usize, usize),
     #[error("Attempted to devide by zero")]
     DividedByZero,
     #[error("Failed to calculate the square root of: {0})")]

--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -1,10 +1,6 @@
-use num_bigint::BigInt;
-use num_integer::Integer;
-use num_traits::ToPrimitive;
-use std::ops::Shl;
-
+use super::BuiltinRunner;
 use crate::bigint;
-use crate::math_utils::safe_div;
+use crate::math_utils::safe_div_usize;
 use crate::types::instance_definitions::bitwise_instance_def::{
     BitwiseInstanceDef, CELLS_PER_BITWISE, INPUT_CELLS_PER_BITWISE,
 };
@@ -14,11 +10,12 @@ use crate::vm::errors::runner_errors::RunnerError;
 use crate::vm::vm_core::VirtualMachine;
 use crate::vm::vm_memory::memory::Memory;
 use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
-
-use super::BuiltinRunner;
+use num_bigint::BigInt;
+use num_integer::Integer;
+use std::ops::Shl;
 
 pub struct BitwiseBuiltinRunner {
-    _ratio: u32,
+    ratio: u32,
     pub base: isize,
     pub(crate) cells_per_instance: u32,
     pub(crate) n_input_cells: u32,
@@ -31,7 +28,7 @@ impl BitwiseBuiltinRunner {
     pub(crate) fn new(instance_def: &BitwiseInstanceDef) -> Self {
         BitwiseBuiltinRunner {
             base: 0,
-            _ratio: instance_def.ratio,
+            ratio: instance_def.ratio,
             cells_per_instance: CELLS_PER_BITWISE,
             n_input_cells: INPUT_CELLS_PER_BITWISE,
             bitwise_builtin: instance_def.clone(),
@@ -54,6 +51,10 @@ impl BitwiseBuiltinRunner {
 
     pub fn base(&self) -> isize {
         self.base
+    }
+
+    pub fn ratio(&self) -> u32 {
+        self.ratio
     }
 
     pub fn add_validation_rule(&self, _memory: &mut Memory) -> Result<(), RunnerError> {
@@ -107,12 +108,9 @@ impl BitwiseBuiltinRunner {
     }
 
     pub fn get_allocated_memory_units(&self, vm: &VirtualMachine) -> Result<usize, MemoryError> {
-        let value = safe_div(&bigint!(vm.current_step), &bigint!(self._ratio))
+        let value = safe_div_usize(vm.current_step, self.ratio as usize)
             .map_err(|_| MemoryError::ErrorCalculatingMemoryUnits)?;
-        match (self.cells_per_instance * value).to_usize() {
-            Some(result) => Ok(result),
-            _ => Err(MemoryError::ErrorCalculatingMemoryUnits),
-        }
+        Ok(self.cells_per_instance as usize * value)
     }
 
     pub fn get_memory_segment_addresses(&self) -> (&'static str, (isize, Option<usize>)) {
@@ -123,7 +121,7 @@ impl BitwiseBuiltinRunner {
         self,
         vm: &VirtualMachine,
     ) -> Result<(usize, usize), MemoryError> {
-        let ratio = self._ratio as usize;
+        let ratio = self.ratio as usize;
         let cells_per_instance = self.cells_per_instance;
         let min_step = ratio * self.instances_per_component as usize;
         if vm.current_step < min_step {
@@ -131,11 +129,9 @@ impl BitwiseBuiltinRunner {
         } else {
             let builtin = BuiltinRunner::Bitwise(self);
             let used = builtin.get_used_cells(vm)?;
-            let size = (cells_per_instance
-                * safe_div(&bigint!(vm.current_step), &bigint!(ratio))
-                    .map_err(|_| MemoryError::InsufficientAllocatedCells)?)
-            .to_usize()
-            .ok_or(MemoryError::InsufficientAllocatedCells)?;
+            let size = cells_per_instance as usize
+                * safe_div_usize(vm.current_step, ratio)
+                    .map_err(|_| MemoryError::InsufficientAllocatedCells)?;
             Ok((used, size))
         }
     }

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -1,9 +1,5 @@
-use num_bigint::BigInt;
-use num_integer::Integer;
-use num_traits::ToPrimitive;
-use std::borrow::Cow;
-
-use crate::math_utils::{ec_add, ec_double, safe_div};
+use super::BuiltinRunner;
+use crate::math_utils::{ec_add, ec_double, safe_div_usize};
 use crate::types::instance_definitions::ec_op_instance_def::{
     EcOpInstanceDef, CELLS_PER_EC_OP, INPUT_CELLS_PER_EC_OP,
 };
@@ -14,11 +10,12 @@ use crate::vm::vm_core::VirtualMachine;
 use crate::vm::vm_memory::memory::Memory;
 use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
 use crate::{bigint, bigint_str};
-
-use super::BuiltinRunner;
+use num_bigint::BigInt;
+use num_integer::Integer;
+use std::borrow::Cow;
 
 pub struct EcOpBuiltinRunner {
-    _ratio: u32,
+    ratio: u32,
     pub base: isize,
     pub(crate) cells_per_instance: u32,
     pub(crate) n_input_cells: u32,
@@ -31,7 +28,7 @@ impl EcOpBuiltinRunner {
     pub(crate) fn new(instance_def: &EcOpInstanceDef) -> Self {
         EcOpBuiltinRunner {
             base: 0,
-            _ratio: instance_def.ratio,
+            ratio: instance_def.ratio,
             n_input_cells: INPUT_CELLS_PER_EC_OP,
             cells_per_instance: CELLS_PER_EC_OP,
             ec_op_builtin: instance_def.clone(),
@@ -99,6 +96,11 @@ impl EcOpBuiltinRunner {
     pub fn base(&self) -> isize {
         self.base
     }
+
+    pub fn ratio(&self) -> u32 {
+        self.ratio
+    }
+
     pub fn add_validation_rule(&self, _memory: &mut Memory) -> Result<(), RunnerError> {
         Ok(())
     }
@@ -191,12 +193,9 @@ impl EcOpBuiltinRunner {
     }
 
     pub fn get_allocated_memory_units(&self, vm: &VirtualMachine) -> Result<usize, MemoryError> {
-        let value = safe_div(&bigint!(vm.current_step), &bigint!(self._ratio))
+        let value = safe_div_usize(vm.current_step, self.ratio as usize)
             .map_err(|_| MemoryError::ErrorCalculatingMemoryUnits)?;
-        match (self.cells_per_instance * value).to_usize() {
-            Some(result) => Ok(result),
-            _ => Err(MemoryError::ErrorCalculatingMemoryUnits),
-        }
+        Ok(self.cells_per_instance as usize * value)
     }
 
     pub fn get_memory_segment_addresses(&self) -> (&'static str, (isize, Option<usize>)) {
@@ -206,8 +205,8 @@ impl EcOpBuiltinRunner {
     pub fn get_used_cells_and_allocated_size(
         self,
         vm: &VirtualMachine,
-    ) -> Result<(usize, BigInt), MemoryError> {
-        let ratio = self._ratio as usize;
+    ) -> Result<(usize, usize), MemoryError> {
+        let ratio = self.ratio as usize;
         let cells_per_instance = self.cells_per_instance;
         let min_step = ratio * self.instances_per_component as usize;
         if vm.current_step < min_step {
@@ -215,8 +214,8 @@ impl EcOpBuiltinRunner {
         } else {
             let builtin = BuiltinRunner::EcOp(self);
             let used = builtin.get_used_cells(vm)?;
-            let size = cells_per_instance
-                * safe_div(&bigint!(vm.current_step), &bigint!(ratio))
+            let size = cells_per_instance as usize
+                * safe_div_usize(vm.current_step, ratio)
                     .map_err(|_| MemoryError::InsufficientAllocatedCells)?;
             Ok((used, size))
         }
@@ -288,10 +287,7 @@ mod tests {
             .run_until_pc(address, &mut vm, &hint_processor)
             .unwrap();
 
-        assert_eq!(
-            builtin.get_used_cells_and_allocated_size(&vm),
-            Ok((0_usize, bigint!(7)))
-        );
+        assert_eq!(builtin.get_used_cells_and_allocated_size(&vm), Ok((0, 7)));
     }
 
     #[test]

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -1,10 +1,5 @@
-use num_bigint::{BigInt, Sign};
-use num_integer::Integer;
-use num_traits::ToPrimitive;
-use starknet_crypto::{pedersen_hash, FieldElement};
-
-use crate::bigint;
-use crate::math_utils::safe_div;
+use super::BuiltinRunner;
+use crate::math_utils::safe_div_usize;
 use crate::types::instance_definitions::pedersen_instance_def::{
     CELLS_PER_HASH, INPUT_CELLS_PER_HASH,
 };
@@ -14,12 +9,13 @@ use crate::vm::errors::runner_errors::RunnerError;
 use crate::vm::vm_core::VirtualMachine;
 use crate::vm::vm_memory::memory::Memory;
 use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
-
-use super::BuiltinRunner;
+use num_bigint::{BigInt, Sign};
+use num_integer::Integer;
+use starknet_crypto::{pedersen_hash, FieldElement};
 
 pub struct HashBuiltinRunner {
     pub base: isize,
-    _ratio: u32,
+    ratio: u32,
     pub(crate) cells_per_instance: u32,
     pub(crate) n_input_cells: u32,
     stop_ptr: Option<usize>,
@@ -31,7 +27,7 @@ impl HashBuiltinRunner {
     pub fn new(ratio: u32) -> Self {
         HashBuiltinRunner {
             base: 0,
-            _ratio: ratio,
+            ratio,
             cells_per_instance: CELLS_PER_HASH,
             n_input_cells: INPUT_CELLS_PER_HASH,
             stop_ptr: None,
@@ -54,6 +50,10 @@ impl HashBuiltinRunner {
 
     pub fn base(&self) -> isize {
         self.base
+    }
+
+    pub fn ratio(&self) -> u32 {
+        self.ratio
     }
 
     pub fn add_validation_rule(&self, _memory: &mut Memory) -> Result<(), RunnerError> {
@@ -109,12 +109,9 @@ impl HashBuiltinRunner {
     }
 
     pub fn get_allocated_memory_units(&self, vm: &VirtualMachine) -> Result<usize, MemoryError> {
-        let value = safe_div(&bigint!(vm.current_step), &bigint!(self._ratio))
+        let value = safe_div_usize(vm.current_step, self.ratio as usize)
             .map_err(|_| MemoryError::ErrorCalculatingMemoryUnits)?;
-        match (self.cells_per_instance * value).to_usize() {
-            Some(result) => Ok(result),
-            _ => Err(MemoryError::ErrorCalculatingMemoryUnits),
-        }
+        Ok(self.cells_per_instance as usize * value)
     }
 
     pub fn get_memory_segment_addresses(&self) -> (&'static str, (isize, Option<usize>)) {
@@ -124,8 +121,8 @@ impl HashBuiltinRunner {
     pub fn get_used_cells_and_allocated_size(
         self,
         vm: &VirtualMachine,
-    ) -> Result<(usize, BigInt), MemoryError> {
-        let ratio = self._ratio as usize;
+    ) -> Result<(usize, usize), MemoryError> {
+        let ratio = self.ratio as usize;
         let cells_per_instance = self.cells_per_instance;
         let min_step = ratio * self.instances_per_component as usize;
         if vm.current_step < min_step {
@@ -133,8 +130,8 @@ impl HashBuiltinRunner {
         } else {
             let builtin = BuiltinRunner::Hash(self);
             let used = builtin.get_used_cells(vm)?;
-            let size = cells_per_instance
-                * safe_div(&bigint!(vm.current_step), &bigint!(ratio))
+            let size = cells_per_instance as usize
+                * safe_div_usize(vm.current_step, ratio as usize)
                     .map_err(|_| MemoryError::InsufficientAllocatedCells)?;
             Ok((used, size))
         }
@@ -206,10 +203,7 @@ mod tests {
             .run_until_pc(address, &mut vm, &hint_processor)
             .unwrap();
 
-        assert_eq!(
-            builtin.get_used_cells_and_allocated_size(&vm),
-            Ok((0_usize, bigint!(3)))
-        );
+        assert_eq!(builtin.get_used_cells_and_allocated_size(&vm), Ok((0, 3)));
     }
 
     #[test]

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -78,6 +78,16 @@ impl BuiltinRunner {
         }
     }
 
+    pub fn ratio(&self) -> Option<u32> {
+        match self {
+            BuiltinRunner::Bitwise(bitwise) => Some(bitwise.ratio()),
+            BuiltinRunner::EcOp(ec) => Some(ec.ratio()),
+            BuiltinRunner::Hash(hash) => Some(hash.ratio()),
+            BuiltinRunner::Output(_) => None,
+            BuiltinRunner::RangeCheck(range_check) => Some(range_check.ratio()),
+        }
+    }
+
     pub fn add_validation_rule(&self, memory: &mut Memory) -> Result<(), RunnerError> {
         match *self {
             BuiltinRunner::Bitwise(ref bitwise) => bitwise.add_validation_rule(memory),

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -444,11 +444,11 @@ impl CairoRunner {
                 diluted_pool_instance.n_bits,
             );
 
-            used_units_by_builtins += used_units
-                * safe_div_usize(
-                    vm.current_step,
-                    builtin_runner.ratio().unwrap_or(1) as usize,
-                )?;
+            let multiplier = safe_div_usize(
+                vm.current_step,
+                builtin_runner.ratio().unwrap_or(1) as usize,
+            )?;
+            used_units_by_builtins += used_units * multiplier;
         }
 
         let diluted_units = diluted_pool_instance.units_per_step as usize * vm.current_step;


### PR DESCRIPTION
# Implement `CairoRunner::check_diluted_check_usage()`

## Description

Implementation of `CairoRunner::check_diluted_check_usage()` and a few more fixes.

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [x] This change requires new documentation.
  - [x] Documentation has been added/updated.
