### PR TITLE
Change DiffAssertValues error message

### DIFF
--- a/src/vm/errors/vm_errors.rs
+++ b/src/vm/errors/vm_errors.rs
@@ -28,7 +28,7 @@ pub enum VirtualMachineError {
     UnconstrainedResJumpRel,
     #[error("Res.UNCONSTRAINED cannot be used with Opcode.ASSERT_EQ")]
     UnconstrainedResAssertEq,
-    #[error("ASSERT_EQ instruction failed; res:{0} != dst:{1}")]
+    #[error("ASSERT_EQ instruction failed; {0} != {1}")]
     DiffAssertValues(BigInt, BigInt),
     #[error("Call failed to write return-pc (inconsistent op0): {0:?} != {1:?}. Did you forget to increment ap?")]
     CantWriteReturnPc(MaybeRelocatable, MaybeRelocatable),

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -378,8 +378,8 @@ impl VirtualMachine {
                         {
                             if res_num != dst_num {
                                 return Err(VirtualMachineError::DiffAssertValues(
-                                    res_num.clone(),
                                     dst_num.clone(),
+                                    res_num.clone(),
                                 ));
                             };
                         };
@@ -2391,8 +2391,8 @@ mod tests {
         assert_eq!(
             vm.opcode_assertions(&instruction, &operands),
             Err(VirtualMachineError::DiffAssertValues(
-                bigint!(8),
-                bigint!(9)
+                bigint!(9),
+                bigint!(8)
             ))
         );
     }


### PR DESCRIPTION
This change is needed so that some Protostar tests pass.

The test asserts for the error message and in the Python version, and the `res` and `dst` are flipped.