### PR TITLE
Change builtin instance counter to HashMap

### DIFF
--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -774,10 +774,12 @@ impl CairoRunner {
         };
         let n_memory_holes = self.get_memory_holes(vm)?;
 
-        let mut builtin_instance_counter = Vec::with_capacity(vm.builtin_runners.len());
-        for (key, builtin_runner) in &vm.builtin_runners {
-            builtin_instance_counter
-                .push((key.to_string(), builtin_runner.get_used_instances(vm)?));
+        let mut builtin_instance_counter = HashMap::new();
+        for (builtin_name, builtin_runner) in &vm.builtin_runners {
+            builtin_instance_counter.insert(
+                builtin_name.to_string(),
+                builtin_runner.get_used_instances(vm)?,
+            );
         }
 
         Ok(ExecutionResources {
@@ -1019,7 +1021,7 @@ pub struct SegmentInfo {
 pub struct ExecutionResources {
     pub n_steps: usize,
     pub n_memory_holes: usize,
-    pub builtin_instance_counter: Vec<(String, usize)>,
+    pub builtin_instance_counter: HashMap<String, usize>,
 }
 
 #[cfg(test)]
@@ -3150,7 +3152,7 @@ mod tests {
             Ok(ExecutionResources {
                 n_steps: 0,
                 n_memory_holes: 0,
-                builtin_instance_counter: Vec::new(),
+                builtin_instance_counter: HashMap::new(),
             }),
         );
     }
@@ -3170,7 +3172,7 @@ mod tests {
             Ok(ExecutionResources {
                 n_steps: 10,
                 n_memory_holes: 0,
-                builtin_instance_counter: Vec::new(),
+                builtin_instance_counter: HashMap::new(),
             }),
         );
     }
@@ -3196,7 +3198,7 @@ mod tests {
             Ok(ExecutionResources {
                 n_steps: 10,
                 n_memory_holes: 0,
-                builtin_instance_counter: vec![("output".to_string(), 4)],
+                builtin_instance_counter: HashMap::from([("output".to_string(), 4)]),
             }),
         );
     }


### PR DESCRIPTION
# Change builtin instance counter to HashMap

## Description

This PR changes the representation of builtin instance counter from vector of tuples to a HashMap builtin_name->used_instances

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
