### PR TITLE
Iai

### DIFF
--- a/.github/workflows/iai_main.yml
+++ b/.github/workflows/iai_main.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Install Rust

--- a/.github/workflows/iai_main.yml
+++ b/.github/workflows/iai_main.yml
@@ -26,13 +26,14 @@ jobs:
     - uses: actions/checkout@v3
     # NB: this should never result in a hit, but rather just populate for PRs
     - name: Initialize IAI cache for ${{ github.event.push.payload.head }}
-    - uses: actions/cache@v3
+      uses: actions/cache@v3
       id: cache-iai-results
-      path: |
-        target/iai/
-        !target/iai/**.old
-      key: ${{ runner.os }}-iai-benchmark-cache-${{ github.event.push.payload.head }}
-      restore-keys: |
-        ${{ runner.os }}-iai-benchmark-cache-
+      with:
+        path: |
+          target/iai/
+          !target/iai/**.old
+        key: ${{ runner.os }}-iai-benchmark-cache-${{ github.event.push.payload.head }}
+        restore-keys: |
+          ${{ runner.os }}-iai-benchmark-cache-
     - name: Run iai benchmarks
       run: make iai-benchmark-action

--- a/.github/workflows/iai_main.yml
+++ b/.github/workflows/iai_main.yml
@@ -25,14 +25,14 @@ jobs:
         sudo apt install -y valgrind
     - uses: actions/checkout@v3
     # NB: this should never result in a hit, but rather just populate for PRs
-    - name: Initialize IAI cache for ${{ github.event.push.payload.head }}
+    - name: Initialize IAI cache for ${{ github.event.push.head.sha }}
       uses: actions/cache@v3
       id: cache-iai-results
       with:
         path: |
           target/iai/
           !target/iai/**.old
-        key: ${{ runner.os }}-iai-benchmark-cache-${{ github.event.push.payload.head }}
+        key: ${{ runner.os }}-iai-benchmark-cache-${{ github.event.push.head.sha }}
         restore-keys: |
           ${{ runner.os }}-iai-benchmark-cache-
     - name: Run iai benchmarks

--- a/.github/workflows/iai_main.yml
+++ b/.github/workflows/iai_main.yml
@@ -21,8 +21,8 @@ jobs:
     - name: Install test dependencies
       run: |
         pip install ecdsa fastecdsa sympy cairo-lang==0.9.1
-        apt update
-        apt install -y valgrind
+        sudo apt update
+        sudo apt install -y valgrind
     - uses: actions/checkout@v3
     # NB: this should never result in a hit, but rather just populate for PRs
     - name: Initialize IAI cache for ${{ github.event.push.payload.head }}

--- a/.github/workflows/iai_main.yml
+++ b/.github/workflows/iai_main.yml
@@ -11,6 +11,10 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install Rust
       uses: actions-rs/toolchain@v1
+      with:
+          toolchain: 1.61.0
+          override: true
+          profile: minimal
     - name: Python3 Build
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/iai_main.yml
+++ b/.github/workflows/iai_main.yml
@@ -8,9 +8,9 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
+    - uses: actions/checkout@v3
     - name: Install Rust
       uses: actions-rs/toolchain@v1
-    - uses: actions/checkout@v3
     - name: Python3 Build
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/iai_main.yml
+++ b/.github/workflows/iai_main.yml
@@ -1,0 +1,21 @@
+name: iai benchmarks
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+    - uses: actions/checkout@v3
+    - name: Python3 Build
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
+    - name: Install test dependencies
+      run: pip install ecdsa fastecdsa sympy cairo-lang==0.9.1
+    - name: Run iai benchmarks
+      run: make iai-benchmark-action

--- a/.github/workflows/iai_main.yml
+++ b/.github/workflows/iai_main.yml
@@ -5,10 +5,9 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  cache-iai-results:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
@@ -21,5 +20,16 @@ jobs:
         python-version: '3.9'
     - name: Install test dependencies
       run: pip install ecdsa fastecdsa sympy cairo-lang==0.9.1
+    - uses: actions/checkout@v3
+    # NB: this should never result in a hit, but rather just populate for PRs
+    - name: Initialize IAI cache for ${{ github.event.push.payload.head }}
+    - uses: actions/cache@v3
+      id: cache-iai-results
+      path: |
+        target/iai/
+        !target/iai/**.old
+      key: ${{ runner.os }}-iai-benchmark-cache-${{ github.event.push.payload.head }}
+      restore-keys: |
+        ${{ runner.os }}-iai-benchmark-cache-
     - name: Run iai benchmarks
       run: make iai-benchmark-action

--- a/.github/workflows/iai_main.yml
+++ b/.github/workflows/iai_main.yml
@@ -19,7 +19,10 @@ jobs:
       with:
         python-version: '3.9'
     - name: Install test dependencies
-      run: pip install ecdsa fastecdsa sympy cairo-lang==0.9.1
+      run: |
+        pip install ecdsa fastecdsa sympy cairo-lang==0.9.1
+        apt update
+        apt install -y valgrind
     - uses: actions/checkout@v3
     # NB: this should never result in a hit, but rather just populate for PRs
     - name: Initialize IAI cache for ${{ github.event.push.payload.head }}

--- a/.github/workflows/iai_main.yml
+++ b/.github/workflows/iai_main.yml
@@ -36,4 +36,5 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-iai-benchmark-cache-
     - name: Run iai benchmarks
+      if: ${{ steps.cache-iai-results.outputs.cache-hit != 'true' }}
       run: make iai-benchmark-action

--- a/.github/workflows/iai_pr.yml
+++ b/.github/workflows/iai_pr.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Install Rust

--- a/.github/workflows/iai_pr.yml
+++ b/.github/workflows/iai_pr.yml
@@ -25,19 +25,20 @@ jobs:
         apt install -y valgrind
     - uses: actions/checkout@v3
     - name: Initialize IAI cache for ${{ github.event.push.payload.head }}
-    - uses: actions/cache@v3
+      uses: actions/cache@v3
       id: cache-iai-results
-      path: |
-        target/iai/
-        !target/iai/**.old
-      key: ${{ runner.os }}-iai-benchmark-cache-${{ github.event.push.payload.head }}
-      restore-keys: |
-        ${{ runner.os }}-iai-benchmark-cache-
-    - if: ${{ steps.cache-iai-results.outputs.cache-hit != 'true' }}
+      with:
+        path: |
+          target/iai/
+          !target/iai/**.old
+        key: ${{ runner.os }}-iai-benchmark-cache-${{ github.event.push.payload.head }}
+        restore-keys: |
+          ${{ runner.os }}-iai-benchmark-cache-
     - name: Run iai benchmarks
+      if: ${{ steps.cache-iai-results.outputs.cache-hit != 'true' }}
       run: make iai-benchmark-action
   run-iai-benchmark:
-    depends: fetch-iai-results
+    needs: fetch-iai-results
     runs-on: ubuntu-22.04
     steps:
     - name: Install Rust
@@ -57,13 +58,14 @@ jobs:
         apt install -y valgrind
     - uses: actions/checkout@v3
     - name: Initialize IAI cache for ${{ github.event.push.payload.head }}
-    - uses: actions/cache@v3
+      uses: actions/cache@v3
       id: cache-iai-results
-      path: |
-        target/iai/
-        !target/iai/**.old
-      key: ${{ runner.os }}-iai-benchmark-cache-${{ github.event.push.payload.head }}
-      restore-keys: |
-        ${{ runner.os }}-iai-benchmark-cache-
+      with:
+        path: |
+          target/iai/
+          !target/iai/**.old
+        key: ${{ runner.os }}-iai-benchmark-cache-${{ github.event.push.payload.head }}
+        restore-keys: |
+          ${{ runner.os }}-iai-benchmark-cache-
     - name: Run iai benchmarks
       run: make iai-benchmark-action

--- a/.github/workflows/iai_pr.yml
+++ b/.github/workflows/iai_pr.yml
@@ -5,10 +5,9 @@ on:
     branches: [ '*' ]
 
 jobs:
-  build:
+  fetch-iai-results:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
@@ -21,5 +20,44 @@ jobs:
         python-version: '3.9'
     - name: Install test dependencies
       run: pip install ecdsa fastecdsa sympy cairo-lang==0.9.1
+    - uses: actions/checkout@v3
+    - name: Initialize IAI cache for ${{ github.event.push.payload.head }}
+    - uses: actions/cache@v3
+      id: cache-iai-results
+      path: |
+        target/iai/
+        !target/iai/**.old
+      key: ${{ runner.os }}-iai-benchmark-cache-${{ github.event.push.payload.head }}
+      restore-keys: |
+        ${{ runner.os }}-iai-benchmark-cache-
+    - if: ${{ steps.cache-iai-results.outputs.cache-hit != 'true' }}
+    - name: Run iai benchmarks
+      run: make iai-benchmark-action
+  run-iai-benchmark:
+    depends: fetch-iai-results
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: 1.61.0
+          override: true
+          profile: minimal
+    - name: Python3 Build
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
+    - name: Install test dependencies
+      run: pip install ecdsa fastecdsa sympy cairo-lang==0.9.1
+    - uses: actions/checkout@v3
+    - name: Initialize IAI cache for ${{ github.event.push.payload.head }}
+    - uses: actions/cache@v3
+      id: cache-iai-results
+      path: |
+        target/iai/
+        !target/iai/**.old
+      key: ${{ runner.os }}-iai-benchmark-cache-${{ github.event.push.payload.head }}
+      restore-keys: |
+        ${{ runner.os }}-iai-benchmark-cache-
     - name: Run iai benchmarks
       run: make iai-benchmark-action

--- a/.github/workflows/iai_pr.yml
+++ b/.github/workflows/iai_pr.yml
@@ -1,8 +1,8 @@
 name: benchmark_pr 
 
-on:
-  pull_request:
-    branches: [ '*' ]
+  #on:
+  #pull_request:
+  #branches: [ '*' ]
 
 jobs:
   fetch-iai-results:

--- a/.github/workflows/iai_pr.yml
+++ b/.github/workflows/iai_pr.yml
@@ -19,7 +19,10 @@ jobs:
       with:
         python-version: '3.9'
     - name: Install test dependencies
-      run: pip install ecdsa fastecdsa sympy cairo-lang==0.9.1
+      run: |
+        pip install ecdsa fastecdsa sympy cairo-lang==0.9.1
+        apt update
+        apt install -y valgrind
     - uses: actions/checkout@v3
     - name: Initialize IAI cache for ${{ github.event.push.payload.head }}
     - uses: actions/cache@v3
@@ -48,7 +51,10 @@ jobs:
       with:
         python-version: '3.9'
     - name: Install test dependencies
-      run: pip install ecdsa fastecdsa sympy cairo-lang==0.9.1
+      run: |
+        pip install ecdsa fastecdsa sympy cairo-lang==0.9.1
+        apt update
+        apt install -y valgrind
     - uses: actions/checkout@v3
     - name: Initialize IAI cache for ${{ github.event.push.payload.head }}
     - uses: actions/cache@v3

--- a/.github/workflows/iai_pr.yml
+++ b/.github/workflows/iai_pr.yml
@@ -11,6 +11,10 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install Rust
       uses: actions-rs/toolchain@v1
+      with:
+          toolchain: 1.61.0
+          override: true
+          profile: minimal
     - name: Python3 Build
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/iai_pr.yml
+++ b/.github/workflows/iai_pr.yml
@@ -8,9 +8,9 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
+    - uses: actions/checkout@v3
     - name: Install Rust
       uses: actions-rs/toolchain@v1
-    - uses: actions/checkout@v3
     - name: Python3 Build
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/iai_pr.yml
+++ b/.github/workflows/iai_pr.yml
@@ -21,8 +21,8 @@ jobs:
     - name: Install test dependencies
       run: |
         pip install ecdsa fastecdsa sympy cairo-lang==0.9.1
-        apt update
-        apt install -y valgrind
+        sudo apt update
+        sudo apt install -y valgrind
     - uses: actions/checkout@v3
     - name: Initialize IAI cache for ${{ github.event.push.payload.head }}
       uses: actions/cache@v3
@@ -54,8 +54,8 @@ jobs:
     - name: Install test dependencies
       run: |
         pip install ecdsa fastecdsa sympy cairo-lang==0.9.1
-        apt update
-        apt install -y valgrind
+        sudo apt update
+        sudo apt install -y valgrind
     - uses: actions/checkout@v3
     - name: Initialize IAI cache for ${{ github.event.push.payload.head }}
       uses: actions/cache@v3

--- a/.github/workflows/iai_pr.yml
+++ b/.github/workflows/iai_pr.yml
@@ -24,6 +24,8 @@ jobs:
         sudo apt update
         sudo apt install -y valgrind
     - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.base.sha }}
     - name: Initialize IAI cache for ${{ github.event.pull_request.base.sha }}
       uses: actions/cache@v3
       id: cache-iai-results

--- a/.github/workflows/iai_pr.yml
+++ b/.github/workflows/iai_pr.yml
@@ -1,0 +1,21 @@
+name: benchmark_pr 
+
+on:
+  pull_request:
+    branches: [ '*' ]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+    - uses: actions/checkout@v3
+    - name: Python3 Build
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
+    - name: Install test dependencies
+      run: pip install ecdsa fastecdsa sympy cairo-lang==0.9.1
+    - name: Run iai benchmarks
+      run: make iai-benchmark-action

--- a/.github/workflows/iai_pr.yml
+++ b/.github/workflows/iai_pr.yml
@@ -24,14 +24,14 @@ jobs:
         sudo apt update
         sudo apt install -y valgrind
     - uses: actions/checkout@v3
-    - name: Initialize IAI cache for ${{ github.event.push.payload.head }}
+    - name: Initialize IAI cache for ${{ github.event.pull_request.base.sha }}
       uses: actions/cache@v3
       id: cache-iai-results
       with:
         path: |
           target/iai/
           !target/iai/**.old
-        key: ${{ runner.os }}-iai-benchmark-cache-${{ github.event.push.payload.head }}
+        key: ${{ runner.os }}-iai-benchmark-cache-${{ github.event.pull_request.base.sha }}
         restore-keys: |
           ${{ runner.os }}-iai-benchmark-cache-
     - name: Run iai benchmarks
@@ -57,14 +57,14 @@ jobs:
         sudo apt update
         sudo apt install -y valgrind
     - uses: actions/checkout@v3
-    - name: Initialize IAI cache for ${{ github.event.push.payload.head }}
+    - name: Initialize IAI cache for ${{ github.event.pull_request.base.sha }}
       uses: actions/cache@v3
       id: cache-iai-results
       with:
         path: |
           target/iai/
           !target/iai/**.old
-        key: ${{ runner.os }}-iai-benchmark-cache-${{ github.event.push.payload.head }}
+        key: ${{ runner.os }}-iai-benchmark-cache-${{ github.event.pull_request.base.sha }}
         restore-keys: |
           ${{ runner.os }}-iai-benchmark-cache-
     - name: Run iai benchmarks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,6 +139,7 @@ dependencies = [
  "criterion",
  "generic-array",
  "hex",
+ "iai",
  "keccak",
  "lazy_static",
  "mimalloc",
@@ -504,6 +505,12 @@ dependencies = [
  "crypto-mac",
  "digest 0.9.0",
 ]
+
+[[package]]
+name = "iai"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71a816c97c42258aa5834d07590b718b4c9a598944cd39a52dc25b351185d678"
 
 [[package]]
 name = "indexmap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,12 +35,20 @@ generic-array = "0.14.6"
 keccak = "0.1.2"
 parse-hyperlinks = { path = "./deps/parse-hyperlinks" }
 
+[dev-dependencies]
+iai = "0.1"
+
 [dev-dependencies.rusty-hook]
 version = "0.11"
 
 [dev-dependencies.criterion]
 version = "0.3"
 features = ["html_reports"]
+
+[[bench]]
+path = "bench/iai_benchmark.rs"
+name = "iai_benchmark"
+harness = false
 
 [[bench]]
 path = "bench/criterion_benchmark.rs"

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,9 @@ benchmark: $(COMPILED_BENCHES)
 benchmark-action: $(COMPILED_BENCHES)
 	cargo bench --bench criterion_benchmark -- --output-format bencher |sed 1d | tee output.txt
 
+iai-benchmark-action: $(COMPILED_BENCHES)
+	cargo bench --bench iai_benchmark
+
 flamegraph:
 	cargo flamegraph --root --bench criterion_benchmark -- --bench
 

--- a/bench/iai_benchmark.rs
+++ b/bench/iai_benchmark.rs
@@ -1,0 +1,129 @@
+use std::path::Path;
+
+use cairo_rs::{
+    cairo_run::cairo_run,
+    hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor,
+    vm::errors::cairo_run_errors::CairoRunError, vm::runners::cairo_runner::CairoRunner,
+};
+use iai::{black_box, main};
+
+// TODO: expand_benchmark_program! macro
+fn iai_benchmark_cairo_run(path: &Path) -> Result<CairoRunner, CairoRunError> {
+    let hint_executor = BuiltinHintProcessor::new_empty();
+    cairo_run(
+        black_box(path),
+        "main",
+        false,
+        false,
+        "all",
+        false,
+        &hint_executor,
+    )
+}
+
+fn iai_benchmark_math() -> Result<CairoRunner, CairoRunError> {
+    iai_benchmark_cairo_run(Path::new(
+        "cairo_programs/benchmarks/math_integration_benchmark.json",
+    ))
+}
+
+fn iai_benchmark_compare_arrays_200000() -> Result<CairoRunner, CairoRunError> {
+    iai_benchmark_cairo_run(Path::new(
+        "cairo_programs/benchmarks/compare_arrays_200000.json",
+    ))
+}
+
+fn iai_benchmark_factorial_multirun() -> Result<CairoRunner, CairoRunError> {
+    iai_benchmark_cairo_run(Path::new(
+        "cairo_programs/benchmarks/factorial_multirun.json",
+    ))
+}
+
+fn iai_benchmark_fibonacci_1000_multirun() -> Result<CairoRunner, CairoRunError> {
+    iai_benchmark_cairo_run(Path::new(
+        "cairo_programs/benchmarks/fibonacci_1000_multirun.json",
+    ))
+}
+
+fn iai_benchmark_integration_builtins() -> Result<CairoRunner, CairoRunError> {
+    iai_benchmark_cairo_run(Path::new(
+        "cairo_programs/benchmarks/integration_builtins.json",
+    ))
+}
+
+fn iai_benchmark_linear_search() -> Result<CairoRunner, CairoRunError> {
+    iai_benchmark_cairo_run(Path::new("cairo_programs/benchmarks/linear_search.json"))
+}
+
+fn iai_benchmark_keccak_integration_benchmark() -> Result<CairoRunner, CairoRunError> {
+    iai_benchmark_cairo_run(Path::new(
+        "cairo_programs/benchmarks/keccak_integration_benchmark.json",
+    ))
+}
+
+fn iai_benchmark_secp_integration_benchmark() -> Result<CairoRunner, CairoRunError> {
+    iai_benchmark_cairo_run(Path::new(
+        "cairo_programs/benchmarks/secp_integration_benchmark.json",
+    ))
+}
+
+fn iai_benchmark_blake2s_integration_benchmark() -> Result<CairoRunner, CairoRunError> {
+    iai_benchmark_cairo_run(Path::new(
+        "cairo_programs/benchmarks/blake2s_integration_benchmark.json",
+    ))
+}
+
+fn iai_benchmark_dict_integration_benchmark() -> Result<CairoRunner, CairoRunError> {
+    iai_benchmark_cairo_run(Path::new(
+        "cairo_programs/benchmarks/dict_integration_benchmark.json",
+    ))
+}
+
+fn iai_benchmark_memory_integration_benchmark() -> Result<CairoRunner, CairoRunError> {
+    iai_benchmark_cairo_run(Path::new(
+        "cairo_programs/benchmarks/memory_integration_benchmark.json",
+    ))
+}
+
+fn iai_benchmark_math_cmp_and_pow_integration_benchmark() -> Result<CairoRunner, CairoRunError> {
+    iai_benchmark_cairo_run(Path::new(
+        "cairo_programs/benchmarks/math_cmp_and_pow_integration_benchmark.json",
+    ))
+}
+
+fn iai_benchmark_operations_with_data_structures_benchmarks() -> Result<CairoRunner, CairoRunError>
+{
+    iai_benchmark_cairo_run(Path::new(
+        "cairo_programs/benchmarks/operations_with_data_structures_benchmarks.json",
+    ))
+}
+
+fn iai_benchmark_uint256_integration_benchmark() -> Result<CairoRunner, CairoRunError> {
+    iai_benchmark_cairo_run(Path::new(
+        "cairo_programs/benchmarks/uint256_integration_benchmark.json",
+    ))
+}
+
+fn iai_benchmark_set_integration_benchmark() -> Result<CairoRunner, CairoRunError> {
+    iai_benchmark_cairo_run(Path::new(
+        "cairo_programs/benchmarks/set_integration_benchmark.json",
+    ))
+}
+
+main!(
+    iai_benchmark_math,
+    iai_benchmark_compare_arrays_200000,
+    iai_benchmark_factorial_multirun,
+    iai_benchmark_fibonacci_1000_multirun,
+    iai_benchmark_integration_builtins,
+    iai_benchmark_linear_search,
+    iai_benchmark_keccak_integration_benchmark,
+    iai_benchmark_secp_integration_benchmark,
+    iai_benchmark_blake2s_integration_benchmark,
+    iai_benchmark_dict_integration_benchmark,
+    iai_benchmark_memory_integration_benchmark,
+    iai_benchmark_math_cmp_and_pow_integration_benchmark,
+    iai_benchmark_operations_with_data_structures_benchmarks,
+    iai_benchmark_uint256_integration_benchmark,
+    iai_benchmark_set_integration_benchmark,
+);

--- a/bench/iai_benchmark.rs
+++ b/bench/iai_benchmark.rs
@@ -7,123 +7,58 @@ use cairo_rs::{
 };
 use iai::{black_box, main};
 
-// TODO: expand_benchmark_program! macro
-fn iai_benchmark_cairo_run(path: &Path) -> Result<CairoRunner, CairoRunError> {
-    let hint_executor = BuiltinHintProcessor::new_empty();
-    cairo_run(
-        black_box(path),
-        "main",
-        false,
-        false,
-        "all",
-        false,
-        &hint_executor,
-    )
+macro_rules! iai_bench_expand_prog {
+    ($val: ident) => {
+        fn $val() -> Result<CairoRunner, CairoRunError> {
+            let hint_executor = BuiltinHintProcessor::new_empty();
+            let path = Path::new(concat!(
+                "cairo_programs/benchmarks/",
+                stringify!($val),
+                ".json"
+            ));
+            cairo_run(
+                black_box(path),
+                "main",
+                false,
+                false,
+                "all",
+                false,
+                &hint_executor,
+            )
+        }
+    };
 }
 
-fn iai_benchmark_math() -> Result<CairoRunner, CairoRunError> {
-    iai_benchmark_cairo_run(Path::new(
-        "cairo_programs/benchmarks/math_integration_benchmark.json",
-    ))
-}
-
-fn iai_benchmark_compare_arrays_200000() -> Result<CairoRunner, CairoRunError> {
-    iai_benchmark_cairo_run(Path::new(
-        "cairo_programs/benchmarks/compare_arrays_200000.json",
-    ))
-}
-
-fn iai_benchmark_factorial_multirun() -> Result<CairoRunner, CairoRunError> {
-    iai_benchmark_cairo_run(Path::new(
-        "cairo_programs/benchmarks/factorial_multirun.json",
-    ))
-}
-
-fn iai_benchmark_fibonacci_1000_multirun() -> Result<CairoRunner, CairoRunError> {
-    iai_benchmark_cairo_run(Path::new(
-        "cairo_programs/benchmarks/fibonacci_1000_multirun.json",
-    ))
-}
-
-fn iai_benchmark_integration_builtins() -> Result<CairoRunner, CairoRunError> {
-    iai_benchmark_cairo_run(Path::new(
-        "cairo_programs/benchmarks/integration_builtins.json",
-    ))
-}
-
-fn iai_benchmark_linear_search() -> Result<CairoRunner, CairoRunError> {
-    iai_benchmark_cairo_run(Path::new("cairo_programs/benchmarks/linear_search.json"))
-}
-
-fn iai_benchmark_keccak_integration_benchmark() -> Result<CairoRunner, CairoRunError> {
-    iai_benchmark_cairo_run(Path::new(
-        "cairo_programs/benchmarks/keccak_integration_benchmark.json",
-    ))
-}
-
-fn iai_benchmark_secp_integration_benchmark() -> Result<CairoRunner, CairoRunError> {
-    iai_benchmark_cairo_run(Path::new(
-        "cairo_programs/benchmarks/secp_integration_benchmark.json",
-    ))
-}
-
-fn iai_benchmark_blake2s_integration_benchmark() -> Result<CairoRunner, CairoRunError> {
-    iai_benchmark_cairo_run(Path::new(
-        "cairo_programs/benchmarks/blake2s_integration_benchmark.json",
-    ))
-}
-
-fn iai_benchmark_dict_integration_benchmark() -> Result<CairoRunner, CairoRunError> {
-    iai_benchmark_cairo_run(Path::new(
-        "cairo_programs/benchmarks/dict_integration_benchmark.json",
-    ))
-}
-
-fn iai_benchmark_memory_integration_benchmark() -> Result<CairoRunner, CairoRunError> {
-    iai_benchmark_cairo_run(Path::new(
-        "cairo_programs/benchmarks/memory_integration_benchmark.json",
-    ))
-}
-
-fn iai_benchmark_math_cmp_and_pow_integration_benchmark() -> Result<CairoRunner, CairoRunError> {
-    iai_benchmark_cairo_run(Path::new(
-        "cairo_programs/benchmarks/math_cmp_and_pow_integration_benchmark.json",
-    ))
-}
-
-fn iai_benchmark_operations_with_data_structures_benchmarks() -> Result<CairoRunner, CairoRunError>
-{
-    iai_benchmark_cairo_run(Path::new(
-        "cairo_programs/benchmarks/operations_with_data_structures_benchmarks.json",
-    ))
-}
-
-fn iai_benchmark_uint256_integration_benchmark() -> Result<CairoRunner, CairoRunError> {
-    iai_benchmark_cairo_run(Path::new(
-        "cairo_programs/benchmarks/uint256_integration_benchmark.json",
-    ))
-}
-
-fn iai_benchmark_set_integration_benchmark() -> Result<CairoRunner, CairoRunError> {
-    iai_benchmark_cairo_run(Path::new(
-        "cairo_programs/benchmarks/set_integration_benchmark.json",
-    ))
-}
+iai_bench_expand_prog! {math_integration_benchmark}
+iai_bench_expand_prog! {compare_arrays_200000}
+iai_bench_expand_prog! {factorial_multirun}
+iai_bench_expand_prog! {fibonacci_1000_multirun}
+iai_bench_expand_prog! {integration_builtins}
+iai_bench_expand_prog! {linear_search}
+iai_bench_expand_prog! {keccak_integration_benchmark}
+iai_bench_expand_prog! {secp_integration_benchmark}
+iai_bench_expand_prog! {blake2s_integration_benchmark}
+iai_bench_expand_prog! {dict_integration_benchmark}
+iai_bench_expand_prog! {memory_integration_benchmark}
+iai_bench_expand_prog! {math_cmp_and_pow_integration_benchmark}
+iai_bench_expand_prog! {operations_with_data_structures_benchmarks}
+iai_bench_expand_prog! {uint256_integration_benchmark}
+iai_bench_expand_prog! {set_integration_benchmark}
 
 main!(
-    iai_benchmark_math,
-    iai_benchmark_compare_arrays_200000,
-    iai_benchmark_factorial_multirun,
-    iai_benchmark_fibonacci_1000_multirun,
-    iai_benchmark_integration_builtins,
-    iai_benchmark_linear_search,
-    iai_benchmark_keccak_integration_benchmark,
-    iai_benchmark_secp_integration_benchmark,
-    iai_benchmark_blake2s_integration_benchmark,
-    iai_benchmark_dict_integration_benchmark,
-    iai_benchmark_memory_integration_benchmark,
-    iai_benchmark_math_cmp_and_pow_integration_benchmark,
-    iai_benchmark_operations_with_data_structures_benchmarks,
-    iai_benchmark_uint256_integration_benchmark,
-    iai_benchmark_set_integration_benchmark,
+    math_integration_benchmark,
+    compare_arrays_200000,
+    factorial_multirun,
+    fibonacci_1000_multirun,
+    integration_builtins,
+    linear_search,
+    keccak_integration_benchmark,
+    secp_integration_benchmark,
+    blake2s_integration_benchmark,
+    dict_integration_benchmark,
+    memory_integration_benchmark,
+    math_cmp_and_pow_integration_benchmark,
+    operations_with_data_structures_benchmarks,
+    uint256_integration_benchmark,
+    set_integration_benchmark,
 );

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,4 @@
 [toolchain]
+profile = "minimal"
 channel = "1.61.0"
-components = ["rust-src"]
+components = ["rustfmt", "clippy"]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-profile = "minimal"
 channel = "1.61.0"
 components = ["rustfmt", "clippy"]
+profile = "minimal"


### PR DESCRIPTION
# Implement IAI benchmarks

Running Criterion on the CI gives unstable results and is also quite slow. Further, we're comparing against __whatever got benchmarked last__ rather than the base of the PR. Proper comparison requires both running against base and against head.
IAI gives stable results because it's a single run on top of a Valgrind-emulated CPU and measures cycles and cache hits instead of wall time, so it's more appropriate for looking for regressions.
This PR includes an initial implementation with workflows that leverage caches for faster execution and compares runs for the base commit and the head commit. Typically the base commit will belong to the main branch, but that's not necessarily always the case.
There's also one job that will run on pushes to the main branch.

The PR workflow has been tested but is currently disabled, as it needs first to run on main and main doesn't yet have this support. Once merged, a different PR should enable it and take advantage of the push workflow having already populated the cache.

For now one needs to manually check the output, as we still need a script that processes the text output to:
- Generate alerts/issues when `main` regresses more than a given threshold;
- Generate alerts/comments in the PR when a given PR regresses more than a given threshold;
- Possibly block the merge in the latter case.