### PR TITLE
Implement `Memory::relocate_memory`.

### DIFF
--- a/src/cairo_run.rs
+++ b/src/cairo_run.rs
@@ -30,6 +30,7 @@ pub fn cairo_run(
     cairo_runner
         .run_until_pc(end, &mut vm, hint_executor)
         .map_err(CairoRunError::VirtualMachine)?;
+    cairo_runner.end_run(false, false, &mut vm, hint_executor)?;
 
     vm.verify_auto_deductions()
         .map_err(CairoRunError::VirtualMachine)?;

--- a/src/cairo_run.rs
+++ b/src/cairo_run.rs
@@ -27,20 +27,15 @@ pub fn cairo_run(
     let mut vm = VirtualMachine::new(program.prime, trace_enabled);
     let end = cairo_runner.initialize(&mut vm)?;
 
-    cairo_runner
-        .run_until_pc(end, &mut vm, hint_executor)
-        .map_err(CairoRunError::VirtualMachine)?;
+    cairo_runner.run_until_pc(end, &mut vm, hint_executor)?;
     cairo_runner.end_run(false, false, &mut vm, hint_executor)?;
 
-    vm.verify_auto_deductions()
-        .map_err(CairoRunError::VirtualMachine)?;
+    vm.verify_auto_deductions()?;
 
     if proof_mode {
         cairo_runner.finalize_segments(&mut vm)?;
     }
-    cairo_runner
-        .relocate(&mut vm)
-        .map_err(CairoRunError::Trace)?;
+    cairo_runner.relocate(&mut vm)?;
 
     if print_output {
         write_output(&mut cairo_runner, &mut vm)?;
@@ -56,9 +51,7 @@ pub fn write_output(
     let mut buffer = BufWriter::new(io::stdout());
     writeln!(&mut buffer, "Program Output: ")
         .map_err(|_| CairoRunError::Runner(RunnerError::WriteFail))?;
-    cairo_runner
-        .write_output(vm, &mut buffer)
-        .map_err(CairoRunError::Runner)?;
+    cairo_runner.write_output(vm, &mut buffer)?;
     buffer
         .flush()
         .map_err(|_| CairoRunError::Runner(RunnerError::WriteFail))

--- a/src/hint_processor/builtin_hint_processor/segments.rs
+++ b/src/hint_processor/builtin_hint_processor/segments.rs
@@ -50,14 +50,13 @@ pub fn temporary_array(
 mod tests {
     use super::*;
     use crate::any_box;
+    use crate::bigint;
     use crate::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor;
     use crate::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::HintProcessorData;
     use crate::hint_processor::builtin_hint_processor::hint_code;
     use crate::hint_processor::hint_processor_definition::HintProcessor;
-    use crate::relocatable;
     use crate::types::exec_scope::ExecutionScopes;
     use crate::types::relocatable::MaybeRelocatable;
-    use crate::types::relocatable::Relocatable;
     use crate::utils::test_utils::*;
     use crate::vm::errors::memory_errors::MemoryError;
     use crate::vm::vm_core::VirtualMachine;
@@ -74,7 +73,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 2;
         //Insert ids into memory
-        vm.memory = memory![((1, 0), (-2, 0)), ((1, 1), (3, 0))];
+        vm.memory = memory![((1, 0), (-2, 0)), ((1, 1), (3, 0)), ((3, 0), 42)];
 
         //Create ids_data & hint_data
         let ids_data = ids_data!["src_ptr", "dest_ptr"];
@@ -82,10 +81,9 @@ mod tests {
         //Execute the hint
         assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
 
-        assert_eq!(
-            vm.memory.relocation_rules.get(&2),
-            Some(&relocatable!(3, 0))
-        );
+        vm.memory
+            .relocate_memory()
+            .expect("Couldn't relocate memory.");
     }
 
     #[test]

--- a/src/types/relocatable.rs
+++ b/src/types/relocatable.rs
@@ -5,7 +5,7 @@ use crate::{
 use num_bigint::BigInt;
 use num_integer::Integer;
 use num_traits::{FromPrimitive, Signed, ToPrimitive};
-use std::{collections::HashMap, ops::Add};
+use std::ops::Add;
 
 #[derive(Eq, Hash, PartialEq, PartialOrd, Clone, Debug)]
 pub struct Relocatable {
@@ -348,13 +348,12 @@ impl<'a> Add<usize> for &'a Relocatable {
     }
 }
 
-///Turns a MaybeRelocatable into a BigInt value
-/// If the value is an Int, it will extract the BigInt value from it
-/// If the value is Relocatable, it will relocate it using the relocation_table
+/// Turns a MaybeRelocatable into a BigInt value.
+/// If the value is an Int, it will extract the BigInt value from it.
+/// If the value is Relocatable, it will return an error since it should've already been relocated.
 pub fn relocate_value(
     value: MaybeRelocatable,
     relocation_table: &Vec<usize>,
-    relocation_rules: &HashMap<usize, Relocatable>,
 ) -> Result<BigInt, MemoryError> {
     match value {
         MaybeRelocatable::Int(num) => Ok(num),
@@ -365,16 +364,9 @@ pub fn relocate_value(
                     relocatable.offset as usize,
                 )
             } else {
-                let relocation_address = relocation_rules
-                    .get(&(relocatable.segment_index.abs() as usize))
-                    .ok_or(MemoryError::TemporarySegmentWithoutRelocationAddreess(
-                        relocatable.segment_index,
-                    ))?;
-
-                (
-                    relocation_address.segment_index as usize,
-                    (relocation_address.offset + relocatable.offset) as usize,
-                )
+                return Err(MemoryError::TemporarySegmentInRelocation(
+                    relocatable.segment_index,
+                ));
             };
 
             if relocation_table.len() <= segment_index {
@@ -657,21 +649,16 @@ mod tests {
     fn relocate_relocatable_value() {
         let value = MaybeRelocatable::from((2, 7));
         let relocation_table = vec![1, 2, 5];
-        assert_eq!(
-            relocate_value(value, &relocation_table, &HashMap::new()),
-            Ok(bigint!(12))
-        );
+        assert_eq!(relocate_value(value, &relocation_table), Ok(bigint!(12)));
     }
 
     #[test]
     fn relocate_relocatable_in_temp_segment_value() {
         let value = MaybeRelocatable::from((-1, 7));
         let relocation_table = vec![1, 2, 5];
-        let mut relocation_rules = HashMap::new();
-        relocation_rules.insert(1, relocatable!(2, 0));
         assert_eq!(
-            relocate_value(value, &relocation_table, &relocation_rules),
-            Ok(bigint!(12))
+            relocate_value(value, &relocation_table),
+            Err(MemoryError::TemporarySegmentInRelocation(-1)),
         );
     }
 
@@ -679,11 +666,9 @@ mod tests {
     fn relocate_relocatable_in_temp_segment_value_with_offset() {
         let value = MaybeRelocatable::from((-1, 7));
         let relocation_table = vec![1, 2, 5];
-        let mut relocation_rules = HashMap::new();
-        relocation_rules.insert(1, relocatable!(2, 5));
         assert_eq!(
-            relocate_value(value, &relocation_table, &relocation_rules),
-            Ok(bigint!(17))
+            relocate_value(value, &relocation_table),
+            Err(MemoryError::TemporarySegmentInRelocation(-1)),
         );
     }
 
@@ -692,8 +677,8 @@ mod tests {
         let value = MaybeRelocatable::from((-1, 7));
         let relocation_table = vec![1, 2, 5];
         assert_eq!(
-            relocate_value(value, &relocation_table, &HashMap::new()),
-            Err(MemoryError::TemporarySegmentWithoutRelocationAddreess(-1))
+            relocate_value(value, &relocation_table),
+            Err(MemoryError::TemporarySegmentInRelocation(-1))
         );
     }
 
@@ -701,10 +686,7 @@ mod tests {
     fn relocate_int_value() {
         let value = MaybeRelocatable::from(bigint!(7));
         let relocation_table = vec![1, 2, 5];
-        assert_eq!(
-            relocate_value(value, &relocation_table, &HashMap::new()),
-            Ok(bigint!(7))
-        );
+        assert_eq!(relocate_value(value, &relocation_table), Ok(bigint!(7)));
     }
 
     #[test]
@@ -712,7 +694,7 @@ mod tests {
         let value = MaybeRelocatable::from((2, 7));
         let relocation_table = vec![1, 2];
         assert_eq!(
-            relocate_value(value, &relocation_table, &HashMap::new()),
+            relocate_value(value, &relocation_table),
             Err(MemoryError::Relocation)
         );
     }

--- a/src/vm/errors/memory_errors.rs
+++ b/src/vm/errors/memory_errors.rs
@@ -24,8 +24,8 @@ pub enum MemoryError {
     AddressInTemporarySegment(isize),
     #[error("Memory addresses must be in a TemporarySegment, segment: {0}")]
     AddressNotInTemporarySegment(isize),
-    #[error("Non-zero offset found where zero is required, offset: {0}")]
-    TemporarySegmentWithoutRelocationAddreess(isize),
+    #[error("Temporary segment found while relocating (flattening), segment: {0}")]
+    TemporarySegmentInRelocation(isize),
     #[error("The TemporarySegment: {0} doesn't have a relocation address")]
     NonZeroOffset(usize),
     #[error("Attempt to overwrite a relocation rule, segment: {0}")]

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -540,8 +540,7 @@ impl CairoRunner {
             new_accessed_addresses
         });
 
-        self.relocate(vm)
-            .map_err(VirtualMachineError::TracerError)?;
+        vm.memory.relocate_memory()?;
         vm.end_run(&self.exec_scopes)?;
 
         if !disable_finalize_all {

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -667,11 +667,9 @@ impl CairoRunner {
 
             for element in segment {
                 match element {
-                    Some(elem) => self.relocated_memory.push(Some(relocate_value(
-                        elem.clone(),
-                        relocation_table,
-                        &vm.memory.relocation_rules,
-                    )?)),
+                    Some(elem) => self
+                        .relocated_memory
+                        .push(Some(relocate_value(elem.clone(), relocation_table)?)),
                     None => self.relocated_memory.push(None),
                 }
             }
@@ -1009,7 +1007,7 @@ mod tests {
         let mut vm = vm!();
         vm.segments.segment_used_sizes = Some(vec![4]);
 
-        assert_eq!(cairo_runner.check_memory_usage(&mut vm), Ok(()));
+        assert_eq!(cairo_runner.check_memory_usage(&vm), Ok(()));
     }
 
     #[test]

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -118,7 +118,7 @@ impl Memory {
             return Ok(Cow::Borrowed(value));
         }
 
-        let relocation = match self.relocation_rules.get(&(-segment_idx as usize)) {
+        let relocation = match self.relocation_rules.get(&(-(segment_idx + 1) as usize)) {
             Some(x) => x,
             None => return Ok(Cow::Borrowed(value)),
         };
@@ -224,7 +224,7 @@ impl Memory {
             return Err(MemoryError::NonZeroOffset(src_ptr.offset));
         }
 
-        let segment_index = -src_ptr.segment_index as usize;
+        let segment_index = -(src_ptr.segment_index + 1) as usize;
         if self.relocation_rules.contains_key(&segment_index) {
             return Err(MemoryError::DuplicatedRelocation(src_ptr.segment_index));
         }
@@ -781,8 +781,8 @@ mod memory_tests {
     #[test]
     fn relocate_value_mayberelocatable_temporary_segment_rules() {
         let mut memory = Memory::new();
-        memory.relocation_rules.insert(1, (2, 0).into());
-        memory.relocation_rules.insert(2, (2, 2).into());
+        memory.relocation_rules.insert(0, (2, 0).into());
+        memory.relocation_rules.insert(1, (2, 2).into());
 
         // Test when value is Some(MaybeRelocatable) with segment_index < 0 and
         // there are applicable relocation rules:

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -781,8 +781,12 @@ mod memory_tests {
     #[test]
     fn relocate_value_mayberelocatable_temporary_segment_rules() {
         let mut memory = Memory::new();
-        memory.relocation_rules.insert(0, (2, 0).into());
-        memory.relocation_rules.insert(1, (2, 2).into());
+        memory
+            .add_relocation_rule((-1, 0).into(), (2, 0).into())
+            .unwrap();
+        memory
+            .add_relocation_rule((-2, 0).into(), (2, 2).into())
+            .unwrap();
 
         // Test when value is Some(MaybeRelocatable) with segment_index < 0 and
         // there are applicable relocation rules:

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -930,12 +930,6 @@ mod memory_tests {
                     mayberelocatable!(5).into(),
                     mayberelocatable!(2, 3).into(),
                 ],
-                vec![
-                    None,
-                    mayberelocatable!(7).into(),
-                    mayberelocatable!(8).into(),
-                    mayberelocatable!(9).into(),
-                ],
             ],
         );
         assert!(memory.temp_data.is_empty());

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -13,9 +13,9 @@ pub struct ValidationRule(
 pub struct Memory {
     pub data: Vec<Vec<Option<MaybeRelocatable>>>,
     pub temp_data: Vec<Vec<Option<MaybeRelocatable>>>,
-    pub relocation_rules: HashMap<usize, Relocatable>,
+    relocation_rules: HashMap<usize, Relocatable>,
     pub validated_addresses: HashSet<MaybeRelocatable>,
-    pub validation_rules: HashMap<usize, ValidationRule>,
+    validation_rules: HashMap<usize, ValidationRule>,
 }
 
 impl Memory {


### PR DESCRIPTION
# Implement `Memory::relocate_memory`

## Description

Implementation `Memory::relocate_memory`.
Fix `CairoRunner::end_run()`.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [x] This change requires new documentation.
  - [ ] Documentation has been added/updated.
