### PR TITLE
Separate codecov-report upload in a different job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,9 +38,23 @@ jobs:
       run: make clippy
     - name: Coverage
       run: make coverage
+    - name: Cleanup tests
+      run: make clean
+    - name: Cache Codecov-report
+      uses: actions//upload-artifact@master
+      with:
+        name: codecov-report
+        path: target/tarpaulin
+  upload-codecov:
+    needs: build
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Retrieve cached report
+      uses: actions/download-artifact@master
+      with:
+        name: codecov-report
+        path: target/tarpaulin
     - name: Upload coverage to codecov.io
       uses: codecov/codecov-action@v2
       with:
         fail_ci_if_error:     true
-    - name: Cleanup tests
-      run: make clean


### PR DESCRIPTION
Separate the upload of   codecov report on from other workflow tasks
This PR aims to reduce CI time in case of unexpected failures by separating the uploading task in  a different job which can be quickly re-run in case of failure. Creating each report takes a considerable amount of time, and uploading those reports may fail due to external reasons. When this happens, we have to re-run the whole job, when we could just re-run the uploading of the results.