### PR TITLE
Miscellaneous fixes and improvements.

### DIFF
--- a/src/hint_processor/builtin_hint_processor/blake2s_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/blake2s_utils.rs
@@ -28,17 +28,22 @@ fn get_fixed_size_u32_array<const T: usize>(
         .map_err(|_| VirtualMachineError::FixedSizeArrayFail(T))
 }
 
-fn get_maybe_relocatable_array_from_u32(array: &Vec<u32>) -> Vec<MaybeRelocatable> {
-    let mut new_array = Vec::<MaybeRelocatable>::with_capacity(array.len());
-    for element in array {
-        new_array.push(MaybeRelocatable::from(bigint!(*element)));
-    }
-    new_array
+/// Map an iterator of u32 values into MaybeRelocatable.
+fn map_iter_u32_to_maybe_relocatable(
+    iter: impl IntoIterator<Item = u32>,
+) -> impl Iterator<Item = MaybeRelocatable> {
+    iter.into_iter()
+        .map(BigInt::from)
+        .map(MaybeRelocatable::from)
 }
 
-fn get_maybe_relocatable_array_from_bigint(array: &[BigInt]) -> Vec<MaybeRelocatable> {
-    array.iter().map(MaybeRelocatable::from).collect()
+/// Map an iterator of BigInt into values MaybeRelocatable.
+fn map_iter_bigint_to_maybe_relocatable(
+    iter: impl IntoIterator<Item = BigInt>,
+) -> impl Iterator<Item = MaybeRelocatable> {
+    iter.into_iter().map(MaybeRelocatable::from)
 }
+
 /*Helper function for the Cairo blake2s() implementation.
 Computes the blake2s compress function and fills the value in the right position.
 output_ptr should point to the middle of an instance, right after initial_state, message, t, f,
@@ -51,12 +56,12 @@ fn compute_blake2s_func(
     let h = get_fixed_size_u32_array::<8>(&vm.get_integer_range(&(output_rel.sub(26)?), 8)?)?;
     let message =
         get_fixed_size_u32_array::<16>(&vm.get_integer_range(&(output_rel.sub(18)?), 16)?)?;
-    let t = bigint_to_u32(vm.get_integer(&output_rel.sub(2)?)?.as_ref())?;
-    let f = bigint_to_u32(vm.get_integer(&output_rel.sub(1)?)?.as_ref())?;
-    let new_state =
-        get_maybe_relocatable_array_from_u32(&blake2s_compress(&h, &message, t, 0, f, 0));
+    let t = bigint_to_u32(vm.get_integer(output_rel.sub(2)?)?.as_ref())?;
+    let f = bigint_to_u32(vm.get_integer(output_rel.sub(1)?)?.as_ref())?;
+    let new_state_iter =
+        map_iter_u32_to_maybe_relocatable(blake2s_compress(&h, &message, t, 0, f, 0));
     let output_ptr = MaybeRelocatable::RelocatableValue(output_rel);
-    vm.load_data(&output_ptr, new_state)
+    vm.load_data(output_ptr, new_state_iter)
         .map_err(VirtualMachineError::MemoryError)?;
     Ok(())
 }
@@ -116,8 +121,8 @@ pub fn finalize_blake2s(
     for _ in 0..N_PACKED_INSTANCES - 1 {
         full_padding.extend_from_slice(padding);
     }
-    let data = get_maybe_relocatable_array_from_u32(&full_padding);
-    vm.load_data(&MaybeRelocatable::RelocatableValue(blake2s_ptr_end), data)
+    let data_iter = map_iter_u32_to_maybe_relocatable(full_padding);
+    vm.load_data(blake2s_ptr_end, data_iter)
         .map_err(VirtualMachineError::MemoryError)?;
     Ok(())
 }
@@ -137,8 +142,8 @@ pub fn blake2s_add_uint256(
     let data_ptr = get_ptr_from_var_name("data", vm, ids_data, ap_tracking)?;
     let low_addr = get_relocatable_from_var_name("low", vm, ids_data, ap_tracking)?;
     let high_addr = get_relocatable_from_var_name("high", vm, ids_data, ap_tracking)?;
-    let low = vm.get_integer(&low_addr)?.into_owned();
-    let high = vm.get_integer(&high_addr)?.into_owned();
+    let low = vm.get_integer(low_addr)?.into_owned();
+    let high = vm.get_integer(high_addr)?.into_owned();
     //Main logic
     //Declare constant
     const MASK: u32 = u32::MAX;
@@ -151,8 +156,8 @@ pub fn blake2s_add_uint256(
         inner_data.push((&low >> (B * i)) & &mask);
     }
     //Insert first batch of data
-    let data = get_maybe_relocatable_array_from_bigint(&inner_data);
-    vm.load_data(&MaybeRelocatable::RelocatableValue(data_ptr.clone()), data)
+    let data_iter = map_iter_bigint_to_maybe_relocatable(inner_data);
+    vm.load_data(&data_ptr, data_iter)
         .map_err(VirtualMachineError::MemoryError)?;
     //Build second batch of data
     let mut inner_data = Vec::<BigInt>::new();
@@ -160,12 +165,9 @@ pub fn blake2s_add_uint256(
         inner_data.push((&high >> (B * i)) & &mask);
     }
     //Insert second batch of data
-    let data = get_maybe_relocatable_array_from_bigint(&inner_data);
-    vm.load_data(
-        &MaybeRelocatable::RelocatableValue(data_ptr).add_usize_mod(4, None),
-        data,
-    )
-    .map_err(VirtualMachineError::MemoryError)?;
+    let data_iter = map_iter_bigint_to_maybe_relocatable(inner_data);
+    vm.load_data(data_ptr + 4, data_iter)
+        .map_err(VirtualMachineError::MemoryError)?;
     Ok(())
 }
 
@@ -184,8 +186,8 @@ pub fn blake2s_add_uint256_bigend(
     let data_ptr = get_ptr_from_var_name("data", vm, ids_data, ap_tracking)?;
     let low_addr = get_relocatable_from_var_name("low", vm, ids_data, ap_tracking)?;
     let high_addr = get_relocatable_from_var_name("high", vm, ids_data, ap_tracking)?;
-    let low = vm.get_integer(&low_addr)?.into_owned();
-    let high = vm.get_integer(&high_addr)?.into_owned();
+    let low = vm.get_integer(low_addr)?.into_owned();
+    let high = vm.get_integer(high_addr)?.into_owned();
     //Main logic
     //Declare constant
     const MASK: u32 = u32::MAX as u32;
@@ -198,8 +200,8 @@ pub fn blake2s_add_uint256_bigend(
         inner_data.push((&high >> (B * (3 - i))) & &mask);
     }
     //Insert first batch of data
-    let data = get_maybe_relocatable_array_from_bigint(&inner_data);
-    vm.load_data(&MaybeRelocatable::RelocatableValue(data_ptr.clone()), data)
+    let data_iter = map_iter_bigint_to_maybe_relocatable(inner_data);
+    vm.load_data(&data_ptr, data_iter)
         .map_err(VirtualMachineError::MemoryError)?;
     //Build second batch of data
     let mut inner_data = Vec::<BigInt>::new();
@@ -207,12 +209,9 @@ pub fn blake2s_add_uint256_bigend(
         inner_data.push((&low >> (B * (3 - i))) & &mask);
     }
     //Insert second batch of data
-    let data = get_maybe_relocatable_array_from_bigint(&inner_data);
-    vm.load_data(
-        &MaybeRelocatable::RelocatableValue(data_ptr).add_usize_mod(4, None),
-        data,
-    )
-    .map_err(VirtualMachineError::MemoryError)?;
+    let data_iter = map_iter_bigint_to_maybe_relocatable(inner_data);
+    vm.load_data(data_ptr + 4, data_iter)
+        .map_err(VirtualMachineError::MemoryError)?;
     Ok(())
 }
 

--- a/src/hint_processor/builtin_hint_processor/cairo_keccak/keccak_hints.rs
+++ b/src/hint_processor/builtin_hint_processor/cairo_keccak/keccak_hints.rs
@@ -11,7 +11,6 @@ use num_bigint::BigInt;
 use num_traits::ToPrimitive;
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::ops::Add;
 
 // Constants in package "starkware.cairo.common.cairo_keccak.keccak".
 const BYTES_IN_WORD: &str = "starkware.cairo.common.cairo_keccak.keccak.BYTES_IN_WORD";
@@ -50,7 +49,7 @@ pub fn keccak_write_args(
         .map_err(VirtualMachineError::MemoryError)?;
 
     let high_args: Vec<_> = high_args.into_iter().map(MaybeRelocatable::from).collect();
-    vm.write_arg(&inputs_ptr.add(2), &high_args)
+    vm.write_arg(inputs_ptr + 2, &high_args)
         .map_err(VirtualMachineError::MemoryError)?;
 
     Ok(())
@@ -148,7 +147,7 @@ pub fn block_permutation(
     let keccak_state_size_felts = keccak_state_size_felts.to_usize().unwrap();
     let values = vm
         .get_range(
-            &MaybeRelocatable::RelocatableValue(keccak_ptr.sub(keccak_state_size_felts)?),
+            keccak_ptr.sub(keccak_state_size_felts)?,
             keccak_state_size_felts,
         )
         .map_err(VirtualMachineError::MemoryError)?;
@@ -163,7 +162,7 @@ pub fn block_permutation(
 
     let bigint_values = u64_array_to_mayberelocatable_vec(&u64_values);
 
-    vm.write_arg(&keccak_ptr, &bigint_values)
+    vm.write_arg(keccak_ptr, &bigint_values)
         .map_err(VirtualMachineError::MemoryError)?;
 
     Ok(())
@@ -226,7 +225,7 @@ pub fn cairo_keccak_finalize(
 
     let keccak_ptr_end = get_ptr_from_var_name("keccak_ptr_end", vm, ids_data, ap_tracking)?;
 
-    vm.write_arg(&keccak_ptr_end, &padding)
+    vm.write_arg(keccak_ptr_end, &padding)
         .map_err(VirtualMachineError::MemoryError)?;
 
     Ok(())

--- a/src/hint_processor/builtin_hint_processor/find_element_hint.rs
+++ b/src/hint_processor/builtin_hint_processor/find_element_hint.rs
@@ -39,7 +39,7 @@ pub fn find_element(
     if let Some(find_element_index_value) = find_element_index {
         let find_element_index_usize = bigint_to_usize(&find_element_index_value)?;
         let found_key = vm
-            .get_integer(&(array_start + (elm_size * find_element_index_usize)))
+            .get_integer(array_start + (elm_size * find_element_index_usize))
             .map_err(|_| VirtualMachineError::KeyNotFound)?;
 
         if found_key.as_ref() != key.as_ref() {
@@ -71,7 +71,7 @@ pub fn find_element(
 
         for i in 0..n_elms_iter {
             let iter_key = vm
-                .get_integer(&(array_start.clone() + (elm_size * i as usize)))
+                .get_integer(&array_start + (elm_size * i as usize))
                 .map_err(|_| VirtualMachineError::KeyNotFound)?;
 
             if iter_key.as_ref() == key.as_ref() {
@@ -112,7 +112,7 @@ pub fn search_sorted_lower(
         }
     }
 
-    let mut array_iter = vm.get_relocatable(&rel_array_ptr)?.into_owned();
+    let mut array_iter = vm.get_relocatable(rel_array_ptr)?.into_owned();
     let n_elms_usize = n_elms.to_usize().ok_or(VirtualMachineError::KeyNotFound)?;
     let elm_size_usize = elm_size
         .to_usize()

--- a/src/hint_processor/builtin_hint_processor/hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/hint_utils.rs
@@ -44,7 +44,7 @@ pub fn get_ptr_from_var_name(
         .get(&String::from(var_name))
         .ok_or(VirtualMachineError::FailedToGetIds)?;
     if hint_reference.dereference {
-        let value = vm.get_relocatable(&var_addr)?;
+        let value = vm.get_relocatable(var_addr)?;
         if let Some(immediate) = &hint_reference.immediate {
             let modified_value = value.as_ref() + bigint_to_usize(immediate)?;
             Ok(modified_value)
@@ -133,7 +133,7 @@ mod tests {
         let ids_data = HashMap::from([("imm".to_string(), hint_ref)]);
 
         assert_eq!(
-            get_ptr_from_var_name("imm", &mut vm, &ids_data, &ApTracking::new()),
+            get_ptr_from_var_name("imm", &vm, &ids_data, &ApTracking::new()),
             Ok(relocatable!(0, 2))
         );
     }

--- a/src/hint_processor/builtin_hint_processor/keccak_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/keccak_utils.rs
@@ -7,10 +7,7 @@ use crate::{
         hint_processor_definition::HintReference,
     },
     serde::deserialize_program::ApTracking,
-    types::{
-        exec_scope::ExecutionScopes,
-        relocatable::{MaybeRelocatable, Relocatable},
-    },
+    types::{exec_scope::ExecutionScopes, relocatable::Relocatable},
     vm::{errors::vm_errors::VirtualMachineError, vm_core::VirtualMachine},
 };
 use num_bigint::{BigInt, Sign};
@@ -77,7 +74,7 @@ pub fn unsafe_keccak(
             offset: data.offset + word_i,
         };
 
-        let word = vm.get_integer(&word_addr)?;
+        let word = vm.get_integer(word_addr)?;
         let n_bytes = cmp::min(16, u64_length - byte_i);
 
         if word.is_negative() || word.as_ref() >= &bigint!(1).shl(8 * (n_bytes as u32)) {
@@ -143,24 +140,14 @@ pub fn unsafe_keccak_finalize(
 
     // in the KeccakState struct, the field `end_ptr` is the second one, so this variable should be get from
     // the memory cell contiguous to the one where KeccakState is pointing to.
-    let end_ptr = vm.get_relocatable(&Relocatable {
-        segment_index: keccak_state_ptr.segment_index,
-        offset: keccak_state_ptr.offset + 1,
-    })?;
+    let end_ptr =
+        vm.get_relocatable((keccak_state_ptr.segment_index, keccak_state_ptr.offset + 1))?;
 
-    // this is not very nice code, we should consider adding the sub() method for Relocatable's
-    let maybe_rel_start_ptr = MaybeRelocatable::RelocatableValue(start_ptr);
-    let maybe_rel_end_ptr = MaybeRelocatable::RelocatableValue(end_ptr.into_owned());
-
-    let n_elems = maybe_rel_end_ptr
-        .sub(&maybe_rel_start_ptr, vm.get_prime())?
-        .get_int_ref()?
-        .to_usize()
-        .ok_or(VirtualMachineError::BigintToUsizeFail)?;
+    let n_elems = start_ptr.distance_to(&end_ptr)?;
 
     let mut keccak_input = Vec::new();
     let range = vm
-        .get_range(&maybe_rel_start_ptr, n_elems)
+        .get_range(start_ptr, n_elems)
         .map_err(VirtualMachineError::MemoryError)?;
 
     check_no_nones_in_range(&range)?;

--- a/src/hint_processor/builtin_hint_processor/math_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/math_utils.rs
@@ -127,38 +127,34 @@ pub fn assert_not_equal(
     let a_addr = get_address_from_var_name("a", vm, ids_data, ap_tracking)?;
     let b_addr = get_address_from_var_name("b", vm, ids_data, ap_tracking)?;
     //Check that the ids are in memory
-    match (vm.get_maybe(&a_addr), vm.get_maybe(&b_addr)) {
-        (Ok(Some(maybe_rel_a)), Ok(Some(maybe_rel_b))) => {
-            let maybe_rel_a = maybe_rel_a;
-            let maybe_rel_b = maybe_rel_b;
-            match (maybe_rel_a, maybe_rel_b) {
-                (MaybeRelocatable::Int(a), MaybeRelocatable::Int(b)) => {
-                    if (&a - &b).is_multiple_of(vm.get_prime()) {
-                        return Err(VirtualMachineError::AssertNotEqualFail(
-                            MaybeRelocatable::Int(a),
-                            MaybeRelocatable::Int(b),
-                        ));
-                    };
-                    Ok(())
-                }
-                (MaybeRelocatable::RelocatableValue(a), MaybeRelocatable::RelocatableValue(b)) => {
-                    if a.segment_index != b.segment_index {
-                        return Err(VirtualMachineError::DiffIndexComp(a, b));
-                    };
-                    if a.offset == b.offset {
-                        return Err(VirtualMachineError::AssertNotEqualFail(
-                            MaybeRelocatable::RelocatableValue(a),
-                            MaybeRelocatable::RelocatableValue(b),
-                        ));
-                    };
-                    Ok(())
-                }
-                (maybe_rel_a, maybe_rel_b) => Err(VirtualMachineError::DiffTypeComparison(
-                    maybe_rel_a,
-                    maybe_rel_b,
-                )),
+    match (vm.get_maybe(a_addr), vm.get_maybe(b_addr)) {
+        (Ok(Some(maybe_rel_a)), Ok(Some(maybe_rel_b))) => match (maybe_rel_a, maybe_rel_b) {
+            (MaybeRelocatable::Int(a), MaybeRelocatable::Int(b)) => {
+                if (&a - &b).is_multiple_of(vm.get_prime()) {
+                    return Err(VirtualMachineError::AssertNotEqualFail(
+                        MaybeRelocatable::Int(a),
+                        MaybeRelocatable::Int(b),
+                    ));
+                };
+                Ok(())
             }
-        }
+            (MaybeRelocatable::RelocatableValue(a), MaybeRelocatable::RelocatableValue(b)) => {
+                if a.segment_index != b.segment_index {
+                    return Err(VirtualMachineError::DiffIndexComp(a, b));
+                };
+                if a.offset == b.offset {
+                    return Err(VirtualMachineError::AssertNotEqualFail(
+                        MaybeRelocatable::RelocatableValue(a),
+                        MaybeRelocatable::RelocatableValue(b),
+                    ));
+                };
+                Ok(())
+            }
+            (maybe_rel_a, maybe_rel_b) => Err(VirtualMachineError::DiffTypeComparison(
+                maybe_rel_a,
+                maybe_rel_b,
+            )),
+        },
         _ => Err(VirtualMachineError::FailedToGetIds),
     }
 }

--- a/src/hint_processor/builtin_hint_processor/pow_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/pow_utils.rs
@@ -19,7 +19,7 @@ pub fn pow(
     ap_tracking: &ApTracking,
 ) -> Result<(), VirtualMachineError> {
     let prev_locs_addr = get_relocatable_from_var_name("prev_locs", vm, ids_data, ap_tracking)?;
-    let prev_locs_exp = vm.get_integer(&(&prev_locs_addr + 4))?;
+    let prev_locs_exp = vm.get_integer(prev_locs_addr + 4)?;
     let locs_bit = prev_locs_exp.mod_floor(vm.get_prime()) & bigint!(1);
     insert_value_from_var_name("locs", locs_bit, vm, ids_data, ap_tracking)?;
     Ok(())

--- a/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
@@ -35,7 +35,7 @@ pub fn nondet_bigint3(
         .into_iter()
         .map(MaybeRelocatable::from)
         .collect();
-    vm.write_arg(&res_reloc, &arg)
+    vm.write_arg(res_reloc, &arg)
         .map_err(VirtualMachineError::MemoryError)?;
     Ok(())
 }
@@ -50,7 +50,7 @@ pub fn bigint_to_uint256(
 ) -> Result<(), VirtualMachineError> {
     let x_struct = get_relocatable_from_var_name("x", vm, ids_data, ap_tracking)?;
     let d0 = vm.get_integer(&x_struct)?;
-    let d1 = vm.get_integer(&(&x_struct + 1))?;
+    let d1 = vm.get_integer(x_struct + 1)?;
     let d0 = d0.as_ref();
     let d1 = d1.as_ref();
     let base_86 = constants

--- a/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
@@ -75,11 +75,11 @@ pub fn compute_doubling_slope(
 
     let (x_d0, x_d1, x_d2, y_d0, y_d1, y_d2) = (
         vm.get_integer(&point_reloc)?,
-        vm.get_integer(&(&point_reloc + 1))?,
-        vm.get_integer(&(&point_reloc + 2))?,
-        vm.get_integer(&(&point_reloc + 3))?,
-        vm.get_integer(&(&point_reloc + 4))?,
-        vm.get_integer(&(&point_reloc + 5))?,
+        vm.get_integer(&point_reloc + 1)?,
+        vm.get_integer(&point_reloc + 2)?,
+        vm.get_integer(&point_reloc + 3)?,
+        vm.get_integer(&point_reloc + 4)?,
+        vm.get_integer(point_reloc + 5)?,
     );
 
     let value = ec_double_slope(
@@ -126,11 +126,11 @@ pub fn compute_slope(
 
     let (point0_x_d0, point0_x_d1, point0_x_d2, point0_y_d0, point0_y_d1, point0_y_d2) = (
         vm.get_integer(&point0_reloc)?,
-        vm.get_integer(&(&point0_reloc + 1))?,
-        vm.get_integer(&(&point0_reloc + 2))?,
-        vm.get_integer(&(&point0_reloc + 3))?,
-        vm.get_integer(&(&point0_reloc + 4))?,
-        vm.get_integer(&(&point0_reloc + 5))?,
+        vm.get_integer(&point0_reloc + 1)?,
+        vm.get_integer(&point0_reloc + 2)?,
+        vm.get_integer(&point0_reloc + 3)?,
+        vm.get_integer(&point0_reloc + 4)?,
+        vm.get_integer(point0_reloc + 5)?,
     );
 
     //ids.point1
@@ -138,11 +138,11 @@ pub fn compute_slope(
 
     let (point1_x_d0, point1_x_d1, point1_x_d2, point1_y_d0, point1_y_d1, point1_y_d2) = (
         vm.get_integer(&point1_reloc)?,
-        vm.get_integer(&(&point1_reloc + 1))?,
-        vm.get_integer(&(&point1_reloc + 2))?,
-        vm.get_integer(&(&point1_reloc + 3))?,
-        vm.get_integer(&(&point1_reloc + 4))?,
-        vm.get_integer(&(&point1_reloc + 5))?,
+        vm.get_integer(&point1_reloc + 1)?,
+        vm.get_integer(&point1_reloc + 2)?,
+        vm.get_integer(&point1_reloc + 3)?,
+        vm.get_integer(&point1_reloc + 4)?,
+        vm.get_integer(point1_reloc + 5)?,
     );
 
     let value = line_slope(
@@ -210,8 +210,8 @@ pub fn ec_double_assign_new_x(
 
     let (slope_d0, slope_d1, slope_d2) = (
         vm.get_integer(&slope_reloc)?,
-        vm.get_integer(&(&slope_reloc + 1))?,
-        vm.get_integer(&(&slope_reloc + 2))?,
+        vm.get_integer(&slope_reloc + 1)?,
+        vm.get_integer(slope_reloc + 2)?,
     );
 
     //ids.point
@@ -219,11 +219,11 @@ pub fn ec_double_assign_new_x(
 
     let (x_d0, x_d1, x_d2, y_d0, y_d1, y_d2) = (
         vm.get_integer(&point_reloc)?,
-        vm.get_integer(&(&point_reloc + 1))?,
-        vm.get_integer(&(&point_reloc + 2))?,
-        vm.get_integer(&(&point_reloc + 3))?,
-        vm.get_integer(&(&point_reloc + 4))?,
-        vm.get_integer(&(&point_reloc + 5))?,
+        vm.get_integer(&point_reloc + 1)?,
+        vm.get_integer(&point_reloc + 2)?,
+        vm.get_integer(&point_reloc + 3)?,
+        vm.get_integer(&point_reloc + 4)?,
+        vm.get_integer(point_reloc + 5)?,
     );
 
     let slope = pack(
@@ -303,8 +303,8 @@ pub fn fast_ec_add_assign_new_x(
 
     let (slope_d0, slope_d1, slope_d2) = (
         vm.get_integer(&slope_reloc)?,
-        vm.get_integer(&(&slope_reloc + 1))?,
-        vm.get_integer(&(&slope_reloc + 2))?,
+        vm.get_integer(&slope_reloc + 1)?,
+        vm.get_integer(slope_reloc + 2)?,
     );
 
     //ids.point0
@@ -312,11 +312,11 @@ pub fn fast_ec_add_assign_new_x(
 
     let (point0_x_d0, point0_x_d1, point0_x_d2, point0_y_d0, point0_y_d1, point0_y_d2) = (
         vm.get_integer(&point0_reloc)?,
-        vm.get_integer(&(&point0_reloc + 1))?,
-        vm.get_integer(&(&point0_reloc + 2))?,
-        vm.get_integer(&(&point0_reloc + 3))?,
-        vm.get_integer(&(&point0_reloc + 4))?,
-        vm.get_integer(&(&point0_reloc + 5))?,
+        vm.get_integer(&point0_reloc + 1)?,
+        vm.get_integer(&point0_reloc + 2)?,
+        vm.get_integer(&point0_reloc + 3)?,
+        vm.get_integer(&point0_reloc + 4)?,
+        vm.get_integer(point0_reloc + 5)?,
     );
 
     //ids.point1.x
@@ -324,8 +324,8 @@ pub fn fast_ec_add_assign_new_x(
 
     let (point1_x_d0, point1_x_d1, point1_x_d2) = (
         vm.get_integer(&point1_reloc)?,
-        vm.get_integer(&(&point1_reloc + 1))?,
-        vm.get_integer(&(&point1_reloc + 2))?,
+        vm.get_integer(&point1_reloc + 1)?,
+        vm.get_integer(point1_reloc + 2)?,
     );
 
     let slope = pack(

--- a/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
@@ -77,8 +77,8 @@ pub fn pack_from_var_name(
     let to_pack = get_relocatable_from_var_name(name, vm, ids_data, ap_tracking)?;
 
     let d0 = vm.get_integer(&to_pack)?;
-    let d1 = vm.get_integer(&(&to_pack + 1))?;
-    let d2 = vm.get_integer(&(&to_pack + 2))?;
+    let d1 = vm.get_integer(&to_pack + 1)?;
+    let d2 = vm.get_integer(to_pack + 2)?;
 
     Ok(pack(d0.as_ref(), d1.as_ref(), d2.as_ref(), vm.get_prime()))
 }
@@ -88,8 +88,8 @@ pub fn pack_from_relocatable(
     vm: &VirtualMachine,
 ) -> Result<BigInt, VirtualMachineError> {
     let d0 = vm.get_integer(&rel)?;
-    let d1 = vm.get_integer(&(&rel + 1))?;
-    let d2 = vm.get_integer(&(&rel + 2))?;
+    let d1 = vm.get_integer(&rel + 1)?;
+    let d2 = vm.get_integer(rel + 2)?;
 
     Ok(pack(d0.as_ref(), d1.as_ref(), d2.as_ref(), vm.get_prime()))
 }

--- a/src/hint_processor/builtin_hint_processor/set.rs
+++ b/src/hint_processor/builtin_hint_processor/set.rs
@@ -38,7 +38,7 @@ pub fn set_add(
         ));
     }
 
-    let range_limit = set_end_ptr.sub_rel(&set_ptr)?;
+    let range_limit = set_ptr.distance_to(&set_end_ptr)?;
 
     for i in (0..range_limit).step_by(elm_size) {
         let set_iter = vm

--- a/src/hint_processor/builtin_hint_processor/sha256_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/sha256_utils.rs
@@ -54,7 +54,7 @@ pub fn sha256_main(
     let mut message: Vec<u8> = Vec::with_capacity(4 * SHA256_INPUT_CHUNK_SIZE_FELTS);
 
     for i in 0..SHA256_INPUT_CHUNK_SIZE_FELTS {
-        let input_element = vm.get_integer(&(&input_ptr + i))?;
+        let input_element = vm.get_integer(&input_ptr + i)?;
         let bytes = bigint_to_u32(input_element.as_ref())?.to_be_bytes();
         message.extend(bytes);
     }
@@ -71,7 +71,7 @@ pub fn sha256_main(
 
     let output_base = get_ptr_from_var_name("output", vm, ids_data, ap_tracking)?;
 
-    vm.write_arg(&output_base, &output)
+    vm.write_arg(output_base, &output)
         .map_err(VirtualMachineError::MemoryError)?;
     Ok(())
 }
@@ -107,7 +107,7 @@ pub fn sha256_finalize(
         padding.extend_from_slice(output.as_slice());
     }
 
-    vm.write_arg(&sha256_ptr_end, &padding)
+    vm.write_arg(sha256_ptr_end, &padding)
         .map_err(VirtualMachineError::MemoryError)?;
     Ok(())
 }

--- a/src/hint_processor/builtin_hint_processor/uint256_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/uint256_utils.rs
@@ -36,9 +36,9 @@ pub fn uint256_add(
     let a_relocatable = get_relocatable_from_var_name("a", vm, ids_data, ap_tracking)?;
     let b_relocatable = get_relocatable_from_var_name("b", vm, ids_data, ap_tracking)?;
     let a_low = vm.get_integer(&a_relocatable)?;
-    let a_high = vm.get_integer(&(a_relocatable + 1))?;
+    let a_high = vm.get_integer(a_relocatable + 1)?;
     let b_low = vm.get_integer(&b_relocatable)?;
-    let b_high = vm.get_integer(&(b_relocatable + 1))?;
+    let b_high = vm.get_integer(b_relocatable + 1)?;
     let a_low = a_low.as_ref();
     let a_high = a_high.as_ref();
     let b_low = b_low.as_ref();
@@ -108,7 +108,7 @@ pub fn uint256_sqrt(
     let n_addr = get_relocatable_from_var_name("n", vm, ids_data, ap_tracking)?;
     let root_addr = get_relocatable_from_var_name("root", vm, ids_data, ap_tracking)?;
     let n_low = vm.get_integer(&n_addr)?;
-    let n_high = vm.get_integer(&(n_addr + 1))?;
+    let n_high = vm.get_integer(n_addr + 1)?;
     let n_low = n_low.as_ref();
     let n_high = n_high.as_ref();
 
@@ -142,7 +142,7 @@ pub fn uint256_signed_nn(
     ap_tracking: &ApTracking,
 ) -> Result<(), VirtualMachineError> {
     let a_addr = get_relocatable_from_var_name("a", vm, ids_data, ap_tracking)?;
-    let a_high = vm.get_integer(&(a_addr + 1))?;
+    let a_high = vm.get_integer(a_addr + 1)?;
     //Main logic
     //memory[ap] = 1 if 0 <= (ids.a.high % PRIME) < 2 ** 127 else 0
     let result: BigInt =
@@ -178,9 +178,9 @@ pub fn uint256_unsigned_div_rem(
     let remainder_addr = get_relocatable_from_var_name("remainder", vm, ids_data, ap_tracking)?;
 
     let a_low = vm.get_integer(&a_addr)?;
-    let a_high = vm.get_integer(&(a_addr + 1))?;
+    let a_high = vm.get_integer(a_addr + 1)?;
     let div_low = vm.get_integer(&div_addr)?;
-    let div_high = vm.get_integer(&(div_addr + 1))?;
+    let div_high = vm.get_integer(div_addr + 1)?;
     let a_low = a_low.as_ref();
     let a_high = a_high.as_ref();
     let div_low = div_low.as_ref();

--- a/src/hint_processor/builtin_hint_processor/usort.rs
+++ b/src/hint_processor/builtin_hint_processor/usort.rs
@@ -52,7 +52,7 @@ pub fn usort_body(
     let mut positions_dict: HashMap<BigInt, Vec<u64>> = HashMap::new();
     let mut output: Vec<BigInt> = Vec::new();
     for i in 0..input_len_u64 {
-        let val = vm.get_integer(&(&input_ptr + i as usize))?.into_owned();
+        let val = vm.get_integer(&input_ptr + i as usize)?.into_owned();
         if let Err(output_index) = output.binary_search(&val) {
             output.insert(output_index, val.clone());
         }

--- a/src/hint_processor/hint_processor_utils.rs
+++ b/src/hint_processor/hint_processor_utils.rs
@@ -39,7 +39,7 @@ pub fn get_integer_from_reference<'a>(
     }
 
     let var_addr = compute_addr_from_reference(hint_reference, vm, ap_tracking)?;
-    vm.get_integer(&var_addr)
+    vm.get_integer(var_addr)
 }
 
 ///Returns the Relocatable value stored in the given ids variable
@@ -51,7 +51,7 @@ pub fn get_ptr_from_reference(
     let var_addr = compute_addr_from_reference(hint_reference, vm, ap_tracking)?;
     //Add immediate if present in reference
     if hint_reference.dereference {
-        let value = vm.get_relocatable(&var_addr)?;
+        let value = vm.get_relocatable(var_addr)?;
         if let Some(immediate) = &hint_reference.immediate {
             let modified_value = value.as_ref() + bigint_to_usize(immediate)?;
             Ok(modified_value)
@@ -94,7 +94,7 @@ pub fn compute_addr_from_reference(
     } else {
         let addr = base_addr + hint_reference.offset1;
         let dereferenced_addr = vm
-            .get_relocatable(&addr)
+            .get_relocatable(addr)
             .map_err(|_| VirtualMachineError::FailedToGetIds)?;
         let dereferenced_addr = dereferenced_addr.as_ref();
         if let Some(imm) = &hint_reference.immediate {
@@ -154,7 +154,7 @@ mod tests {
         hint_ref.immediate = Some(bigint!(2));
 
         assert_eq!(
-            get_integer_from_reference(&mut vm, &hint_ref, &ApTracking::new())
+            get_integer_from_reference(&vm, &hint_ref, &ApTracking::new())
                 .expect("Unexpected get integer fail")
                 .into_owned(),
             bigint!(2)
@@ -168,7 +168,7 @@ mod tests {
 
         assert_eq!(
             get_ptr_from_reference(
-                &mut vm,
+                &vm,
                 &HintReference::new(0, 0, false, false),
                 &ApTracking::new()
             ),
@@ -183,7 +183,7 @@ mod tests {
 
         assert_eq!(
             get_ptr_from_reference(
-                &mut vm,
+                &vm,
                 &HintReference::new(0, 0, false, true),
                 &ApTracking::new()
             ),
@@ -199,7 +199,7 @@ mod tests {
         hint_ref.immediate = Some(bigint!(2));
 
         assert_eq!(
-            get_ptr_from_reference(&mut vm, &hint_ref, &ApTracking::new()),
+            get_ptr_from_reference(&vm, &hint_ref, &ApTracking::new()),
             Ok(relocatable!(4, 2))
         );
     }
@@ -225,7 +225,7 @@ mod tests {
         hint_reference.offset1 = -1;
 
         assert_eq!(
-            compute_addr_from_reference(&hint_reference, &mut vm, &ApTracking::new()),
+            compute_addr_from_reference(&hint_reference, &vm, &ApTracking::new()),
             Err(VirtualMachineError::FailedToGetIds)
         );
     }

--- a/src/types/relocatable.rs
+++ b/src/types/relocatable.rs
@@ -170,18 +170,20 @@ impl Relocatable {
         })
     }
 
-    pub fn sub_rel(&self, other: &Self) -> Result<usize, VirtualMachineError> {
-        if self.segment_index != other.segment_index {
-            return Err(VirtualMachineError::DiffIndexSub);
+    /// Calculate the distance between two relocatables pointing to the same segment.
+    pub fn distance_to(&self, other: &Self) -> Result<usize, VirtualMachineError> {
+        if self.segment_index == other.segment_index {
+            if other.offset >= self.offset {
+                Ok(other.offset - self.offset)
+            } else {
+                Err(VirtualMachineError::CantSubOffset(
+                    self.offset,
+                    other.offset,
+                ))
+            }
+        } else {
+            Err(VirtualMachineError::DiffIndexSub)
         }
-        if self.offset < other.offset {
-            return Err(VirtualMachineError::CantSubOffset(
-                self.offset,
-                other.offset,
-            ));
-        }
-        let result = self.offset - other.offset;
-        Ok(result)
     }
 }
 
@@ -262,6 +264,7 @@ impl MaybeRelocatable {
             }
         }
     }
+
     ///Substracts two MaybeRelocatable values and returns the result as a MaybeRelocatable value.
     /// Only values of the same type may be substracted.
     /// Relocatable values can only be substracted if they belong to the same segment.
@@ -768,13 +771,13 @@ mod tests {
     }
 
     #[test]
-    fn relocatable_sub_rel_test() {
-        let reloc = relocatable!(7, 6);
+    fn relocatable_distance_to_test() {
+        let reloc = relocatable!(7, 5);
 
-        assert_eq!(Ok(1), reloc.sub_rel(&relocatable!(7, 5)));
+        assert_eq!(Ok(1), reloc.distance_to(&relocatable!(7, 6)));
         assert_eq!(
-            Err(VirtualMachineError::CantSubOffset(6, 9)),
-            reloc.sub_rel(&relocatable!(7, 9))
+            Err(VirtualMachineError::CantSubOffset(5, 2)),
+            reloc.distance_to(&relocatable!(7, 2))
         );
     }
 

--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -176,7 +176,7 @@ impl BitwiseBuiltinRunner {
     ) -> Result<(Relocatable, usize), RunnerError> {
         if self._included {
             if let Ok(stop_pointer) = vm
-                .get_relocatable(&(pointer.sub(1)).map_err(|_| RunnerError::FinalStack)?)
+                .get_relocatable(pointer.sub(1).map_err(|_| RunnerError::FinalStack)?)
                 .as_deref()
             {
                 if self.base() != stop_pointer.segment_index {

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -135,13 +135,13 @@ impl EcOpBuiltinRunner {
         if index != OUTPUT_INDICES.0 && index != OUTPUT_INDICES.1 {
             return Ok(None);
         }
-        let instance = MaybeRelocatable::from((address.segment_index, address.offset - index));
+        let instance = Relocatable::from((address.segment_index, address.offset - index));
         //All input cells should be filled, and be integer values
         //If an input cell is not filled, return None
         let mut input_cells = Vec::<Cow<BigInt>>::with_capacity(self.n_input_cells as usize);
         for i in 0..self.n_input_cells as usize {
             match memory
-                .get(&instance.add_usize_mod(i, None))
+                .get(&instance + i)
                 .map_err(RunnerError::FailedMemoryGet)?
             {
                 None => return Ok(None),
@@ -149,11 +149,7 @@ impl EcOpBuiltinRunner {
                     input_cells.push(match addr {
                         Cow::Borrowed(MaybeRelocatable::Int(num)) => Cow::Borrowed(num),
                         Cow::Owned(MaybeRelocatable::Int(num)) => Cow::Owned(num),
-                        _ => {
-                            return Err(RunnerError::ExpectedInteger(
-                                instance.add_usize_mod(i, None),
-                            ))
-                        }
+                        _ => return Err(RunnerError::ExpectedInteger((instance + i).into())),
                     });
                 }
             };
@@ -248,7 +244,7 @@ impl EcOpBuiltinRunner {
     ) -> Result<(Relocatable, usize), RunnerError> {
         if self._included {
             if let Ok(stop_pointer) = vm
-                .get_relocatable(&(pointer.sub(1)).map_err(|_| RunnerError::FinalStack)?)
+                .get_relocatable(pointer.sub(1).map_err(|_| RunnerError::FinalStack)?)
                 .as_deref()
             {
                 if self.base() != stop_pointer.segment_index {

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -80,14 +80,8 @@ impl HashBuiltinRunner {
             return Ok(None);
         };
 
-        let num_a = memory.get(&MaybeRelocatable::RelocatableValue(Relocatable {
-            segment_index: address.segment_index,
-            offset: address.offset - 1,
-        }));
-        let num_b = memory.get(&MaybeRelocatable::RelocatableValue(Relocatable {
-            segment_index: address.segment_index,
-            offset: address.offset - 2,
-        }));
+        let num_a = memory.get((address.segment_index, address.offset - 1));
+        let num_b = memory.get((address.segment_index, address.offset - 2));
         if let (Ok(Some(MaybeRelocatable::Int(num_a))), Ok(Some(MaybeRelocatable::Int(num_b)))) = (
             num_a.as_ref().map(|x| x.as_ref().map(|x| x.as_ref())),
             num_b.as_ref().map(|x| x.as_ref().map(|x| x.as_ref())),
@@ -164,7 +158,7 @@ impl HashBuiltinRunner {
     ) -> Result<(Relocatable, usize), RunnerError> {
         if self._included {
             if let Ok(stop_pointer) = vm
-                .get_relocatable(&(pointer.sub(1)).map_err(|_| RunnerError::FinalStack)?)
+                .get_relocatable(pointer.sub(1).map_err(|_| RunnerError::FinalStack)?)
                 .as_deref()
             {
                 if self.base() != stop_pointer.segment_index {

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -734,8 +734,7 @@ mod tests {
             output_builtin.get_memory_segment_addresses(),
             ("output", (0, None)),
         );
-        let range_check_builtin: BuiltinRunner =
-            BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new(8, 8, true)).into();
+        let range_check_builtin: BuiltinRunner = RangeCheckBuiltinRunner::new(8, 8, true).into();
         assert_eq!(
             range_check_builtin.get_memory_segment_addresses(),
             ("range_check", (0, None)),
@@ -889,8 +888,7 @@ mod tests {
 
     #[test]
     fn run_security_checks_range_check_missing_memory_cells_with_offsets() {
-        let builtin: BuiltinRunner =
-            BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new(8, 8, true)).into();
+        let builtin: BuiltinRunner = RangeCheckBuiltinRunner::new(8, 8, true).into();
         let mut vm = vm!();
 
         vm.memory.data = vec![vec![
@@ -1083,8 +1081,7 @@ mod tests {
         assert_eq!(hash_builtin.ratio(), (Some(8)),);
         let output_builtin: BuiltinRunner = OutputBuiltinRunner::new(true).into();
         assert_eq!(output_builtin.ratio(), None,);
-        let range_check_builtin: BuiltinRunner =
-            BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new(8, 8, true)).into();
+        let range_check_builtin: BuiltinRunner = RangeCheckBuiltinRunner::new(8, 8, true).into();
         assert_eq!(range_check_builtin.ratio(), (Some(8)),);
     }
 
@@ -1130,8 +1127,7 @@ mod tests {
         let mut vm = vm!();
         vm.segments.segment_used_sizes = Some(vec![4]);
 
-        let range_check_builtin: BuiltinRunner =
-            BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new(8, 8, true)).into();
+        let range_check_builtin: BuiltinRunner = RangeCheckBuiltinRunner::new(8, 8, true).into();
         assert_eq!(range_check_builtin.get_used_instances(&vm), Ok(4));
     }
 }

--- a/src/vm/runners/builtin_runner/output.rs
+++ b/src/vm/runners/builtin_runner/output.rs
@@ -90,7 +90,7 @@ impl OutputBuiltinRunner {
     ) -> Result<(Relocatable, usize), RunnerError> {
         if self._included {
             if let Ok(stop_pointer) = vm
-                .get_relocatable(&(pointer.sub(1)).map_err(|_| RunnerError::FinalStack)?)
+                .get_relocatable(pointer.sub(1).map_err(|_| RunnerError::FinalStack)?)
                 .as_deref()
             {
                 if self.base() != stop_pointer.segment_index {

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -71,9 +71,7 @@ impl RangeCheckBuiltinRunner {
 
     pub fn add_validation_rule(&self, memory: &mut Memory) -> Result<(), RunnerError> {
         let rule: ValidationRule = ValidationRule(Box::new(
-            |memory: &Memory,
-             address: &MaybeRelocatable|
-             -> Result<MaybeRelocatable, MemoryError> {
+            |memory, address| -> Result<MaybeRelocatable, MemoryError> {
                 match memory.get(address)? {
                     Some(Cow::Owned(MaybeRelocatable::Int(ref num)))
                     | Some(Cow::Borrowed(MaybeRelocatable::Int(ref num))) => {
@@ -185,7 +183,7 @@ impl RangeCheckBuiltinRunner {
     ) -> Result<(Relocatable, usize), RunnerError> {
         if self._included {
             if let Ok(stop_pointer) = vm
-                .get_relocatable(&(pointer.sub(1)).map_err(|_| RunnerError::FinalStack)?)
+                .get_relocatable(pointer.sub(1).map_err(|_| RunnerError::FinalStack)?)
                 .as_deref()
             {
                 if self.base() != stop_pointer.segment_index {

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -252,7 +252,7 @@ impl CairoRunner {
                 .load_data(
                     &mut vm.memory,
                     &MaybeRelocatable::RelocatableValue(prog_base),
-                    self.program.data.clone(),
+                    self.program.data.iter().cloned(),
                 )
                 .map_err(RunnerError::MemoryInitializationError)?;
         }
@@ -821,7 +821,7 @@ impl CairoRunner {
             for i in 0..vm.segments.segment_used_sizes.as_ref().unwrap()[segment_index] {
                 let value = vm
                     .memory
-                    .get_integer(&(base, i).into())
+                    .get_integer((base, i))
                     .map_err(|_| RunnerError::MemoryGet((base, i).into()))?;
                 writeln!(
                     stdout,

--- a/src/vm/trace/mod.rs
+++ b/src/vm/trace/mod.rs
@@ -3,7 +3,7 @@ use super::{
     decoding::decoder::decode_instruction, errors::vm_errors::VirtualMachineError,
     vm_memory::memory::Memory,
 };
-use crate::types::relocatable::{MaybeRelocatable, Relocatable};
+use crate::types::relocatable::MaybeRelocatable;
 use num_traits::ToPrimitive;
 use std::borrow::Cow;
 
@@ -18,8 +18,7 @@ pub fn get_perm_range_check_limits(
         .iter()
         .try_fold(None, |offsets: Option<(isize, isize)>, trace| {
             let instruction = memory.get_integer(&trace.pc)?;
-            let immediate =
-                memory.get::<Relocatable>(&(trace.pc.segment_index, trace.pc.offset + 1).into())?;
+            let immediate = memory.get((trace.pc.segment_index, trace.pc.offset + 1))?;
 
             let instruction = instruction
                 .to_i64()

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -30,16 +30,15 @@ impl Memory {
     ///Inserts an MaybeRelocatable value into an address given by a MaybeRelocatable::Relocatable
     /// Will panic if the segment index given by the address corresponds to a non-allocated segment
     /// If the address isnt contiguous with previously inserted data, memory gaps will be represented by inserting None values
-    pub fn insert<'a, K: 'a, V: 'a>(&mut self, key: &'a K, val: &'a V) -> Result<(), MemoryError>
+    pub fn insert<K, V>(&mut self, key: K, val: V) -> Result<(), MemoryError>
     where
-        Relocatable: TryFrom<&'a K>,
-        MaybeRelocatable: From<&'a K>,
-        MaybeRelocatable: From<&'a V>,
+        K: TryInto<Relocatable>,
+        V: Into<MaybeRelocatable>,
     {
         let relocatable: Relocatable = key
             .try_into()
             .map_err(|_| MemoryError::AddressNotRelocatable)?;
-        let val = MaybeRelocatable::from(val);
+        let val = val.into();
         let (value_index, value_offset) = from_relocatable_to_indexes(&relocatable);
 
         let data = if relocatable.segment_index.is_negative() {
@@ -73,16 +72,13 @@ impl Memory {
                 }
             }
         };
-        self.validate_memory_cell(&MaybeRelocatable::from(key))
+        self.validate_memory_cell(&relocatable.into())
     }
 
     /// Retrieve a value from memory (either normal or temporary) and apply relocation rules
-    pub(crate) fn get<'a, 'b: 'a, K: 'a>(
-        &'b self,
-        key: &'a K,
-    ) -> Result<Option<Cow<MaybeRelocatable>>, MemoryError>
+    pub(crate) fn get<K>(&self, key: K) -> Result<Option<Cow<MaybeRelocatable>>, MemoryError>
     where
-        Relocatable: TryFrom<&'a K>,
+        K: TryInto<Relocatable>,
     {
         let relocatable: Relocatable = key
             .try_into()
@@ -158,35 +154,40 @@ impl Memory {
     //Gets the value from memory address.
     //If the value is an MaybeRelocatable::Int(Bigint) return &Bigint
     //else raises Err
-    pub fn get_integer(&self, key: &Relocatable) -> Result<Cow<BigInt>, VirtualMachineError> {
-        match self.get(key).map_err(VirtualMachineError::MemoryError)? {
+    pub fn get_integer<K>(&self, key: K) -> Result<Cow<BigInt>, VirtualMachineError>
+    where
+        K: TryInto<Relocatable>,
+    {
+        let key: Relocatable = key
+            .try_into()
+            .map_err(|_| MemoryError::AddressNotRelocatable)?;
+        match self.get(&key).map_err(VirtualMachineError::MemoryError)? {
             Some(Cow::Borrowed(MaybeRelocatable::Int(int))) => Ok(Cow::Borrowed(int)),
             Some(Cow::Owned(MaybeRelocatable::Int(int))) => Ok(Cow::Owned(int)),
-            _ => Err(VirtualMachineError::ExpectedInteger(
-                MaybeRelocatable::from(key),
-            )),
+            _ => Err(VirtualMachineError::ExpectedInteger(key.into())),
         }
     }
 
-    pub fn get_relocatable(
-        &self,
-        key: &Relocatable,
-    ) -> Result<Cow<Relocatable>, VirtualMachineError> {
-        match self.get(key).map_err(VirtualMachineError::MemoryError)? {
+    pub fn get_relocatable<K>(&self, key: K) -> Result<Cow<Relocatable>, VirtualMachineError>
+    where
+        K: TryInto<Relocatable>,
+    {
+        let key: Relocatable = key
+            .try_into()
+            .map_err(|_| MemoryError::AddressNotRelocatable)?;
+        match self.get(&key).map_err(VirtualMachineError::MemoryError)? {
             Some(Cow::Borrowed(MaybeRelocatable::RelocatableValue(rel))) => Ok(Cow::Borrowed(rel)),
             Some(Cow::Owned(MaybeRelocatable::RelocatableValue(rel))) => Ok(Cow::Owned(rel)),
-            _ => Err(VirtualMachineError::ExpectedRelocatable(
-                MaybeRelocatable::from(key),
-            )),
+            _ => Err(VirtualMachineError::ExpectedRelocatable(key.into())),
         }
     }
 
-    pub fn insert_value<T: Into<MaybeRelocatable>>(
-        &mut self,
-        key: &Relocatable,
-        val: T,
-    ) -> Result<(), VirtualMachineError> {
-        self.insert(key, &val.into())
+    pub fn insert_value<K, T>(&mut self, key: K, val: T) -> Result<(), VirtualMachineError>
+    where
+        K: TryInto<Relocatable>,
+        T: Into<MaybeRelocatable>,
+    {
+        self.insert(key, val)
             .map_err(VirtualMachineError::MemoryError)
     }
 
@@ -220,29 +221,41 @@ impl Memory {
         Ok(())
     }
 
-    pub fn get_range(
+    pub fn get_range<K>(
         &self,
-        addr: &MaybeRelocatable,
+        addr: K,
         size: usize,
-    ) -> Result<Vec<Option<Cow<MaybeRelocatable>>>, MemoryError> {
-        let mut values = Vec::new();
+    ) -> Result<Vec<Option<Cow<MaybeRelocatable>>>, MemoryError>
+    where
+        K: TryInto<Relocatable>,
+    {
+        let addr: Relocatable = addr
+            .try_into()
+            .map_err(|_| MemoryError::AddressNotRelocatable)?;
 
+        let mut values = Vec::new();
         for i in 0..size {
-            values.push(self.get(&addr.add_usize_mod(i, None))?);
+            values.push(self.get(&addr + i)?);
         }
 
         Ok(values)
     }
 
-    pub fn get_continuous_range(
+    pub fn get_continuous_range<K>(
         &self,
-        addr: &MaybeRelocatable,
+        addr: K,
         size: usize,
-    ) -> Result<Vec<MaybeRelocatable>, MemoryError> {
-        let mut values = Vec::with_capacity(size);
+    ) -> Result<Vec<MaybeRelocatable>, MemoryError>
+    where
+        K: TryInto<Relocatable>,
+    {
+        let addr = addr
+            .try_into()
+            .map_err(|_| MemoryError::AddressNotRelocatable)?;
 
+        let mut values = Vec::with_capacity(size);
         for i in 0..size {
-            values.push(match self.get(&addr.add_usize_mod(i, None))? {
+            values.push(match self.get(&addr + i)? {
                 Some(elem) => elem.into_owned(),
                 None => return Err(MemoryError::GetRangeMemoryGap),
             });
@@ -251,15 +264,21 @@ impl Memory {
         Ok(values)
     }
 
-    pub fn get_integer_range(
+    pub fn get_integer_range<K>(
         &self,
-        addr: &Relocatable,
+        addr: K,
         size: usize,
-    ) -> Result<Vec<Cow<BigInt>>, VirtualMachineError> {
-        let mut values = Vec::new();
+    ) -> Result<Vec<Cow<BigInt>>, VirtualMachineError>
+    where
+        K: TryInto<Relocatable>,
+    {
+        let addr = addr
+            .try_into()
+            .map_err(|_| MemoryError::AddressNotRelocatable)?;
 
+        let mut values = Vec::new();
         for i in 0..size {
-            values.push(self.get_integer(&(addr + i))?);
+            values.push(self.get_integer(&addr + i)?);
         }
 
         Ok(values)
@@ -578,13 +597,7 @@ mod memory_tests {
                 &MaybeRelocatable::from(bigint!(10)),
             )
             .unwrap();
-        assert_eq!(
-            memory
-                .get_integer(&Relocatable::from((0, 0)))
-                .unwrap()
-                .as_ref(),
-            &bigint!(10)
-        );
+        assert_eq!(memory.get_integer((0, 0)).unwrap().as_ref(), &bigint!(10));
     }
 
     #[test]

--- a/src/vm/vm_memory/memory_segments.rs
+++ b/src/vm/vm_memory/memory_segments.rs
@@ -46,16 +46,26 @@ impl MemorySegmentManager {
     }
 
     ///Writes data into the memory at address ptr and returns the first address after the data.
-    pub fn load_data(
+    pub fn load_data<K, I>(
         &mut self,
         memory: &mut Memory,
-        ptr: &MaybeRelocatable,
-        data: Vec<MaybeRelocatable>,
-    ) -> Result<MaybeRelocatable, MemoryError> {
-        for (num, value) in data.iter().enumerate() {
-            memory.insert(&ptr.add_usize_mod(num, None), value)?;
+        ptr: K,
+        data: I,
+    ) -> Result<MaybeRelocatable, MemoryError>
+    where
+        K: TryInto<Relocatable>,
+        I: IntoIterator<Item = MaybeRelocatable>,
+    {
+        let mut ptr = ptr
+            .try_into()
+            .map_err(|_| MemoryError::AddressNotRelocatable)?;
+
+        for value in data.into_iter() {
+            memory.insert(&ptr, value)?;
+            ptr.offset += 1;
         }
-        Ok(ptr.add_usize_mod(data.len(), None))
+
+        Ok(ptr.into())
     }
 
     pub fn new() -> MemorySegmentManager {
@@ -156,36 +166,32 @@ impl MemorySegmentManager {
         Ok(cairo_args)
     }
 
-    pub fn write_arg(
+    pub fn write_arg<K>(
         &mut self,
         memory: &mut Memory,
-        ptr: &Relocatable,
+        ptr: K,
         arg: &dyn Any,
         prime: Option<&BigInt>,
-    ) -> Result<MaybeRelocatable, MemoryError> {
+    ) -> Result<MaybeRelocatable, MemoryError>
+    where
+        K: TryInto<Relocatable>,
+    {
+        let ptr = ptr
+            .try_into()
+            .map_err(|_| MemoryError::AddressNotRelocatable)?;
+
         if let Some(vector) = arg.downcast_ref::<Vec<MaybeRelocatable>>() {
-            let data = vector
-                .iter()
-                .map(|value| match value {
-                    MaybeRelocatable::RelocatableValue(value) => value.into(),
-                    MaybeRelocatable::Int(value) => MaybeRelocatable::Int(match prime {
-                        Some(prime) => value.mod_floor(prime),
-                        None => value.clone(),
-                    }),
-                })
-                .collect();
-            self.load_data(
-                memory,
-                &MaybeRelocatable::from((ptr.segment_index, ptr.offset)),
-                data,
-            )
+            let data_iter = vector.iter().map(|value| match value {
+                MaybeRelocatable::RelocatableValue(value) => value.into(),
+                MaybeRelocatable::Int(value) => MaybeRelocatable::Int(match prime {
+                    Some(prime) => value.mod_floor(prime),
+                    None => value.clone(),
+                }),
+            });
+            self.load_data(memory, ptr, data_iter)
         } else if let Some(vector) = arg.downcast_ref::<Vec<Relocatable>>() {
-            let data = vector.iter().map(|value| value.into()).collect();
-            self.load_data(
-                memory,
-                &MaybeRelocatable::from((ptr.segment_index, ptr.offset)),
-                data,
-            )
+            let data_iter = vector.iter().map(|value| value.into());
+            self.load_data(memory, ptr, data_iter)
         } else {
             Err(MemoryError::WriteArg)
         }


### PR DESCRIPTION
# Miscellaneous fixes and improvements.

## Description

**Changes**
  - Changed methods from `Memory`, `MemorySegmentManager` and its `VirtualMachine` shortcuts to accept generics.
  - Updated their usages (except on testing) to reflect those changes, which should remove unnecessary clones and potential allocations.
  - Change some methods that used to accept `Vec<_>` to accept `impl IntoIterator<_>` instead, which avoids a few `Vec<_>` allocations and provides better type compatibility.
  - Rename utility method `Relocatable::sub_rel()` to `Relocatable::distance_to()` with swapped parameters (`self` becomes `other` and `other` becomes `self`).
  - Fixed a few `rust-analyzer`-only errors (unnecessary mutability in some places).

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
