### PR TITLE
Implement VmException 

### DIFF
--- a/cairo_programs/manually_compiled/deserialize_constant_test.json
+++ b/cairo_programs/manually_compiled/deserialize_constant_test.json
@@ -1,6 +1,9 @@
 {
     "prime": "0x000A",
     "attributes": [],
+    "debug_info": {
+        "instruction_locations": {}
+    },
     "data": [
     ],
     "builtins": [],

--- a/src/cairo_run.rs
+++ b/src/cairo_run.rs
@@ -1,5 +1,6 @@
 use crate::hint_processor::hint_processor_definition::HintProcessor;
 use crate::types::program::Program;
+use crate::vm::errors::vm_exception::VmException;
 use crate::vm::errors::{cairo_run_errors::CairoRunError, runner_errors::RunnerError};
 use crate::vm::runners::cairo_runner::CairoRunner;
 use crate::vm::trace::trace_entry::RelocatedTraceEntry;
@@ -31,7 +32,9 @@ pub fn cairo_run(
     );
     let end = cairo_runner.initialize(&mut vm)?;
 
-    cairo_runner.run_until_pc(end, &mut vm, hint_executor)?;
+    cairo_runner
+        .run_until_pc(end, &mut vm, hint_executor)
+        .map_err(|err| VmException::from_vm_error(&cairo_runner, err, vm.run_context.pc.offset))?;
     cairo_runner.end_run(false, false, &mut vm, hint_executor)?;
 
     vm.verify_auto_deductions()?;

--- a/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -866,7 +866,7 @@ mod tests {
         hint_processor.add_hint(String::from("enter_scope_custom_a"), Rc::clone(&hint_func));
         hint_processor.add_hint(String::from("enter_scope_custom_b"), hint_func);
         let mut vm = vm!();
-        let mut exec_scopes = exec_scopes_ref!();
+        let exec_scopes = exec_scopes_ref!();
         assert_eq!(exec_scopes.data.len(), 1);
         let hint_data =
             HintProcessorData::new_default(String::from("enter_scope_custom_a"), HashMap::new());

--- a/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -873,7 +873,7 @@ mod tests {
         assert_eq!(
             hint_processor.execute_hint(
                 &mut vm,
-                &mut exec_scopes,
+                exec_scopes,
                 &any_box!(hint_data),
                 &HashMap::new()
             ),
@@ -885,7 +885,7 @@ mod tests {
         assert_eq!(
             hint_processor.execute_hint(
                 &mut vm,
-                &mut exec_scopes,
+                exec_scopes,
                 &any_box!(hint_data),
                 &HashMap::new()
             ),

--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -88,11 +88,11 @@ pub struct Attribute {
 
 #[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Location {
-    end_line: u32,
-    end_col: u32,
-    parent_location: Option<(Box<Location>, String)>,
-    start_line: u32,
-    start_col: u32,
+    pub end_line: u32,
+    pub end_col: u32,
+    pub parent_location: Option<(Box<Location>, String)>,
+    pub start_line: u32,
+    pub start_col: u32,
 }
 
 #[derive(Deserialize, Debug, PartialEq)]

--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -21,8 +21,7 @@ pub struct ProgramJson {
     pub hints: HashMap<usize, Vec<HintParams>>,
     pub reference_manager: ReferenceManager,
     pub attributes: Vec<Attribute>,
-    #[serde(deserialize_with = "deserialize_inst_debug_info")]
-    pub debug_info: HashMap<usize, Location>
+    pub debug_info: DebugInfo,
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -86,15 +85,26 @@ pub struct Attribute {
     pub end_pc: usize,
     pub value: String,
 }
-
+#[allow(dead_code)]
 #[derive(Deserialize, Debug)]
 pub struct Location {
     end_line: u32,
     end_col: u32,
-    input_file: String,
     parent_location: Option<(Box<Location>, String)>,
     start_line: u32,
     start_col: u32,
+}
+
+#[allow(dead_code)]
+#[derive(Deserialize, Debug)]
+pub struct DebugInfo {
+    instruction_locations: HashMap<usize, InstructionLocation>,
+}
+
+#[allow(dead_code)]
+#[derive(Deserialize, Debug)]
+pub struct InstructionLocation {
+    inst: Location,
 }
 
 fn bigint_from_number<'de, D>(deserializer: D) -> Result<Option<BigInt>, D::Error>

--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -1152,7 +1152,7 @@ mod tests {
                         inst: Location {
                             end_line: 7,
                             end_col: 73,
-                            input_file: InputFile { filename: String::from("/Users/user/test/env/lib/python3.9/site-packages/starkware/cairo/common/alloc.cairo") },
+                            input_file: InputFile { filename: String::from("/Users/user/test/env/lib/python3.9/site-packages/starkware/cairo/lang/compiler/lib/registers.cairo") },
                             parent_location: None,
                             start_line: 7,
                             start_col: 5,
@@ -1165,7 +1165,7 @@ mod tests {
                         inst: Location {
                             end_line: 5,
                             end_col: 40,
-                            input_file: InputFile { filename: String::from("/Users/user/test/env/lib/python3.9/site-packages/starkware/cairo/lang/compiler/lib/registers.cairo") },
+                            input_file: InputFile { filename: String::from("/Users/user/test/env/lib/python3.9/site-packages/starkware/cairo/common/alloc.cairo") },
                             parent_location: None,
                             start_line: 5,
                             start_col: 5,

--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -86,7 +86,7 @@ pub struct Attribute {
     pub value: String,
 }
 #[allow(dead_code)]
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Location {
     end_line: u32,
     end_col: u32,
@@ -355,6 +355,12 @@ pub fn deserialize_program(
             .attributes
             .into_iter()
             .filter(|attr| attr.name == "error_message")
+            .collect(),
+        instruction_locations: program_json
+            .debug_info
+            .instruction_locations
+            .into_iter()
+            .map(|(offset, instruction_location)| (offset, instruction_location.inst))
             .collect(),
     })
 }

--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -21,7 +21,7 @@ pub struct ProgramJson {
     pub hints: HashMap<usize, Vec<HintParams>>,
     pub reference_manager: ReferenceManager,
     pub attributes: Vec<Attribute>,
-    pub debug_info: DebugInfo,
+    pub debug_info: Option<DebugInfo>,
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -360,12 +360,13 @@ pub fn deserialize_program(
             .into_iter()
             .filter(|attr| attr.name == "error_message")
             .collect(),
-        instruction_locations: program_json
-            .debug_info
-            .instruction_locations
-            .into_iter()
-            .map(|(offset, instruction_location)| (offset, instruction_location.inst))
-            .collect(),
+        instruction_locations: program_json.debug_info.map(|debug_info| {
+            debug_info
+                .instruction_locations
+                .into_iter()
+                .map(|(offset, instruction_location)| (offset, instruction_location.inst))
+                .collect()
+        }),
     })
 }
 
@@ -1175,7 +1176,7 @@ mod tests {
             ]),
         };
 
-        assert_eq!(program_json.debug_info, debug_info);
+        assert_eq!(program_json.debug_info, Some(debug_info));
     }
 
     #[test]
@@ -1274,6 +1275,6 @@ mod tests {
             ]
         ) };
 
-        assert_eq!(program_json.debug_info, debug_info);
+        assert_eq!(program_json.debug_info, Some(debug_info));
     }
 }

--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -426,6 +426,9 @@ mod tests {
             {
                 "prime": "0x000A",
                 "attributes": [],
+                "debug_info": {
+                    "instruction_locations": {}
+                }, 
                 "builtins": [],
                 "data": [
                     "0x480680017fff8000",
@@ -945,6 +948,9 @@ mod tests {
             {
                 "prime": "0x000A",
                 "attributes": [],
+                "debug_info": {
+                    "instruction_locations": {}
+                },  
                 "builtins": [],
                 "data": [
                 ],
@@ -1024,7 +1030,10 @@ mod tests {
                         "start_pc": 402,
                         "value": "SafeUint256: subtraction overflow"
                     }
-                ],            
+                ], 
+                "debug_info": {
+                    "instruction_locations": {}
+                },           
                 "builtins": [],
                 "data": [
                 ],

--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -21,6 +21,8 @@ pub struct ProgramJson {
     pub hints: HashMap<usize, Vec<HintParams>>,
     pub reference_manager: ReferenceManager,
     pub attributes: Vec<Attribute>,
+    #[serde(deserialize_with = "deserialize_inst_debug_info")]
+    pub debug_info: HashMap<usize, Location>
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -83,6 +85,16 @@ pub struct Attribute {
     pub start_pc: usize,
     pub end_pc: usize,
     pub value: String,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct Location {
+    end_line: u32,
+    end_col: u32,
+    input_file: String,
+    parent_location: Option<(Box<Location>, String)>,
+    start_line: u32,
+    start_col: u32,
 }
 
 fn bigint_from_number<'de, D>(deserializer: D) -> Result<Option<BigInt>, D::Error>

--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -85,7 +85,7 @@ pub struct Attribute {
     pub end_pc: usize,
     pub value: String,
 }
-#[allow(dead_code)]
+
 #[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Location {
     end_line: u32,
@@ -95,7 +95,6 @@ pub struct Location {
     start_col: u32,
 }
 
-#[allow(dead_code)]
 #[derive(Deserialize, Debug)]
 pub struct DebugInfo {
     instruction_locations: HashMap<usize, InstructionLocation>,

--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -90,6 +90,7 @@ pub struct Attribute {
 pub struct Location {
     pub end_line: u32,
     pub end_col: u32,
+    pub input_file: InputFile,
     pub parent_location: Option<(Box<Location>, String)>,
     pub start_line: u32,
     pub start_col: u32,
@@ -103,6 +104,11 @@ pub struct DebugInfo {
 #[derive(Deserialize, Debug, PartialEq)]
 pub struct InstructionLocation {
     inst: Location,
+}
+
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct InputFile {
+    pub filename: String,
 }
 
 fn bigint_from_number<'de, D>(deserializer: D) -> Result<Option<BigInt>, D::Error>
@@ -1146,6 +1152,7 @@ mod tests {
                         inst: Location {
                             end_line: 7,
                             end_col: 73,
+                            input_file: InputFile { filename: String::from("/Users/user/test/env/lib/python3.9/site-packages/starkware/cairo/common/alloc.cairo") },
                             parent_location: None,
                             start_line: 7,
                             start_col: 5,
@@ -1158,6 +1165,7 @@ mod tests {
                         inst: Location {
                             end_line: 5,
                             end_col: 40,
+                            input_file: InputFile { filename: String::from("/Users/user/test/env/lib/python3.9/site-packages/starkware/cairo/lang/compiler/lib/registers.cairo") },
                             parent_location: None,
                             start_line: 5,
                             start_col: 5,
@@ -1241,14 +1249,16 @@ mod tests {
         let debug_info: DebugInfo = DebugInfo { instruction_locations: HashMap::from(
             [
                 (4, InstructionLocation {
-                    inst: Location { end_line: 9, end_col: 36, parent_location: Some(
+                    inst: Location { end_line: 9, end_col: 36,input_file: InputFile { filename: String::from("test/contracts/cairo/always_fail.cairo") }, parent_location: Some(
                         (Box::new(Location {
                             end_line: 9,
                             end_col: 36,
+                            input_file: InputFile { filename: String::from("test/contracts/cairo/always_fail.cairo") },
                             parent_location: Some(
                                 (   Box::new(Location {
                                     end_line: 11,
                                     end_col: 15,
+                                    input_file: InputFile { filename: String::from("test/contracts/cairo/always_fail.cairo") },
                                     parent_location: None,
                                     start_line: 11,
                                     start_col: 5,

--- a/src/types/program.rs
+++ b/src/types/program.rs
@@ -1,5 +1,5 @@
 use crate::serde::deserialize_program::{
-    deserialize_program, Attribute, HintParams, Identifier, ReferenceManager,
+    deserialize_program, Attribute, HintParams, Identifier, Location, ReferenceManager,
 };
 use crate::types::errors::program_errors::ProgramError;
 use crate::types::relocatable::MaybeRelocatable;
@@ -22,6 +22,7 @@ pub struct Program {
     pub reference_manager: ReferenceManager,
     pub identifiers: HashMap<String, Identifier>,
     pub error_message_attributes: Vec<Attribute>,
+    pub instruction_locations: HashMap<usize, Location>,
 }
 
 impl Program {
@@ -35,6 +36,7 @@ impl Program {
         reference_manager: ReferenceManager,
         identifiers: HashMap<String, Identifier>,
         error_message_attributes: Vec<Attribute>,
+        instruction_locations: HashMap<usize, Location>,
     ) -> Result<Program, ProgramError> {
         Ok(Self {
             builtins,
@@ -61,6 +63,7 @@ impl Program {
             reference_manager,
             identifiers,
             error_message_attributes,
+            instruction_locations,
         })
     }
 
@@ -95,6 +98,7 @@ impl Default for Program {
             },
             identifiers: HashMap::new(),
             error_message_attributes: Vec::new(),
+            instruction_locations: HashMap::new(),
         }
     }
 }
@@ -129,6 +133,7 @@ mod tests {
             reference_manager,
             HashMap::new(),
             Vec::new(),
+            HashMap::new(),
         )
         .unwrap();
 
@@ -188,6 +193,7 @@ mod tests {
             reference_manager,
             identifiers.clone(),
             Vec::new(),
+            HashMap::new(),
         )
         .unwrap();
 
@@ -254,6 +260,7 @@ mod tests {
             reference_manager,
             identifiers.clone(),
             Vec::new(),
+            HashMap::new(),
         );
 
         assert!(program.is_err());
@@ -494,6 +501,7 @@ mod tests {
             },
             identifiers: HashMap::new(),
             error_message_attributes: Vec::new(),
+            instruction_locations: HashMap::new(),
         };
 
         assert_eq!(program, Program::default())

--- a/src/types/program.rs
+++ b/src/types/program.rs
@@ -22,7 +22,7 @@ pub struct Program {
     pub reference_manager: ReferenceManager,
     pub identifiers: HashMap<String, Identifier>,
     pub error_message_attributes: Vec<Attribute>,
-    pub instruction_locations: HashMap<usize, Location>,
+    pub instruction_locations: Option<HashMap<usize, Location>>,
 }
 
 impl Program {
@@ -36,7 +36,7 @@ impl Program {
         reference_manager: ReferenceManager,
         identifiers: HashMap<String, Identifier>,
         error_message_attributes: Vec<Attribute>,
-        instruction_locations: HashMap<usize, Location>,
+        instruction_locations: Option<HashMap<usize, Location>>,
     ) -> Result<Program, ProgramError> {
         Ok(Self {
             builtins,
@@ -98,7 +98,7 @@ impl Default for Program {
             },
             identifiers: HashMap::new(),
             error_message_attributes: Vec::new(),
-            instruction_locations: HashMap::new(),
+            instruction_locations: None,
         }
     }
 }
@@ -133,7 +133,7 @@ mod tests {
             reference_manager,
             HashMap::new(),
             Vec::new(),
-            HashMap::new(),
+            None,
         )
         .unwrap();
 
@@ -193,7 +193,7 @@ mod tests {
             reference_manager,
             identifiers.clone(),
             Vec::new(),
-            HashMap::new(),
+            None,
         )
         .unwrap();
 
@@ -252,15 +252,15 @@ mod tests {
         );
 
         let program = Program::new(
-            builtins.clone(),
+            builtins,
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-            data.clone(),
+            data,
             None,
             HashMap::new(),
             reference_manager,
             identifiers.clone(),
             Vec::new(),
-            HashMap::new(),
+            None,
         );
 
         assert!(program.is_err());
@@ -501,7 +501,7 @@ mod tests {
             },
             identifiers: HashMap::new(),
             error_message_attributes: Vec::new(),
-            instruction_locations: HashMap::new(),
+            instruction_locations: None,
         };
 
         assert_eq!(program, Program::default())

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -244,7 +244,7 @@ pub mod test_utils {
                 },
                 identifiers: HashMap::new(),
                 error_message_attributes: Vec::new(),
-                instruction_locations: HashMap::new(),
+                instruction_locations: None,
             }
         };
         // Custom program definition
@@ -940,7 +940,7 @@ mod test {
             },
             identifiers: HashMap::new(),
             error_message_attributes: Vec::new(),
-            instruction_locations: HashMap::new(),
+            instruction_locations: None,
         };
 
         assert_eq!(program, program!())
@@ -962,7 +962,7 @@ mod test {
             },
             identifiers: HashMap::new(),
             error_message_attributes: Vec::new(),
-            instruction_locations: HashMap::new(),
+            instruction_locations: None,
         };
 
         assert_eq!(program, program!["range_check"])
@@ -984,7 +984,7 @@ mod test {
             },
             identifiers: HashMap::new(),
             error_message_attributes: Vec::new(),
-            instruction_locations: HashMap::new(),
+            instruction_locations: None,
         };
 
         assert_eq!(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -244,6 +244,7 @@ pub mod test_utils {
                 },
                 identifiers: HashMap::new(),
                 error_message_attributes: Vec::new(),
+                instruction_locations: HashMap::new(),
             }
         };
         // Custom program definition
@@ -939,6 +940,7 @@ mod test {
             },
             identifiers: HashMap::new(),
             error_message_attributes: Vec::new(),
+            instruction_locations: HashMap::new(),
         };
 
         assert_eq!(program, program!())
@@ -960,6 +962,7 @@ mod test {
             },
             identifiers: HashMap::new(),
             error_message_attributes: Vec::new(),
+            instruction_locations: HashMap::new(),
         };
 
         assert_eq!(program, program!["range_check"])
@@ -981,6 +984,7 @@ mod test {
             },
             identifiers: HashMap::new(),
             error_message_attributes: Vec::new(),
+            instruction_locations: HashMap::new(),
         };
 
         assert_eq!(

--- a/src/vm/errors/cairo_run_errors.rs
+++ b/src/vm/errors/cairo_run_errors.rs
@@ -1,4 +1,5 @@
 use super::memory_errors::MemoryError;
+use super::vm_exception::VmException;
 use crate::types::errors::program_errors::ProgramError;
 use crate::vm::errors::{
     runner_errors::RunnerError, trace_errors::TraceError, vm_errors::VirtualMachineError,
@@ -17,4 +18,6 @@ pub enum CairoRunError {
     Runner(#[from] RunnerError),
     #[error(transparent)]
     MemoryError(#[from] MemoryError),
+    #[error(transparent)]
+    VmException(#[from] VmException),
 }

--- a/src/vm/errors/mod.rs
+++ b/src/vm/errors/mod.rs
@@ -4,4 +4,4 @@ pub mod memory_errors;
 pub mod runner_errors;
 pub mod trace_errors;
 pub mod vm_errors;
-mod vm_exception;
+pub mod vm_exception;

--- a/src/vm/errors/mod.rs
+++ b/src/vm/errors/mod.rs
@@ -4,3 +4,4 @@ pub mod memory_errors;
 pub mod runner_errors;
 pub mod trace_errors;
 pub mod vm_errors;
+mod vm_exception;

--- a/src/vm/errors/vm_exception.rs
+++ b/src/vm/errors/vm_exception.rs
@@ -35,7 +35,12 @@ pub fn get_error_attr_value(pc: usize, runner: &CairoRunner) -> Option<String> {
 }
 
 pub fn get_location(pc: &usize, runner: &CairoRunner) -> Option<Location> {
-    runner.program.instruction_locations.get(pc).cloned()
+    runner
+        .program
+        .instruction_locations
+        .as_ref()?
+        .get(pc)
+        .cloned()
 }
 
 impl Display for VmException {
@@ -101,7 +106,8 @@ mod test {
             start_line: 1,
             start_col: 1,
         };
-        let program = program!(instruction_locations = HashMap::from([(pc, location.clone())]),);
+        let program =
+            program!(instruction_locations = Some(HashMap::from([(pc, location.clone())])),);
         let runner = cairo_runner!(program);
         let vm_excep = VmException {
             pc,
@@ -294,7 +300,8 @@ mod test {
             start_line: 1,
             start_col: 1,
         };
-        let program = program!(instruction_locations = HashMap::from([(2, location.clone())]),);
+        let program =
+            program!(instruction_locations = Some(HashMap::from([(2, location.clone())])),);
         let runner = cairo_runner!(program);
         assert_eq!(get_location(&2, &runner), Some(location));
     }
@@ -311,7 +318,7 @@ mod test {
             start_line: 1,
             start_col: 1,
         };
-        let program = program!(instruction_locations = HashMap::from([(2, location.clone())]),);
+        let program = program!(instruction_locations = Some(HashMap::from([(2, location)])),);
         let runner = cairo_runner!(program);
         assert_eq!(get_location(&3, &runner), None);
     }

--- a/src/vm/errors/vm_exception.rs
+++ b/src/vm/errors/vm_exception.rs
@@ -76,7 +76,7 @@ impl Display for VmException {
 
 impl Location {
     ///  Prints the location with the passed message.
-    fn to_string(&self, message: &String) -> String {
+    pub fn to_string(&self, message: &String) -> String {
         let msg_prefix = if message.is_empty() { "" } else { ":" };
         format!(
             "{}:{}:{}{}{}",

--- a/src/vm/errors/vm_exception.rs
+++ b/src/vm/errors/vm_exception.rs
@@ -1,0 +1,34 @@
+use crate::{
+    serde::deserialize_program::{Attribute, Location},
+    vm::runners::cairo_runner::CairoRunner,
+};
+
+use super::runner_errors::RunnerError;
+
+pub struct VmException {
+    pc: usize,
+    inst_location: Option<Location>,
+    inner_exc: RunnerError,
+    error_attr_value: Option<String>,
+}
+
+impl VmException {
+    fn from_runner_error(runner: CairoRunner, error: RunnerError, pc: usize) -> Self {
+        let error_attr_value = get_error_attr_value(pc, &runner.program.error_message_attributes);
+        VmException {
+            pc,
+            inst_location: runner.program.instruction_locations.get(&pc).cloned(),
+            inner_exc: error,
+            error_attr_value,
+        }
+    }
+}
+
+fn get_error_attr_value(pc: usize, attributes: &Vec<Attribute>) -> Option<String> {
+    for attribute in attributes {
+        if attribute.start_pc >= pc && attribute.end_pc <= pc {
+            return Some(attribute.value.clone());
+        }
+    }
+    None
+}

--- a/src/vm/errors/vm_exception.rs
+++ b/src/vm/errors/vm_exception.rs
@@ -59,6 +59,7 @@ impl Display for VmException {
                     break;
                 }
             }
+            error_msg.push_str(&location_msg)
         } else {
             error_msg.push_str(&format!("{}\n", message));
         }

--- a/src/vm/errors/vm_exception.rs
+++ b/src/vm/errors/vm_exception.rs
@@ -78,3 +78,77 @@ impl Location {
         )
     }
 }
+#[cfg(test)]
+mod test {
+    use std::collections::HashMap;
+
+    use crate::serde::deserialize_program::InputFile;
+    use crate::types::program::Program;
+    use crate::utils::test_utils::*;
+
+    use super::*;
+    #[test]
+    fn get_vm_exception_from_vm_error() {
+        let pc = 1;
+        let location = Location {
+            end_line: 2,
+            end_col: 2,
+            input_file: InputFile {
+                filename: String::from("Folder/file.cairo"),
+            },
+            parent_location: None,
+            start_line: 1,
+            start_col: 1,
+        };
+        let program = program!(instruction_locations = HashMap::from([(pc, location.clone())]),);
+        let runner = cairo_runner!(program);
+        let vm_excep = VmException {
+            pc,
+            inst_location: Some(location),
+            inner_exc: VirtualMachineError::CouldntPopPositions,
+            error_attr_value: None,
+        };
+        assert_eq!(
+            VmException::from_vm_error(&runner, VirtualMachineError::CouldntPopPositions, pc),
+            vm_excep
+        )
+    }
+
+    #[test]
+    fn location_to_string_no_message() {
+        let location = Location {
+            end_line: 2,
+            end_col: 2,
+            input_file: InputFile {
+                filename: String::from("Folder/file.cairo"),
+            },
+            parent_location: None,
+            start_line: 1,
+            start_col: 1,
+        };
+        let message = String::new();
+        assert_eq!(
+            location.to_string(&message),
+            String::from("Folder/file.cairo:1:1")
+        )
+    }
+
+    #[test]
+    fn location_to_string_with_message() {
+        let location = Location {
+            end_line: 2,
+            end_col: 2,
+            input_file: InputFile {
+                filename: String::from("Folder/file.cairo"),
+            },
+            parent_location: None,
+            start_line: 1,
+            start_col: 1,
+        };
+        let message = String::from("While expanding the reference");
+        assert_eq!(
+            location.to_string(&message),
+            String::from("Folder/file.cairo:1:1:While expanding the reference")
+        )
+    }
+}

--- a/src/vm/errors/vm_exception.rs
+++ b/src/vm/errors/vm_exception.rs
@@ -1,19 +1,22 @@
+use thiserror::Error;
+
 use crate::{
     serde::deserialize_program::{Attribute, Location},
     vm::runners::cairo_runner::CairoRunner,
 };
 
-use super::runner_errors::RunnerError;
-
+use super::vm_errors::VirtualMachineError;
+#[derive(Debug, PartialEq, Error)]
+#[error("Error at pc={pc}.\n{inner_exc}")] //Temporary, should impelment Display manually
 pub struct VmException {
     pc: usize,
     inst_location: Option<Location>,
-    inner_exc: RunnerError,
+    inner_exc: VirtualMachineError,
     error_attr_value: Option<String>,
 }
 
 impl VmException {
-    fn from_runner_error(runner: CairoRunner, error: RunnerError, pc: usize) -> Self {
+    pub fn from_vm_error(runner: &CairoRunner, error: VirtualMachineError, pc: usize) -> Self {
         let error_attr_value = get_error_attr_value(pc, &runner.program.error_message_attributes);
         VmException {
             pc,

--- a/src/vm/errors/vm_exception.rs
+++ b/src/vm/errors/vm_exception.rs
@@ -30,8 +30,8 @@ impl VmException {
 
 fn get_error_attr_value(pc: usize, attributes: &Vec<Attribute>) -> Option<String> {
     for attribute in attributes {
-        if attribute.start_pc >= pc && attribute.end_pc <= pc {
-            return Some(format!("Error message :{}\n", attribute.value));
+        if attribute.start_pc <= pc && attribute.end_pc > pc {
+            return Some(format!("Error message: {}\n", attribute.value));
         }
     }
     None
@@ -250,5 +250,30 @@ mod test {
                 VirtualMachineError::FailedToComputeOperands
             )
         )
+    }
+
+    #[test]
+    fn get_error_attr_value_some() {
+        let attributes = vec![Attribute {
+            name: String::from("Error message"),
+            start_pc: 1,
+            end_pc: 5,
+            value: String::from("Invalid hash"),
+        }];
+        assert_eq!(
+            get_error_attr_value(2, &attributes),
+            Some(String::from("Error message: Invalid hash\n"))
+        );
+    }
+
+    #[test]
+    fn get_error_attr_value_none() {
+        let attributes = vec![Attribute {
+            name: String::from("Error message"),
+            start_pc: 1,
+            end_pc: 5,
+            value: String::from("Invalid hash"),
+        }];
+        assert_eq!(get_error_attr_value(5, &attributes), None);
     }
 }

--- a/src/vm/errors/vm_exception.rs
+++ b/src/vm/errors/vm_exception.rs
@@ -151,4 +151,104 @@ mod test {
             String::from("Folder/file.cairo:1:1:While expanding the reference")
         )
     }
+
+    #[test]
+    fn vm_exception_display_instruction_no_location_no_attributes() {
+        let vm_excep = VmException {
+            pc: 2,
+            inst_location: None,
+            inner_exc: VirtualMachineError::FailedToComputeOperands,
+            error_attr_value: None,
+        };
+        assert_eq!(
+            vm_excep.to_string(),
+            format!(
+                "Error at pc=2:\n{}\n",
+                VirtualMachineError::FailedToComputeOperands
+            )
+        )
+    }
+
+    #[test]
+    fn vm_exception_display_instruction_no_location_with_attributes() {
+        let vm_excep = VmException {
+            pc: 2,
+            inst_location: None,
+            inner_exc: VirtualMachineError::FailedToComputeOperands,
+            error_attr_value: Some(String::from("Error message: Block may fail\n")),
+        };
+        assert_eq!(
+            vm_excep.to_string(),
+            format!(
+                "Error message: Block may fail\nError at pc=2:\n{}\n",
+                VirtualMachineError::FailedToComputeOperands
+            )
+        )
+    }
+
+    #[test]
+    fn vm_exception_display_instruction_no_attributes_no_parent() {
+        let location = Location {
+            end_line: 2,
+            end_col: 2,
+            input_file: InputFile {
+                filename: String::from("Folder/file.cairo"),
+            },
+            parent_location: None,
+            start_line: 1,
+            start_col: 1,
+        };
+        let vm_excep = VmException {
+            pc: 2,
+            inst_location: Some(location),
+            inner_exc: VirtualMachineError::FailedToComputeOperands,
+            error_attr_value: None,
+        };
+        assert_eq!(
+            vm_excep.to_string(),
+            format!(
+                "Folder/file.cairo:1:1:Error at pc=2:\n{}\n",
+                VirtualMachineError::FailedToComputeOperands
+            )
+        )
+    }
+
+    #[test]
+    fn vm_exception_display_instruction_no_attributes_with_parent() {
+        let location = Location {
+            end_line: 2,
+            end_col: 2,
+            input_file: InputFile {
+                filename: String::from("Folder/file.cairo"),
+            },
+            parent_location: Some((
+                Box::new(Location {
+                    end_line: 3,
+                    end_col: 3,
+                    input_file: InputFile {
+                        filename: String::from("Folder/file_b.cairo"),
+                    },
+                    parent_location: None,
+                    start_line: 2,
+                    start_col: 2,
+                }),
+                String::from("While expanding the reference:"),
+            )),
+            start_line: 1,
+            start_col: 1,
+        };
+        let vm_excep = VmException {
+            pc: 2,
+            inst_location: Some(location),
+            inner_exc: VirtualMachineError::FailedToComputeOperands,
+            error_attr_value: None,
+        };
+        assert_eq!(
+            vm_excep.to_string(),
+            format!(
+                "Folder/file_b.cairo:2:2:While expanding the reference:\nFolder/file.cairo:1:1:Error at pc=2:\n{}\n",
+                VirtualMachineError::FailedToComputeOperands
+            )
+        )
+    }
 }

--- a/src/vm/errors/vm_exception.rs
+++ b/src/vm/errors/vm_exception.rs
@@ -7,7 +7,7 @@ use crate::{
 
 use super::vm_errors::VirtualMachineError;
 #[derive(Debug, PartialEq, Error)]
-#[error("Error at pc={pc}.\n{inner_exc}")] //Temporary, should impelment Display manually
+#[error("Error at pc={pc}.\n {inner_exc}")] //Temporary, should impelment Display manually
 pub struct VmException {
     pc: usize,
     inst_location: Option<Location>,

--- a/src/vm/errors/vm_exception.rs
+++ b/src/vm/errors/vm_exception.rs
@@ -18,7 +18,7 @@ impl VmException {
         let error_attr_value = get_error_attr_value(pc, runner);
         VmException {
             pc,
-            inst_location: runner.program.instruction_locations.get(&pc).cloned(),
+            inst_location: get_location(&pc, runner),
             inner_exc: error,
             error_attr_value,
         }
@@ -32,6 +32,10 @@ pub fn get_error_attr_value(pc: usize, runner: &CairoRunner) -> Option<String> {
         }
     }
     None
+}
+
+pub fn get_location(pc: &usize, runner: &CairoRunner) -> Option<Location> {
+    runner.program.instruction_locations.get(pc).cloned()
 }
 
 impl Display for VmException {
@@ -276,5 +280,39 @@ mod test {
         let program = program!(error_message_attributes = attributes,);
         let runner = cairo_runner!(program);
         assert_eq!(get_error_attr_value(5, &runner), None);
+    }
+
+    #[test]
+    fn get_location_some() {
+        let location = Location {
+            end_line: 2,
+            end_col: 2,
+            input_file: InputFile {
+                filename: String::from("Folder/file.cairo"),
+            },
+            parent_location: None,
+            start_line: 1,
+            start_col: 1,
+        };
+        let program = program!(instruction_locations = HashMap::from([(2, location.clone())]),);
+        let runner = cairo_runner!(program);
+        assert_eq!(get_location(&2, &runner), Some(location));
+    }
+
+    #[test]
+    fn get_location_none() {
+        let location = Location {
+            end_line: 2,
+            end_col: 2,
+            input_file: InputFile {
+                filename: String::from("Folder/file.cairo"),
+            },
+            parent_location: None,
+            start_line: 1,
+            start_col: 1,
+        };
+        let program = program!(instruction_locations = HashMap::from([(2, location.clone())]),);
+        let runner = cairo_runner!(program);
+        assert_eq!(get_location(&3, &runner), None);
     }
 }

--- a/src/vm/errors/vm_exception.rs
+++ b/src/vm/errors/vm_exception.rs
@@ -31,7 +31,7 @@ impl VmException {
 fn get_error_attr_value(pc: usize, attributes: &Vec<Attribute>) -> Option<String> {
     for attribute in attributes {
         if attribute.start_pc >= pc && attribute.end_pc <= pc {
-            return Some(attribute.value.clone());
+            return Some(format!("Error message :{}\n", attribute.value));
         }
     }
     None

--- a/tests/cairo_run_test.rs
+++ b/tests/cairo_run_test.rs
@@ -780,10 +780,11 @@ fn cairo_run_usort_bad() {
         &hint_executor,
     );
     assert!(err.is_err());
-    assert_eq!(
-        err.err().unwrap().to_string(),
-        "unexpected verify multiplicity fail: positions length != 0"
-    );
+    assert!(err
+        .err()
+        .unwrap()
+        .to_string()
+        .contains("unexpected verify multiplicity fail: positions length != 0"));
 }
 
 #[test]
@@ -810,10 +811,10 @@ fn cairo_run_dict_write_bad() {
         &hint_executor,
     )
     .err();
-    assert_eq!(
-        err.unwrap().to_string(),
-        "Dict Error: Tried to create a dict whithout an initial dict"
-    );
+    assert!(err
+        .unwrap()
+        .to_string()
+        .contains("Dict Error: Tried to create a dict whithout an initial dict"));
 }
 
 #[test]
@@ -839,10 +840,9 @@ fn cairo_run_dict_update_bad() {
         &hint_executor,
     )
     .err();
-    assert_eq!(
-        err.unwrap().to_string(),
+    assert!(err.unwrap().to_string().contains(
         "Dict Error: Got the wrong value for dict_update, expected value: 3, got: 5 for key: 2"
-    );
+    ));
 }
 
 #[test]


### PR DESCRIPTION
- Add more information to errors returned by the runner
- Add cairo-lang compatible VmException error type as a CairoRun enum variant
- Add tests for added methods&functions

The following will be added in a later PR:
- Improving the function `get_error_attr_value` by adding the method `substitute_error_message_references`.
- Fix problem with pc value during hint exceptions leading to not matching the correct attribute value

This PR will not add/process the following information:
- hints field of debug_info.inst_location
- input_file contents
- traceback
- notes
This may be added in the future in terms of priority

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
