### PR TITLE
Make `CairoRunner::write_output()` work with unordered builtins.

### DIFF
--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -843,10 +843,8 @@ impl CairoRunner {
             _ => return Ok(()),
         };
 
-        vm.segments.compute_effective_sizes(&vm.memory);
-        let base = builtin.base();
-
         let segment_used_sizes = vm.segments.compute_effective_sizes(&vm.memory);
+        let base = builtin.base();
 
         let segment_index: usize = base
             .try_into()

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -2731,14 +2731,21 @@ mod tests {
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
 
-        cairo_runner.initialize_builtins(&mut vm).unwrap();
-        cairo_runner.initialize_segments(&mut vm, None);
+        cairo_runner
+            .initialize_builtins(&mut vm)
+            .expect("Couldn't initialize builtins.");
 
         // Swap the first and second builtins (first should be `output`).
         vm.builtin_runners.swap(0, 1);
 
-        let end = cairo_runner.initialize_main_entrypoint(&mut vm).unwrap();
-        cairo_runner.initialize_vm(&mut vm).unwrap();
+        cairo_runner.initialize_segments(&mut vm, None);
+
+        let end = cairo_runner
+            .initialize_main_entrypoint(&mut vm)
+            .expect("Couldn't initialize the main entrypoint.");
+        cairo_runner
+            .initialize_vm(&mut vm)
+            .expect("Couldn't initialize the VM.");
 
         let hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
@@ -2747,7 +2754,9 @@ mod tests {
         );
 
         let mut stdout = Vec::<u8>::new();
-        cairo_runner.write_output(&mut vm, &mut stdout).unwrap();
+        cairo_runner
+            .write_output(&mut vm, &mut stdout)
+            .expect("Call to `write_output()` failed.");
         assert_eq!(String::from_utf8(stdout), Ok(String::from("1\n17\n")));
     }
 

--- a/src/vm/vm_memory/memory_segments.rs
+++ b/src/vm/vm_memory/memory_segments.rs
@@ -68,16 +68,10 @@ impl MemorySegmentManager {
         }
     }
 
-    ///Calculates the size (number of non-none elements) of each memory segment
-    pub fn compute_effective_sizes(&mut self, memory: &Memory) {
-        if self.segment_used_sizes != None {
-            return;
-        }
-        let mut segment_used_sizes = Vec::new();
-        for segment in memory.data.iter() {
-            segment_used_sizes.push(segment.len());
-        }
-        self.segment_used_sizes = Some(segment_used_sizes);
+    /// Calculates the size (number of non-none elements) of each memory segment.
+    pub fn compute_effective_sizes(&mut self, memory: &Memory) -> &Vec<usize> {
+        self.segment_used_sizes
+            .get_or_insert_with(|| memory.data.iter().map(Vec::len).collect())
     }
 
     ///Returns the number of used segments when they are already computed.


### PR DESCRIPTION
# Make `CairoRunner::write_output()` work with unordered builtins.

## Description

  - Make `CairoRunner::write_output()` work with unordered builtins.
  - Remove safe (but unnecessary) `.unwrap()`.
  - Test the changes.

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [x] This change requires new documentation.
  - [x] Documentation has been added/updated.
