### PR TITLE
Add check + Informative error for when there are builtins in the program that are not present in the layout

### DIFF
--- a/src/vm/errors/runner_errors.rs
+++ b/src/vm/errors/runner_errors.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use super::memory_errors::MemoryError;
 use crate::types::relocatable::MaybeRelocatable;
 use num_bigint::BigInt;
@@ -57,8 +59,8 @@ pub enum RunnerError {
     EcOpSameXCoordinate((BigInt, BigInt), BigInt, (BigInt, BigInt)),
     #[error("EcOpBuiltin: point {0:?} is not on the curve")]
     PointNotOnCurve((usize, usize)),
-    #[error("Builtin {0} is not present in layout {1}")]
-    NoBuiltinForInstance(String, String),
+    #[error("Builtin(s) {0:?} not present in layout {1}")]
+    NoBuiltinForInstance(HashSet<String>, String),
     #[error("Invalid layout {0}")]
     InvalidLayoutName(String),
     #[error("Run has already ended.")]

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -177,10 +177,12 @@ impl CairoRunner {
         let program_builtins: HashSet<&String> =
             self.program.builtins.iter().collect::<HashSet<&String>>();
         // Get the builtins that belong to the program but weren't inserted (those who dont belong to the instance)
-        let mut difference = program_builtins.difference(&inserted_builtins).peekable();
-        if difference.peek().is_some() {
+        if !program_builtins.is_subset(&inserted_builtins) {
             return Err(RunnerError::NoBuiltinForInstance(
-                difference.map(|x| (&(**x).clone()).clone()).collect(),
+                program_builtins
+                    .difference(&inserted_builtins)
+                    .map(|x| (&(**x).clone()).clone())
+                    .collect(),
                 self.layout._name.clone(),
             ));
         }

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -4350,4 +4350,79 @@ mod tests {
             ))
         );
     }
+
+    #[test]
+    fn initialize_segments_incorrect_layout_plain_one_builtin() {
+        let program = Program {
+            builtins: vec![String::from("output")],
+            prime: bigint!(17),
+            data: Vec::new(),
+            constants: HashMap::new(),
+            main: None,
+            hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
+            identifiers: HashMap::new(),
+        };
+        let mut vm = vm!();
+        let cairo_runner = cairo_runner!(program, "plain");
+        assert_eq!(
+            cairo_runner.initialize_builtins(&mut vm),
+            Err(RunnerError::NoBuiltinForInstance(
+                HashSet::from([String::from("output")]),
+                String::from("plain")
+            ))
+        );
+    }
+
+    #[test]
+    fn initialize_segments_incorrect_layout_plain_two_builtins() {
+        let program = Program {
+            builtins: vec![String::from("output"), String::from("pedersen")],
+            prime: bigint!(17),
+            data: Vec::new(),
+            constants: HashMap::new(),
+            main: None,
+            hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
+            identifiers: HashMap::new(),
+        };
+        let mut vm = vm!();
+        let cairo_runner = cairo_runner!(program, "plain");
+        assert_eq!(
+            cairo_runner.initialize_builtins(&mut vm),
+            Err(RunnerError::NoBuiltinForInstance(
+                HashSet::from([String::from("output"), String::from("pedersen")]),
+                String::from("plain")
+            ))
+        );
+    }
+
+    #[test]
+    fn initialize_segments_incorrect_layout_small_two_builtins() {
+        let program = Program {
+            builtins: vec![String::from("output"), String::from("bitwise")],
+            prime: bigint!(17),
+            data: Vec::new(),
+            constants: HashMap::new(),
+            main: None,
+            hints: HashMap::new(),
+            reference_manager: ReferenceManager {
+                references: Vec::new(),
+            },
+            identifiers: HashMap::new(),
+        };
+        let mut vm = vm!();
+        let cairo_runner = cairo_runner!(program, "small");
+        assert_eq!(
+            cairo_runner.initialize_builtins(&mut vm),
+            Err(RunnerError::NoBuiltinForInstance(
+                HashSet::from([String::from("bitwise")]),
+                String::from("small")
+            ))
+        );
+    }
 }

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -170,6 +170,25 @@ impl CairoRunner {
             }
         }
 
+        let inserted_builtins = builtin_runners
+            .iter()
+            .map(|x| &x.0)
+            .collect::<HashSet<&String>>();
+        let program_builtins: HashSet<&String> =
+            self.program.builtins.iter().collect::<HashSet<&String>>();
+        // Get the builtins that belong to the program but weren't inserted (those who dont belong to the instance)
+        let difference: HashSet<&&String> =
+            program_builtins.difference(&inserted_builtins).collect();
+        if !difference.is_empty() {
+            return Err(RunnerError::NoBuiltinForInstance(
+                difference
+                    .iter()
+                    .map(|x| (&(**x).clone()).clone())
+                    .collect(),
+                self.layout._name.clone(),
+            ));
+        }
+
         vm.builtin_runners = builtin_runners;
         Ok(())
     }

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -177,14 +177,10 @@ impl CairoRunner {
         let program_builtins: HashSet<&String> =
             self.program.builtins.iter().collect::<HashSet<&String>>();
         // Get the builtins that belong to the program but weren't inserted (those who dont belong to the instance)
-        let difference: HashSet<&&String> =
-            program_builtins.difference(&inserted_builtins).collect();
-        if !difference.is_empty() {
+        let mut difference = program_builtins.difference(&inserted_builtins).peekable();
+        if difference.peek().is_some() {
             return Err(RunnerError::NoBuiltinForInstance(
-                difference
-                    .iter()
-                    .map(|x| (&(**x).clone()).clone())
-                    .collect(),
+                difference.map(|x| (&(**x).clone()).clone()).collect(),
                 self.layout._name.clone(),
             ));
         }


### PR DESCRIPTION
When there are builtins used in the compiled program but the layout chosen doesn't include them, these builtins are not added to the VM, but no error is shown, leading to unpredictable errors later on.
This PR adds a check on CairoRunner::initialize_builtins() that checks this and returns an informative error message in that case
