### PR TITLE
Expose some methods for cairo-rs-py

### DIFF
--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -269,7 +269,7 @@ impl CairoRunner {
         Ok(())
     }
 
-    fn initialize_function_entrypoint(
+    pub fn initialize_function_entrypoint(
         &mut self,
         vm: &mut VirtualMachine,
         entrypoint: usize,
@@ -349,7 +349,7 @@ impl CairoRunner {
         }
     }
 
-    fn initialize_vm(&mut self, vm: &mut VirtualMachine) -> Result<(), RunnerError> {
+    pub fn initialize_vm(&mut self, vm: &mut VirtualMachine) -> Result<(), RunnerError> {
         vm.run_context.pc = self.initial_pc.as_ref().ok_or(RunnerError::NoPC)?.clone();
         vm.run_context.ap = self.initial_ap.as_ref().ok_or(RunnerError::NoAP)?.offset;
         vm.run_context.fp = self.initial_fp.as_ref().ok_or(RunnerError::NoFP)?.offset;

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -822,6 +822,21 @@ impl VirtualMachine {
     ) -> Result<(), MemoryError> {
         self.memory.add_relocation_rule(src_ptr, dst_ptr)
     }
+
+    pub fn gen_typed_args(
+        &self,
+        args: Vec<&dyn Any>,
+    ) -> Result<Vec<MaybeRelocatable>, VirtualMachineError> {
+        self.segments.gen_typed_args(args, self)
+    }
+
+    pub fn gen_arg(
+        &mut self,
+        arg: &dyn Any,
+        prime: Option<&BigInt>,
+    ) -> Result<MaybeRelocatable, VirtualMachineError> {
+        self.segments.gen_arg(arg, prime, &mut self.memory)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR exposes some methods needed for the new implementation of the `run_from_entrypoint` method in the `PyCairoRunner`.