### PR TITLE
Modify `Program::from_*()` to make the entrypoint optional.

### DIFF
--- a/src/cairo_run.rs
+++ b/src/cairo_run.rs
@@ -18,7 +18,7 @@ pub fn cairo_run(
     proof_mode: bool,
     hint_executor: &dyn HintProcessor,
 ) -> Result<CairoRunner, CairoRunError> {
-    let program = match Program::from_file(path, entrypoint) {
+    let program = match Program::from_file(path, Some(entrypoint)) {
         Ok(program) => program,
         Err(error) => return Err(CairoRunError::Program(error)),
     };
@@ -143,7 +143,8 @@ mod tests {
         program_path: &Path,
         hint_processor: &dyn HintProcessor,
     ) -> Result<(CairoRunner, VirtualMachine), CairoRunError> {
-        let program = Program::from_file(program_path, "main").map_err(CairoRunError::Program)?;
+        let program =
+            Program::from_file(program_path, Some("main")).map_err(CairoRunError::Program)?;
 
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!(true);
@@ -161,7 +162,7 @@ mod tests {
     #[test]
     fn cairo_run_custom_entry_point() {
         let program_path = Path::new("cairo_programs/not_main.json");
-        let program = Program::from_file(program_path, "not_main").unwrap();
+        let program = Program::from_file(program_path, Some("not_main")).unwrap();
         let mut vm = vm!();
         let hint_processor = BuiltinHintProcessor::new_empty();
         let mut cairo_runner = cairo_runner!(program);
@@ -306,7 +307,7 @@ mod tests {
     #[test]
     fn run_with_no_trace() {
         let program_path = Path::new("cairo_programs/struct.json");
-        let program = Program::from_file(program_path, "main").unwrap();
+        let program = Program::from_file(program_path, Some("main")).unwrap();
         let hint_processor = BuiltinHintProcessor::new_empty();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();

--- a/src/types/program.rs
+++ b/src/types/program.rs
@@ -24,14 +24,17 @@ pub struct Program {
 }
 
 impl Program {
-    pub fn from_file(path: &Path, entrypoint: &str) -> Result<Program, ProgramError> {
+    pub fn from_file(path: &Path, entrypoint: Option<&str>) -> Result<Program, ProgramError> {
         let file = File::open(path)?;
         let reader = BufReader::new(file);
 
         deserialize_program(reader, entrypoint)
     }
 
-    pub fn from_reader(reader: impl Read, entrypoint: &str) -> Result<Program, ProgramError> {
+    pub fn from_reader(
+        reader: impl Read,
+        entrypoint: Option<&str>,
+    ) -> Result<Program, ProgramError> {
         deserialize_program(reader, entrypoint)
     }
 }
@@ -64,7 +67,7 @@ mod tests {
     fn deserialize_program_test() {
         let program: Program = Program::from_file(
             Path::new("cairo_programs/manually_compiled/valid_program_a.json"),
-            "main",
+            Some("main"),
         )
         .expect("Failed to deserialize program");
 
@@ -145,11 +148,97 @@ mod tests {
         assert_eq!(program.identifiers, identifiers);
     }
 
+    /// Deserialize a program without an entrypoint.
+    #[test]
+    fn deserialize_program_without_entrypoint_test() {
+        let program: Program = Program::from_file(
+            Path::new("cairo_programs/manually_compiled/valid_program_a.json"),
+            None,
+        )
+        .expect("Failed to deserialize program");
+
+        let builtins: Vec<String> = Vec::new();
+        let data: Vec<MaybeRelocatable> = vec![
+            MaybeRelocatable::Int(BigInt::from_i64(5189976364521848832).unwrap()),
+            MaybeRelocatable::Int(BigInt::from_i64(1000).unwrap()),
+            MaybeRelocatable::Int(BigInt::from_i64(5189976364521848832).unwrap()),
+            MaybeRelocatable::Int(BigInt::from_i64(2000).unwrap()),
+            MaybeRelocatable::Int(BigInt::from_i64(5201798304953696256).unwrap()),
+            MaybeRelocatable::Int(BigInt::from_i64(2345108766317314046).unwrap()),
+        ];
+
+        let mut identifiers: HashMap<String, Identifier> = HashMap::new();
+
+        identifiers.insert(
+            String::from("__main__.main"),
+            Identifier {
+                pc: Some(0),
+                type_: Some(String::from("function")),
+                value: None,
+                full_name: None,
+                members: None,
+            },
+        );
+        identifiers.insert(
+            String::from("__main__.main.Args"),
+            Identifier {
+                pc: None,
+                type_: Some(String::from("struct")),
+                value: None,
+                full_name: Some("__main__.main.Args".to_string()),
+                members: Some(HashMap::new()),
+            },
+        );
+        identifiers.insert(
+            String::from("__main__.main.ImplicitArgs"),
+            Identifier {
+                pc: None,
+                type_: Some(String::from("struct")),
+                value: None,
+                full_name: Some("__main__.main.ImplicitArgs".to_string()),
+                members: Some(HashMap::new()),
+            },
+        );
+        identifiers.insert(
+            String::from("__main__.main.Return"),
+            Identifier {
+                pc: None,
+                type_: Some(String::from("struct")),
+                value: None,
+                full_name: Some("__main__.main.Return".to_string()),
+                members: Some(HashMap::new()),
+            },
+        );
+        identifiers.insert(
+            String::from("__main__.main.SIZEOF_LOCALS"),
+            Identifier {
+                pc: None,
+                type_: Some(String::from("const")),
+                value: Some(bigint!(0)),
+                full_name: None,
+                members: None,
+            },
+        );
+
+        assert_eq!(
+            program.prime,
+            BigInt::parse_bytes(
+                b"3618502788666131213697322783095070105623107215331596699973092056135872020481",
+                10
+            )
+            .unwrap()
+        );
+        assert_eq!(program.builtins, builtins);
+        assert_eq!(program.data, data);
+        assert_eq!(program.main, None);
+        assert_eq!(program.identifiers, identifiers);
+    }
+
     #[test]
     fn deserialize_program_constants_test() {
         let program = Program::from_file(
             Path::new("cairo_programs/manually_compiled/deserialize_constant_test.json"),
-            "main",
+            Some("main"),
         )
         .expect("Failed to deserialize program");
 

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -3128,7 +3128,7 @@ mod tests {
     #[test]
     fn run_from_entrypoint_typed_args_invalid_arg_count() {
         let program =
-            Program::from_file(Path::new("cairo_programs/not_main.json"), "main").unwrap();
+            Program::from_file(Path::new("cairo_programs/not_main.json"), Some("main")).unwrap();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         let hint_processor = BuiltinHintProcessor::new_empty();
@@ -3170,7 +3170,7 @@ mod tests {
     #[test]
     fn run_from_entrypoint_typed_args() {
         let program =
-            Program::from_file(Path::new("cairo_programs/not_main.json"), "main").unwrap();
+            Program::from_file(Path::new("cairo_programs/not_main.json"), Some("main")).unwrap();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         let hint_processor = BuiltinHintProcessor::new_empty();
@@ -3204,7 +3204,7 @@ mod tests {
     #[test]
     fn run_from_entrypoint_untyped_args() {
         let program =
-            Program::from_file(Path::new("cairo_programs/not_main.json"), "main").unwrap();
+            Program::from_file(Path::new("cairo_programs/not_main.json"), Some("main")).unwrap();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         let hint_processor = BuiltinHintProcessor::new_empty();

--- a/tests/bitwise_test.rs
+++ b/tests/bitwise_test.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 fn bitwise_integration_test() {
     let program = Program::from_file(
         Path::new("cairo_programs/bitwise_builtin_test.json"),
-        "main",
+        Some("main"),
     )
     .expect("Failed to deserialize program");
     let hint_processor = BuiltinHintProcessor::new_empty();

--- a/tests/pedersen_test.rs
+++ b/tests/pedersen_test.rs
@@ -10,7 +10,7 @@ use num_bigint::{BigInt, Sign};
 
 #[test]
 fn pedersen_integration_test() {
-    let program = Program::from_file(Path::new("cairo_programs/pedersen_test.json"), "main")
+    let program = Program::from_file(Path::new("cairo_programs/pedersen_test.json"), Some("main"))
         .expect("Failed to deserialize program");
     let hint_processor = BuiltinHintProcessor::new_empty();
     let mut cairo_runner = CairoRunner::new(&program, "all", false).unwrap();

--- a/tests/struct_test.rs
+++ b/tests/struct_test.rs
@@ -12,7 +12,7 @@ use cairo_rs::{
 
 #[test]
 fn struct_integration_test() {
-    let program = Program::from_file(Path::new("cairo_programs/struct.json"), "main")
+    let program = Program::from_file(Path::new("cairo_programs/struct.json"), Some("main"))
         .expect("Failed to deserialize program");
     let hint_processor = BuiltinHintProcessor::new_empty();
     let mut cairo_runner = CairoRunner::new(&program, "all", false).unwrap();


### PR DESCRIPTION
# Modify `Program::from_*()` to make the entrypoint optional.

## Description

Modify `Program::from_*()` to make the entrypoint optional.

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
