### PR TITLE
Remove result from relocate value

### DIFF
--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -536,7 +536,7 @@ impl CairoRunner {
             let mut new_accessed_addresses = HashSet::with_capacity(accessed_addresses.len());
 
             for addr in accessed_addresses {
-                let relocated_addr = vm.memory.relocate_value(&addr.into())?.into_owned();
+                let relocated_addr = vm.memory.relocate_value(&addr.into()).into_owned();
 
                 new_accessed_addresses.insert(relocated_addr.try_into().unwrap());
             }


### PR DESCRIPTION
Relocate value was using an unnecessary result