### PR TITLE
Ignore main branch on cancel_duplicates workflow

### DIFF
--- a/.github/workflows/cancel_duplicate.yml
+++ b/.github/workflows/cancel_duplicate.yml
@@ -3,6 +3,7 @@ name: cancel-duplicates
 on:
   pull_request:
     branches: [ '*' ]  
+    branches-ignore: main
 
 jobs:
   cancel-multiple-workflow-runs:


### PR DESCRIPTION
The cancel-duplicates workflow currently runs on all branches, as it runs on main, when more than one PR is merged during a CI cycle the newest one cancels the previous ones' actions, meaning codecov and benchmark reports won't be uploaded properly for every PR. 
This PR changes the cancel-duplicates workflow to ignore the main branch in order to prevent this from happening