### PR TITLE
Expose Memory.add_relocation_rule method

### DIFF
--- a/src/hint_processor/builtin_hint_processor/segments.rs
+++ b/src/hint_processor/builtin_hint_processor/segments.rs
@@ -24,7 +24,7 @@ pub fn relocate_segment(
     let src_ptr = get_ptr_from_var_name("src_ptr", vm, ids_data, ap_tracking)?;
     let dest_ptr = get_ptr_from_var_name("dest_ptr", vm, ids_data, ap_tracking)?;
 
-    vm.memory.add_relocation_rule(src_ptr, dest_ptr)?;
+    vm.add_relocation_rule(src_ptr, dest_ptr)?;
     Ok(())
 }
 

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -804,6 +804,20 @@ impl VirtualMachine {
     pub fn add_temporary_segment(&mut self) -> Relocatable {
         self.segments.add_temporary_segment(&mut self.memory)
     }
+
+    /// Add a new relocation rule.
+    ///
+    /// Will return an error if any of the following conditions are not met:
+    ///   - Source address's segment must be negative (temporary).
+    ///   - Source address's offset must be zero.
+    ///   - There shouldn't already be relocation at the source segment.
+    pub fn add_relocation_rule(
+        &mut self,
+        src_ptr: Relocatable,
+        dst_ptr: Relocatable,
+    ) -> Result<(), MemoryError> {
+        self.memory.add_relocation_rule(src_ptr, dst_ptr)
+    }
 }
 
 #[cfg(test)]

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -3610,4 +3610,30 @@ mod tests {
             Err(VirtualMachineError::InvalidInstructionEncoding)
         );
     }
+
+    #[test]
+    fn add_relocation_rule() {
+        let mut vm = vm!();
+
+        assert_eq!(
+            vm.add_relocation_rule((-1, 0).into(), (1, 2).into()),
+            Ok(()),
+        );
+        assert_eq!(
+            vm.add_relocation_rule((-2, 0).into(), (-1, 1).into()),
+            Ok(()),
+        );
+        assert_eq!(
+            vm.add_relocation_rule((5, 0).into(), (0, 0).into()),
+            Err(MemoryError::AddressNotInTemporarySegment(5)),
+        );
+        assert_eq!(
+            vm.add_relocation_rule((-3, 6).into(), (0, 0).into()),
+            Err(MemoryError::NonZeroOffset(6)),
+        );
+        assert_eq!(
+            vm.add_relocation_rule((-1, 0).into(), (0, 0).into()),
+            Err(MemoryError::DuplicatedRelocation(-1)),
+        );
+    }
 }

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -3612,7 +3612,7 @@ mod tests {
     }
 
     #[test]
-    fn add_relocation_rule() {
+    fn add_relocation_rule_test() {
         let mut vm = vm!();
 
         assert_eq!(

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -132,7 +132,7 @@ impl Memory {
     ///   - Source address's segment must be negative (temporary).
     ///   - Source address's offset must be zero.
     ///   - There shouldn't already be relocation at the source segment.
-    pub fn add_relocation_rule(
+    pub(crate) fn add_relocation_rule(
         &mut self,
         src_ptr: Relocatable,
         dst_ptr: Relocatable,


### PR DESCRIPTION
# Expose Memory.add_relocation_rule method

# Merge after #576 

* Expose the Memory.add_relocation_rule() method in VmCore
* Use the exposed method in the relocate_segment hint implementation

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
