### PR TITLE
Fix empty tarpaulin run

### DIFF
--- a/.tarpaulin.toml
+++ b/.tarpaulin.toml
@@ -1,3 +1,6 @@
+[cairo-rs]
+exclude-files = []
+
 [report]
 output-dir = "target/tarpaulin"
 out = ["Html", "Xml"]


### PR DESCRIPTION
# Fix empty tarpaulin run

## Description

Every run of tarpaulin ended with a _"0/0 lines covered_ report". It seems it doesn't include the project automatically, or (maybe?) excludes all files by default. It can be solved changing its configuration on `.tarpaulin.toml`.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
