### PR TITLE
Mark program segment addresses as accessed in vm_initialize method

### DIFF
--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -360,6 +360,20 @@ impl CairoRunner {
         for (_, builtin) in vm.builtin_runners.iter() {
             builtin.add_validation_rule(&mut vm.memory)?;
         }
+
+        // Mark all addresses from the program segment as accessed
+        let mut initial_accessed_addresses: Vec<Relocatable> = Vec::new();
+        let prog_segment_index = self
+            .program_base
+            .as_ref()
+            .unwrap_or(&Relocatable::from((0, 0)))
+            .segment_index;
+
+        for offset in 0..self.program.data.len() {
+            initial_accessed_addresses.push(Relocatable::from((prog_segment_index, offset)));
+        }
+        vm.accessed_addresses = Some(initial_accessed_addresses);
+
         vm.memory
             .validate_existing_memory()
             .map_err(RunnerError::MemoryValidationError)
@@ -1326,6 +1340,31 @@ mod tests {
         cairo_runner.execution_base = Some(relocatable!(0, 0));
         let return_pc = cairo_runner.initialize_main_entrypoint(&mut vm).unwrap();
         assert_eq!(return_pc, Relocatable::from((1, 0)));
+    }
+
+    #[test]
+    fn initialize_vm_program_segment_accessed_addrs() {
+        // This test checks that all addresses from the program segment are marked as accessed at VM initialization.
+        // The fibonacci program has 24 instructions, so there should be 24 accessed addresses,
+        // from (0, 0) to (0, 23).
+        let program = Program::from_file(Path::new("cairo_programs/fibonacci.json"), Some("main"))
+            .expect("Call to `Program::from_file()` failed.");
+
+        let mut cairo_runner = cairo_runner!(program);
+        cairo_runner.program_base = Some(relocatable!(0, 0));
+        cairo_runner.initial_pc = Some(relocatable!(0, 1));
+        cairo_runner.initial_ap = Some(relocatable!(1, 2));
+        cairo_runner.initial_fp = Some(relocatable!(1, 2));
+
+        let mut vm = vm!();
+
+        let expected_accessed_addresses: Vec<Relocatable> = (0..24)
+            .map(|offset| Relocatable::from((0, offset)))
+            .collect();
+
+        cairo_runner.initialize_vm(&mut vm).unwrap();
+
+        assert_eq!(vm.accessed_addresses.unwrap(), expected_accessed_addresses);
     }
 
     #[test]


### PR DESCRIPTION
In the Python implementation, the program segment addresses are set as accessed in the VM initialization. See https://github.com/starkware-libs/cairo-lang/blob/f951a669e264796d53bf7a3cfd23d5bc1f6e54b8/src/starkware/cairo/lang/vm/vm_core.py#L130

This PR adds this at the `initialize_vm()` method. It is necessary because otherwise those addresses are considered memory holes when running StarkNet contracts.
