### PR TITLE
Bump starknet-crypto to v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "bigdecimal"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aaf33151a6429fe9211d1b276eafdf70cdff28b071e76c0b0e1503221ea3744"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1029,9 +1040,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-crypto"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d5ba05430fcd7c107ad9e4433bb3958722b13d97a44fd07a18dcf0eb6da667"
+checksum = "be7d6b2c959fde2a10dbc31d54bdd0307eecb7ef6c05c23a0263e65b57b3e18a"
 dependencies = [
  "crypto-bigint",
  "hex",
@@ -1041,21 +1052,45 @@ dependencies = [
  "num-traits",
  "rfc6979",
  "sha2 0.9.9",
+ "starknet-crypto-codegen",
+ "starknet-curve",
  "starknet-ff",
  "thiserror",
  "zeroize",
 ]
 
 [[package]]
-name = "starknet-ff"
+name = "starknet-crypto-codegen"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a80865f37a0dcd198f427356d939f1495144c26ed5123b1418ef33a63f82655"
+checksum = "6569d70430f0f6edc41f6820d00acf63356e6308046ca01e57eeac22ad258c47"
+dependencies = [
+ "starknet-curve",
+ "starknet-ff",
+ "syn",
+]
+
+[[package]]
+name = "starknet-curve"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84be6079d3060fdbd8b5335574fef3d3783fa2f7ee6474d08ae0c1e4b0a29ba4"
+dependencies = [
+ "starknet-ff",
+]
+
+[[package]]
+name = "starknet-ff"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5874510620214ebeac50915b01d67437d8ca10a6682b1de85b93cd01157b58eb"
 dependencies = [
  "ark-ff",
+ "bigdecimal",
  "crypto-bigint",
  "getrandom",
  "hex",
+ "num-bigint",
  "serde",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serde_bytes = "0.11.1"
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }
 hex = "0.4.3"
 bincode = "1.2.1"
-starknet-crypto = "0.1.0"
+starknet-crypto = "0.2.0"
 clap = { version = "3.2.5", features = ["derive"] }
 sha3 = "0.10.1"
 rand_core = "0.6.4"


### PR DESCRIPTION
# Bump starknet-crypto to v0.2.0

## Description

`starknet-crypto` just [released](https://github.com/xJonathanLEI/starknet-rs/pull/249) a new version [v0.2.0](https://crates.io/crates/starknet-crypto/0.2.0), which offers a performance gain on Pedersen hash of around 100x compared to the version (v0.1.0) currently used in `cairo-rs`. The new version contains no breaking changes itself, and a minor change on the `starknet-ff` re-export doesn't affect `cairo-rs`. So no Rust code change is needed for this to work. We get this performance gain for free.

For context, `starknet-crypto` is now the 2nd fastest Pedersen hash implementation documented in [`pedersen-bench`](https://github.com/xJonathanLEI/pedersen-bench), faster than `starknet-signatures` and only after `pathfinder`.

## Checklist

_(I guess none of these are needed for this PR?)_

- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
