### PR TITLE
Implement `CairoRunner::check_range_check_usage()`

### DIFF
--- a/src/types/layout.rs
+++ b/src/types/layout.rs
@@ -7,7 +7,7 @@ use super::instance_definitions::{
 pub(crate) struct CairoLayout {
     pub(crate) name: String,
     pub(crate) _cpu_component_step: u32,
-    pub(crate) _rc_units: u32,
+    pub(crate) rc_units: u32,
     pub(crate) builtins: BuiltinsInstanceDef,
     pub(crate) _public_memory_fraction: u32,
     pub(crate) _memory_units_per_step: u32,
@@ -21,7 +21,7 @@ impl CairoLayout {
         CairoLayout {
             name: String::from("plain"),
             _cpu_component_step: 1,
-            _rc_units: 16,
+            rc_units: 16,
             builtins: BuiltinsInstanceDef::plain(),
             _public_memory_fraction: 4,
             _memory_units_per_step: 8,
@@ -35,7 +35,7 @@ impl CairoLayout {
         CairoLayout {
             name: String::from("small"),
             _cpu_component_step: 1,
-            _rc_units: 16,
+            rc_units: 16,
             builtins: BuiltinsInstanceDef::small(),
             _public_memory_fraction: 4,
             _memory_units_per_step: 8,
@@ -49,7 +49,7 @@ impl CairoLayout {
         CairoLayout {
             name: String::from("dex"),
             _cpu_component_step: 1,
-            _rc_units: 4,
+            rc_units: 4,
             builtins: BuiltinsInstanceDef::dex(),
             _public_memory_fraction: 4,
             _memory_units_per_step: 8,
@@ -63,7 +63,7 @@ impl CairoLayout {
         CairoLayout {
             name: String::from("perpetual_with_bitwise"),
             _cpu_component_step: 1,
-            _rc_units: 4,
+            rc_units: 4,
             builtins: BuiltinsInstanceDef::perpetual_with_bitwise(),
             _public_memory_fraction: 4,
             _memory_units_per_step: 8,
@@ -77,7 +77,7 @@ impl CairoLayout {
         CairoLayout {
             name: String::from("bitwise"),
             _cpu_component_step: 1,
-            _rc_units: 4,
+            rc_units: 4,
             builtins: BuiltinsInstanceDef::bitwise(),
             _public_memory_fraction: 8,
             _memory_units_per_step: 8,
@@ -91,7 +91,7 @@ impl CairoLayout {
         CairoLayout {
             name: String::from("recursive"),
             _cpu_component_step: 1,
-            _rc_units: 4,
+            rc_units: 4,
             builtins: BuiltinsInstanceDef::recursive(),
             _public_memory_fraction: 8,
             _memory_units_per_step: 8,
@@ -105,7 +105,7 @@ impl CairoLayout {
         CairoLayout {
             name: String::from("all"),
             _cpu_component_step: 1,
-            _rc_units: 8,
+            rc_units: 8,
             builtins: BuiltinsInstanceDef::all(),
             _public_memory_fraction: 8,
             _memory_units_per_step: 8,
@@ -126,7 +126,7 @@ mod tests {
         let builtins = BuiltinsInstanceDef::plain();
         assert_eq!(&layout.name, "plain");
         assert_eq!(layout._cpu_component_step, 1);
-        assert_eq!(layout._rc_units, 16);
+        assert_eq!(layout.rc_units, 16);
         assert_eq!(layout.builtins, builtins);
         assert_eq!(layout._public_memory_fraction, 4);
         assert_eq!(layout._memory_units_per_step, 8);
@@ -141,7 +141,7 @@ mod tests {
         let builtins = BuiltinsInstanceDef::small();
         assert_eq!(&layout.name, "small");
         assert_eq!(layout._cpu_component_step, 1);
-        assert_eq!(layout._rc_units, 16);
+        assert_eq!(layout.rc_units, 16);
         assert_eq!(layout.builtins, builtins);
         assert_eq!(layout._public_memory_fraction, 4);
         assert_eq!(layout._memory_units_per_step, 8);
@@ -156,7 +156,7 @@ mod tests {
         let builtins = BuiltinsInstanceDef::dex();
         assert_eq!(&layout.name, "dex");
         assert_eq!(layout._cpu_component_step, 1);
-        assert_eq!(layout._rc_units, 4);
+        assert_eq!(layout.rc_units, 4);
         assert_eq!(layout.builtins, builtins);
         assert_eq!(layout._public_memory_fraction, 4);
         assert_eq!(layout._memory_units_per_step, 8);
@@ -171,7 +171,7 @@ mod tests {
         let builtins = BuiltinsInstanceDef::perpetual_with_bitwise();
         assert_eq!(&layout.name, "perpetual_with_bitwise");
         assert_eq!(layout._cpu_component_step, 1);
-        assert_eq!(layout._rc_units, 4);
+        assert_eq!(layout.rc_units, 4);
         assert_eq!(layout.builtins, builtins);
         assert_eq!(layout._public_memory_fraction, 4);
         assert_eq!(layout._memory_units_per_step, 8);
@@ -189,7 +189,7 @@ mod tests {
         let builtins = BuiltinsInstanceDef::bitwise();
         assert_eq!(&layout.name, "bitwise");
         assert_eq!(layout._cpu_component_step, 1);
-        assert_eq!(layout._rc_units, 4);
+        assert_eq!(layout.rc_units, 4);
         assert_eq!(layout.builtins, builtins);
         assert_eq!(layout._public_memory_fraction, 8);
         assert_eq!(layout._memory_units_per_step, 8);
@@ -207,7 +207,7 @@ mod tests {
         let builtins = BuiltinsInstanceDef::recursive();
         assert_eq!(&layout.name, "recursive");
         assert_eq!(layout._cpu_component_step, 1);
-        assert_eq!(layout._rc_units, 4);
+        assert_eq!(layout.rc_units, 4);
         assert_eq!(layout.builtins, builtins);
         assert_eq!(layout._public_memory_fraction, 8);
         assert_eq!(layout._memory_units_per_step, 8);
@@ -225,7 +225,7 @@ mod tests {
         let builtins = BuiltinsInstanceDef::all();
         assert_eq!(&layout.name, "all");
         assert_eq!(layout._cpu_component_step, 1);
-        assert_eq!(layout._rc_units, 8);
+        assert_eq!(layout.rc_units, 8);
         assert_eq!(layout.builtins, builtins);
         assert_eq!(layout._public_memory_fraction, 8);
         assert_eq!(layout._memory_units_per_step, 8);

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -165,6 +165,7 @@ impl BuiltinRunner {
         }
     }
 
+    /// Returns the number of range check units used by the builtin.
     pub fn get_used_perm_range_check_units(
         &self,
         vm: &VirtualMachine,

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -16,7 +16,6 @@ pub use bitwise::BitwiseBuiltinRunner;
 pub use ec_op::EcOpBuiltinRunner;
 pub use hash::HashBuiltinRunner;
 use nom::ToUsize;
-use num_bigint::BigInt;
 use num_integer::{div_ceil, div_floor};
 pub use output::OutputBuiltinRunner;
 pub use range_check::RangeCheckBuiltinRunner;
@@ -159,7 +158,7 @@ impl BuiltinRunner {
         }
     }
 
-    pub fn get_range_check_usage(&self, memory: &Memory) -> Option<(BigInt, BigInt)> {
+    pub fn get_range_check_usage(&self, memory: &Memory) -> Option<(isize, isize)> {
         match self {
             BuiltinRunner::RangeCheck(ref range_check) => range_check.get_range_check_usage(memory),
             _ => None,
@@ -351,10 +350,7 @@ mod tests {
     fn get_range_check_usage_range_check() {
         let builtin = BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new(8, 8));
         let memory = memory![((0, 0), 1), ((0, 1), 2), ((0, 2), 3), ((0, 3), 4)];
-        assert_eq!(
-            builtin.get_range_check_usage(&memory),
-            Some((bigint!(1), bigint!(4)))
-        );
+        assert_eq!(builtin.get_range_check_usage(&memory), Some((1, 4)));
     }
 
     #[test]

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -165,6 +165,18 @@ impl BuiltinRunner {
         }
     }
 
+    pub fn get_used_perm_range_check_units(
+        &self,
+        vm: &VirtualMachine,
+    ) -> Result<usize, MemoryError> {
+        match self {
+            BuiltinRunner::RangeCheck(range_check) => {
+                range_check.get_used_perm_range_check_units(vm)
+            }
+            _ => Ok(0),
+        }
+    }
+
     pub fn get_used_diluted_check_units(&self, diluted_spacing: u32, diluted_n_bits: u32) -> usize {
         match self {
             BuiltinRunner::Bitwise(ref bitwise) => {

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -158,7 +158,7 @@ impl BuiltinRunner {
         }
     }
 
-    pub fn get_range_check_usage(&self, memory: &Memory) -> Option<(isize, isize)> {
+    pub fn get_range_check_usage(&self, memory: &Memory) -> Option<(usize, usize)> {
         match self {
             BuiltinRunner::RangeCheck(ref range_check) => range_check.get_range_check_usage(memory),
             _ => None,

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -492,4 +492,66 @@ mod tests {
             Err(MemoryError::MissingMemoryCellsWithOffsets("bitwise", vec![0],).into()),
         );
     }
+
+    /// Test that get_used_perm_range_check_units() returns zero when the
+    /// builtin is a BitwiseBuiltinRunner.
+    #[test]
+    fn get_used_perm_range_check_units_bitwise() {
+        let builtin_runner: BuiltinRunner =
+            BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default()).into();
+        let mut vm = vm!();
+
+        vm.current_step = 8;
+        vm.segments.segment_used_sizes = Some(vec![5]);
+        assert_eq!(builtin_runner.get_used_perm_range_check_units(&vm), Ok(0));
+    }
+
+    /// Test that get_used_perm_range_check_units() returns zero when the
+    /// builtin is an EcOpBuiltinRunner.
+    #[test]
+    fn get_used_perm_range_check_units_ec_op() {
+        let builtin_runner: BuiltinRunner =
+            EcOpBuiltinRunner::new(&EcOpInstanceDef::default()).into();
+        let mut vm = vm!();
+
+        vm.current_step = 8;
+        vm.segments.segment_used_sizes = Some(vec![5]);
+        assert_eq!(builtin_runner.get_used_perm_range_check_units(&vm), Ok(0));
+    }
+
+    /// Test that get_used_perm_range_check_units() returns zero when the
+    /// builtin is a HashBuiltinRunner.
+    #[test]
+    fn get_used_perm_range_check_units_hash() {
+        let builtin_runner: BuiltinRunner = HashBuiltinRunner::new(8).into();
+        let mut vm = vm!();
+
+        vm.current_step = 8;
+        vm.segments.segment_used_sizes = Some(vec![5]);
+        assert_eq!(builtin_runner.get_used_perm_range_check_units(&vm), Ok(0));
+    }
+
+    /// Test that get_used_perm_range_check_units() returns zero when the
+    /// builtin is an OutputBuiltinRunner.
+    #[test]
+    fn get_used_perm_range_check_units_output() {
+        let builtin_runner: BuiltinRunner = OutputBuiltinRunner::new().into();
+        let mut vm = vm!();
+
+        vm.current_step = 8;
+        vm.segments.segment_used_sizes = Some(vec![5]);
+        assert_eq!(builtin_runner.get_used_perm_range_check_units(&vm), Ok(0));
+    }
+
+    /// Test that get_used_perm_range_check_units() calls the corresponding
+    /// method when the builtin is a RangeCheckBuiltinRunner.
+    #[test]
+    fn get_used_perm_range_check_units_range_check() {
+        let builtin_runner: BuiltinRunner = RangeCheckBuiltinRunner::new(8, 8).into();
+        let mut vm = vm!();
+
+        vm.current_step = 8;
+        vm.segments.segment_used_sizes = Some(vec![5]);
+        assert_eq!(builtin_runner.get_used_perm_range_check_units(&vm), Ok(40));
+    }
 }

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -110,6 +110,7 @@ impl RangeCheckBuiltinRunner {
     pub fn get_range_check_usage(&self, memory: &Memory) -> Option<(isize, isize)> {
         let mut rc_bounds: Option<(isize, isize)> = None;
         let range_check_segment = memory.data.get(self.base as usize)?;
+        let inner_rc_bound = bigint!(self.inner_rc_bound);
         for value in range_check_segment {
             //Split val into n_parts parts.
             for _ in 0..self.n_parts {
@@ -117,8 +118,8 @@ impl RangeCheckBuiltinRunner {
                     .as_ref()?
                     .get_int_ref()
                     .ok()?
-                    .to_isize()?
-                    .mod_floor(&self.inner_rc_bound);
+                    .mod_floor(&inner_rc_bound)
+                    .to_isize()?;
                 rc_bounds = Some(match rc_bounds {
                     None => (part_val, part_val),
                     Some((rc_min, rc_max)) => {

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -166,6 +166,7 @@ impl RangeCheckBuiltinRunner {
         rc_bounds
     }
 
+    /// Returns the number of range check units used by the builtin.
     pub fn get_used_perm_range_check_units(
         &self,
         vm: &VirtualMachine,

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -21,7 +21,7 @@ pub struct RangeCheckBuiltinRunner {
     stop_ptr: Option<usize>,
     pub(crate) cells_per_instance: u32,
     pub(crate) n_input_cells: u32,
-    inner_rc_bound: isize,
+    inner_rc_bound: usize,
     pub _bound: BigInt,
     n_parts: u32,
     instances_per_component: u32,
@@ -29,7 +29,7 @@ pub struct RangeCheckBuiltinRunner {
 
 impl RangeCheckBuiltinRunner {
     pub fn new(ratio: u32, n_parts: u32) -> RangeCheckBuiltinRunner {
-        let inner_rc_bound = 1isize << 16;
+        let inner_rc_bound = 1usize << 16;
         RangeCheckBuiltinRunner {
             ratio,
             base: 0,
@@ -137,8 +137,8 @@ impl RangeCheckBuiltinRunner {
         }
     }
 
-    pub fn get_range_check_usage(&self, memory: &Memory) -> Option<(isize, isize)> {
-        let mut rc_bounds: Option<(isize, isize)> = None;
+    pub fn get_range_check_usage(&self, memory: &Memory) -> Option<(usize, usize)> {
+        let mut rc_bounds: Option<(usize, usize)> = None;
         let range_check_segment = memory.data.get(self.base as usize)?;
         let inner_rc_bound = bigint!(self.inner_rc_bound);
         for value in range_check_segment {
@@ -149,7 +149,7 @@ impl RangeCheckBuiltinRunner {
                     .get_int_ref()
                     .ok()?
                     .mod_floor(&inner_rc_bound)
-                    .to_isize()?;
+                    .to_usize()?;
                 rc_bounds = Some(match rc_bounds {
                     None => (part_val, part_val),
                     Some((rc_min, rc_max)) => {

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -15,8 +15,6 @@ use crate::vm::vm_core::VirtualMachine;
 use crate::vm::vm_memory::memory::{Memory, ValidationRule};
 use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
 
-use super::BuiltinRunner;
-
 pub struct RangeCheckBuiltinRunner {
     ratio: u32,
     base: isize,
@@ -432,5 +430,16 @@ mod tests {
         let builtin = RangeCheckBuiltinRunner::new(8, 8);
         let memory = Memory::new();
         assert_eq!(builtin.get_range_check_usage(&memory), None);
+    }
+
+    /// Test that the method get_used_perm_range_check_units works as intended.
+    #[test]
+    fn get_used_perm_range_check_units() {
+        let builtin_runner = RangeCheckBuiltinRunner::new(8, 8);
+        let mut vm = vm!();
+
+        vm.current_step = 8;
+        vm.segments.segment_used_sizes = Some(vec![5]);
+        assert_eq!(builtin_runner.get_used_perm_range_check_units(&vm), Ok(40));
     }
 }

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -440,6 +440,8 @@ impl CairoRunner {
         }
     }
 
+    /// Checks that there are enough trace cells to fill the entire range check
+    /// range.
     pub fn check_range_check_usage(&self, vm: &VirtualMachine) -> Result<(), VirtualMachineError> {
         let (rc_min, rc_max) = match self.get_perm_range_check_limits(vm)? {
             Some(x) => x,

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -430,8 +430,8 @@ impl CairoRunner {
                         None => continue,
                     };
 
-                    rc_min = rc_min.min(runner_min);
-                    rc_max = rc_max.max(runner_max);
+                    rc_min = rc_min.min(runner_min as isize);
+                    rc_max = rc_max.max(runner_max as isize);
                 }
 
                 Ok(Some((rc_min, rc_max)))

--- a/src/vm/trace/mod.rs
+++ b/src/vm/trace/mod.rs
@@ -1,1 +1,58 @@
+use self::trace_entry::TraceEntry;
+use super::{
+    decoding::decoder::decode_instruction, errors::vm_errors::VirtualMachineError,
+    vm_memory::memory::Memory,
+};
+use crate::types::relocatable::{MaybeRelocatable, Relocatable};
+use num_traits::ToPrimitive;
+use std::borrow::Cow;
+
 pub mod trace_entry;
+
+pub fn get_perm_range_check_limits(
+    trace: &[TraceEntry],
+    memory: &Memory,
+) -> Result<Option<(usize, usize)>, VirtualMachineError> {
+    trace
+        .iter()
+        .try_fold(None, |offsets: Option<(usize, usize)>, trace| {
+            let instruction = memory.get_integer(&trace.pc)?;
+            let immediate =
+                memory.get::<Relocatable>(&(trace.pc.segment_index, trace.pc.offset + 1).into())?;
+
+            let instruction = instruction
+                .to_i64()
+                .ok_or(VirtualMachineError::InvalidInstructionEncoding)?;
+            let immediate = immediate
+                .map(|x| match x {
+                    Cow::Borrowed(MaybeRelocatable::Int(value)) => Ok(value.clone()),
+                    Cow::Owned(MaybeRelocatable::Int(value)) => Ok(value),
+                    _ => Err(VirtualMachineError::ExpectedInteger(
+                        (trace.pc.segment_index, trace.pc.offset + 1).into(),
+                    )),
+                })
+                .transpose()?;
+
+            let decoded_instruction = decode_instruction(instruction, immediate)?;
+            let off0 = decoded_instruction
+                .off0
+                .to_usize()
+                .ok_or(VirtualMachineError::BigintToUsizeFail)?;
+            let off1 = decoded_instruction
+                .off1
+                .to_usize()
+                .ok_or(VirtualMachineError::BigintToUsizeFail)?;
+            let off2 = decoded_instruction
+                .off2
+                .to_usize()
+                .ok_or(VirtualMachineError::BigintToUsizeFail)?;
+
+            let min_value = off0.min(off1).min(off2);
+            let max_value = off0.max(off1).max(off2);
+            Ok(
+                offsets.map_or(Some((min_value, max_value)), |(min_offset, max_offset)| {
+                    Some((min_offset.min(min_value), max_offset.max(max_value)))
+                }),
+            )
+        })
+}

--- a/src/vm/trace/mod.rs
+++ b/src/vm/trace/mod.rs
@@ -9,6 +9,7 @@ use std::borrow::Cow;
 
 pub mod trace_entry;
 
+/// Return the minimum and maximum values in the perm_range_check component.
 pub fn get_perm_range_check_limits(
     trace: &[TraceEntry],
     memory: &Memory,


### PR DESCRIPTION
# Implement `CairoRunner::check_range_check_usage()`

## Description

Implementation of `CairoRunner::check_range_check_usage()` and `BuiltinRunner::get_used_perm_range_check_units()`.
Depends on #549.

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [x] This change requires new documentation.
  - [x] Documentation has been added/updated.
