### PR TITLE
Increase decoder coverage

### DIFF
--- a/src/vm/decoding/decoder.rs
+++ b/src/vm/decoding/decoder.rs
@@ -185,6 +185,14 @@ mod decoder_test {
     }
 
     #[test]
+    fn decode_no_immediate_given() {
+        assert_eq!(
+            decode_instruction(0x14A7800080008000, None),
+            Err(VirtualMachineError::NoImm)
+        );
+    }
+
+    #[test]
     fn decode_flags_call_add_jmp_add_imm_fp_fp() {
         //  0|  opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg
         // 15|14 13 12|    11 10|  9  8  7|     6  5|4  3  2|      1|      0


### PR DESCRIPTION
Add a unit test to check for an instruction with no imm value given when one was expected