### PR TITLE
Fix update_fp to handle starknet case

### DIFF
--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -1016,6 +1016,37 @@ mod tests {
     }
 
     #[test]
+    fn update_fp_dst_num() {
+        let instruction = Instruction {
+            off0: bigint!(1),
+            off1: bigint!(2),
+            off2: bigint!(3),
+            imm: None,
+            dst_register: Register::FP,
+            op0_register: Register::AP,
+            op1_addr: Op1Addr::AP,
+            res: Res::Add,
+            pc_update: PcUpdate::Regular,
+            ap_update: ApUpdate::Regular,
+            fp_update: FpUpdate::Dst,
+            opcode: Opcode::NOp,
+        };
+
+        let operands = Operands {
+            dst: MaybeRelocatable::Int(bigint!(11)),
+            res: Some(MaybeRelocatable::Int(bigint!(8))),
+            op0: MaybeRelocatable::Int(bigint!(9)),
+            op1: MaybeRelocatable::Int(bigint!(10)),
+        };
+
+        let mut vm = vm!();
+        run_context!(vm, 4, 5, 6);
+
+        assert_eq!(Ok(()), vm.update_fp(&instruction, &operands));
+        assert_eq!(vm.run_context.fp, 11)
+    }
+
+    #[test]
     fn update_ap_add_with_res() {
         let instruction = Instruction {
             off0: bigint!(1),


### PR DESCRIPTION
Currently, when running starkness contracts' entrypoints, they use the default return_fp value, which is 0. This value is then used to update the value of fp in the last instruction. As this is the last instruction, the fp value is not appended to the trace, and its value is not relevant to the vm run.  Our `update_fp` method checks that the new value is a relocatable value, which makes sense knowing that fp is a pointer, but it causes an error when encountering this particular case. As we want our memory to match the original vm, we can't change this return_fp value, so we need to let this case pass through.