### PR TITLE
add getter for trace attribute of VirtualMachine

### DIFF
--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -108,6 +108,11 @@ impl VirtualMachine {
         }
     }
 
+    //Simple getter for trace attribute
+    pub fn get_trace(&self) -> Option<&Vec<TraceEntry>> {
+        return self.trace.as_ref();
+    }
+
     ///Returns the encoded instruction (the value at pc) and the immediate value (the value at pc + 1, if it exists in the memory).
     fn get_instruction_encoding(
         &self,


### PR DESCRIPTION
# add getter for trace attribute of VirtualMachine

## Description

Add a function to get the execution trace. We ([FuzzingLabs](https://github.com/FuzzingLabs)) need it for the fuzzer to do the coverage of the cairo program.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [x] Documentation has been added/updated.
