### PR TITLE
Derive `Copy` for `Relocatable`

### DIFF
--- a/src/hint_processor/builtin_hint_processor/blake2s_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/blake2s_utils.rs
@@ -152,7 +152,7 @@ pub fn blake2s_add_uint256(
     }
     //Insert first batch of data
     let data = get_maybe_relocatable_array_from_bigint(&inner_data);
-    vm.load_data(&MaybeRelocatable::RelocatableValue(data_ptr.clone()), data)
+    vm.load_data(&MaybeRelocatable::RelocatableValue(data_ptr), data)
         .map_err(VirtualMachineError::MemoryError)?;
     //Build second batch of data
     let mut inner_data = Vec::<BigInt>::new();
@@ -199,7 +199,7 @@ pub fn blake2s_add_uint256_bigend(
     }
     //Insert first batch of data
     let data = get_maybe_relocatable_array_from_bigint(&inner_data);
-    vm.load_data(&MaybeRelocatable::RelocatableValue(data_ptr.clone()), data)
+    vm.load_data(&MaybeRelocatable::RelocatableValue(data_ptr), data)
         .map_err(VirtualMachineError::MemoryError)?;
     //Build second batch of data
     let mut inner_data = Vec::<BigInt>::new();

--- a/src/hint_processor/builtin_hint_processor/dict_manager.rs
+++ b/src/hint_processor/builtin_hint_processor/dict_manager.rs
@@ -142,8 +142,8 @@ impl DictManager {
             .ok_or(VirtualMachineError::NoDictTracker(dict_ptr.segment_index))?;
         if tracker.current_ptr != *dict_ptr {
             return Err(VirtualMachineError::MismatchedDictPtr(
-                tracker.current_ptr.clone(),
-                dict_ptr.clone(),
+                tracker.current_ptr,
+                *dict_ptr,
             ));
         }
         Ok(tracker)
@@ -157,8 +157,8 @@ impl DictManager {
             .ok_or(VirtualMachineError::NoDictTracker(dict_ptr.segment_index))?;
         if tracker.current_ptr != *dict_ptr {
             return Err(VirtualMachineError::MismatchedDictPtr(
-                tracker.current_ptr.clone(),
-                dict_ptr.clone(),
+                tracker.current_ptr,
+                *dict_ptr,
             ));
         }
         Ok(tracker)
@@ -175,7 +175,7 @@ impl DictTracker {
     pub fn new_empty(base: &Relocatable) -> Self {
         DictTracker {
             data: Dictionary::SimpleDictionary(HashMap::new()),
-            current_ptr: base.clone(),
+            current_ptr: *base,
         }
     }
 
@@ -193,14 +193,14 @@ impl DictTracker {
                 },
                 default_value: default_value.clone(),
             },
-            current_ptr: base.clone(),
+            current_ptr: *base,
         }
     }
 
     pub fn new_with_initial(base: &Relocatable, initial_dict: HashMap<BigInt, BigInt>) -> Self {
         DictTracker {
             data: Dictionary::SimpleDictionary(initial_dict),
-            current_ptr: base.clone(),
+            current_ptr: *base,
         }
     }
 

--- a/src/hint_processor/builtin_hint_processor/find_element_hint.rs
+++ b/src/hint_processor/builtin_hint_processor/find_element_hint.rs
@@ -71,7 +71,7 @@ pub fn find_element(
 
         for i in 0..n_elms_iter {
             let iter_key = vm
-                .get_integer(&(array_start.clone() + (elm_size * i as usize)))
+                .get_integer(&(array_start + (elm_size * i as usize)))
                 .map_err(|_| VirtualMachineError::KeyNotFound)?;
 
             if iter_key.as_ref() == key.as_ref() {
@@ -112,7 +112,7 @@ pub fn search_sorted_lower(
         }
     }
 
-    let mut array_iter = vm.get_relocatable(&rel_array_ptr)?.into_owned();
+    let mut array_iter = vm.get_relocatable(&rel_array_ptr)?;
     let n_elms_usize = n_elms.to_usize().ok_or(VirtualMachineError::KeyNotFound)?;
     let elm_size_usize = elm_size
         .to_usize()

--- a/src/hint_processor/builtin_hint_processor/hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/hint_utils.rs
@@ -46,10 +46,10 @@ pub fn get_ptr_from_var_name(
     if hint_reference.dereference {
         let value = vm.get_relocatable(&var_addr)?;
         if let Some(immediate) = &hint_reference.immediate {
-            let modified_value = value.as_ref() + bigint_to_usize(immediate)?;
+            let modified_value = value + bigint_to_usize(immediate)?;
             Ok(modified_value)
         } else {
-            Ok(value.into_owned())
+            Ok(value)
         }
     } else {
         Ok(var_addr)

--- a/src/hint_processor/builtin_hint_processor/keccak_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/keccak_utils.rs
@@ -150,7 +150,7 @@ pub fn unsafe_keccak_finalize(
 
     // this is not very nice code, we should consider adding the sub() method for Relocatable's
     let maybe_rel_start_ptr = MaybeRelocatable::RelocatableValue(start_ptr);
-    let maybe_rel_end_ptr = MaybeRelocatable::RelocatableValue(end_ptr.into_owned());
+    let maybe_rel_end_ptr = MaybeRelocatable::RelocatableValue(end_ptr);
 
     let n_elems = maybe_rel_end_ptr
         .sub(&maybe_rel_start_ptr, vm.get_prime())?

--- a/src/hint_processor/builtin_hint_processor/set.rs
+++ b/src/hint_processor/builtin_hint_processor/set.rs
@@ -42,10 +42,7 @@ pub fn set_add(
 
     for i in (0..range_limit).step_by(elm_size) {
         let set_iter = vm
-            .get_range(
-                &MaybeRelocatable::from(set_ptr.clone() + i as usize),
-                elm_size,
-            )
+            .get_range(&MaybeRelocatable::from(set_ptr + i as usize), elm_size)
             .map_err(VirtualMachineError::MemoryError)?;
 
         if set_iter == elm {

--- a/src/hint_processor/builtin_hint_processor/sha256_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/sha256_utils.rs
@@ -54,7 +54,7 @@ pub fn sha256_main(
     let mut message: Vec<u8> = Vec::with_capacity(4 * SHA256_INPUT_CHUNK_SIZE_FELTS);
 
     for i in 0..SHA256_INPUT_CHUNK_SIZE_FELTS {
-        let input_element = vm.get_integer(&(&input_ptr + i))?;
+        let input_element = vm.get_integer(&(input_ptr + i))?;
         let bytes = bigint_to_u32(input_element.as_ref())?.to_be_bytes();
         message.extend(bytes);
     }

--- a/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
@@ -262,7 +262,7 @@ pub fn squash_dict(
     //A map from key to the list of indices accessing it.
     let mut access_indices = HashMap::<BigInt, Vec<BigInt>>::new();
     for i in 0..n_accesses_usize {
-        let key_addr = &address + DICT_ACCESS_SIZE * i;
+        let key_addr = address + DICT_ACCESS_SIZE * i;
         let key = vm
             .get_integer(&key_addr)
             .map_err(|_| VirtualMachineError::ExpectedInteger(MaybeRelocatable::from(key_addr)))?;

--- a/src/hint_processor/builtin_hint_processor/usort.rs
+++ b/src/hint_processor/builtin_hint_processor/usort.rs
@@ -52,7 +52,7 @@ pub fn usort_body(
     let mut positions_dict: HashMap<BigInt, Vec<u64>> = HashMap::new();
     let mut output: Vec<BigInt> = Vec::new();
     for i in 0..input_len_u64 {
-        let val = vm.get_integer(&(&input_ptr + i as usize))?.into_owned();
+        let val = vm.get_integer(&(input_ptr + i as usize))?.into_owned();
         if let Err(output_index) = output.binary_search(&val) {
             output.insert(output_index, val.clone());
         }
@@ -69,11 +69,11 @@ pub fn usort_body(
     let output_len = output.len();
 
     for (i, sorted_element) in output.into_iter().enumerate() {
-        vm.insert_value(&(&output_base + i), sorted_element)?;
+        vm.insert_value(&(output_base + i), sorted_element)?;
     }
 
     for (i, repetition_amount) in multiplicities.into_iter().enumerate() {
-        vm.insert_value(&(&multiplicities_base + i), bigint!(repetition_amount))?;
+        vm.insert_value(&(multiplicities_base + i), bigint!(repetition_amount))?;
     }
 
     insert_value_from_var_name("output_len", bigint!(output_len), vm, ids_data, ap_tracking)?;

--- a/src/hint_processor/hint_processor_utils.rs
+++ b/src/hint_processor/hint_processor_utils.rs
@@ -53,10 +53,10 @@ pub fn get_ptr_from_reference(
     if hint_reference.dereference {
         let value = vm.get_relocatable(&var_addr)?;
         if let Some(immediate) = &hint_reference.immediate {
-            let modified_value = value.as_ref() + bigint_to_usize(immediate)?;
+            let modified_value = value + bigint_to_usize(immediate)?;
             Ok(modified_value)
         } else {
-            Ok(value.into_owned())
+            Ok(value)
         }
     } else {
         Ok(var_addr)
@@ -96,7 +96,7 @@ pub fn compute_addr_from_reference(
         let dereferenced_addr = vm
             .get_relocatable(&addr)
             .map_err(|_| VirtualMachineError::FailedToGetIds)?;
-        let dereferenced_addr = dereferenced_addr.as_ref();
+        let dereferenced_addr = dereferenced_addr;
         if let Some(imm) = &hint_reference.immediate {
             Ok(dereferenced_addr + bigint_to_usize(imm)?)
         } else {

--- a/src/types/relocatable.rs
+++ b/src/types/relocatable.rs
@@ -7,7 +7,7 @@ use num_integer::Integer;
 use num_traits::{FromPrimitive, Signed, ToPrimitive};
 use std::ops::Add;
 
-#[derive(Eq, Hash, PartialEq, PartialOrd, Clone, Debug)]
+#[derive(Eq, Hash, PartialEq, PartialOrd, Clone, Copy, Debug)]
 pub struct Relocatable {
     pub segment_index: isize,
     pub offset: usize,

--- a/src/types/relocatable.rs
+++ b/src/types/relocatable.rs
@@ -840,7 +840,7 @@ mod tests {
     #[test]
     fn get_relocatable_test() {
         assert_eq!(
-            Ok(&relocatable!(1, 2)),
+            Ok(relocatable!(1, 2)),
             mayberelocatable!(1, 2).get_relocatable()
         );
         assert_eq!(

--- a/src/types/relocatable.rs
+++ b/src/types/relocatable.rs
@@ -330,9 +330,9 @@ impl MaybeRelocatable {
     }
 
     //Returns reference to Relocatable inside self if Relocatable variant or Error if Int variant
-    pub fn get_relocatable(&self) -> Result<&Relocatable, VirtualMachineError> {
+    pub fn get_relocatable(&self) -> Result<Relocatable, VirtualMachineError> {
         match self {
-            MaybeRelocatable::RelocatableValue(rel) => Ok(rel),
+            MaybeRelocatable::RelocatableValue(rel) => Ok(*rel),
             MaybeRelocatable::Int(_) => Err(VirtualMachineError::ExpectedRelocatable(self.clone())),
         }
     }

--- a/src/types/relocatable.rs
+++ b/src/types/relocatable.rs
@@ -42,13 +42,13 @@ impl From<BigInt> for MaybeRelocatable {
 
 impl From<&Relocatable> for MaybeRelocatable {
     fn from(rel: &Relocatable) -> Self {
-        MaybeRelocatable::RelocatableValue(rel.clone())
+        MaybeRelocatable::RelocatableValue(*rel)
     }
 }
 
 impl From<&Relocatable> for Relocatable {
     fn from(other: &Relocatable) -> Self {
-        other.clone()
+        *other
     }
 }
 
@@ -113,7 +113,7 @@ impl TryFrom<&MaybeRelocatable> for Relocatable {
     type Error = MemoryError;
     fn try_from(other: &MaybeRelocatable) -> Result<Self, MemoryError> {
         match other {
-            MaybeRelocatable::RelocatableValue(rel) => Ok(rel.clone()),
+            MaybeRelocatable::RelocatableValue(rel) => Ok(*rel),
             _ => Err(MemoryError::AddressNotRelocatable),
         }
     }

--- a/src/vm/context/run_context.rs
+++ b/src/vm/context/run_context.rs
@@ -63,11 +63,11 @@ impl RunContext {
             Op1Addr::FP => self.get_fp(),
             Op1Addr::AP => self.get_ap(),
             Op1Addr::Imm => match instruction.off2 == 1 {
-                true => self.pc.clone(),
+                true => self.pc,
                 false => return Err(VirtualMachineError::ImmShouldBe1),
             },
             Op1Addr::Op0 => match op0 {
-                Some(MaybeRelocatable::RelocatableValue(addr)) => addr.clone(),
+                Some(MaybeRelocatable::RelocatableValue(addr)) => *addr,
                 Some(_) => return Err(VirtualMachineError::MemoryError(AddressNotRelocatable)),
                 None => return Err(VirtualMachineError::UnknownOp0),
             },

--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -178,9 +178,8 @@ impl BitwiseBuiltinRunner {
         pointer: Relocatable,
     ) -> Result<(Relocatable, usize), RunnerError> {
         if self._included {
-            if let Ok(stop_pointer) = vm
-                .get_relocatable(&(pointer.sub(1)).map_err(|_| RunnerError::FinalStack)?)
-                .as_deref()
+            if let Ok(stop_pointer) =
+                vm.get_relocatable(&(pointer.sub(1)).map_err(|_| RunnerError::FinalStack)?)
             {
                 if self.base() != stop_pointer.segment_index {
                     return Err(RunnerError::InvalidStopPointer("bitwise".to_string()));

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -250,9 +250,8 @@ impl EcOpBuiltinRunner {
         pointer: Relocatable,
     ) -> Result<(Relocatable, usize), RunnerError> {
         if self._included {
-            if let Ok(stop_pointer) = vm
-                .get_relocatable(&(pointer.sub(1)).map_err(|_| RunnerError::FinalStack)?)
-                .as_deref()
+            if let Ok(stop_pointer) =
+                vm.get_relocatable(&(pointer.sub(1)).map_err(|_| RunnerError::FinalStack)?)
             {
                 if self.base() != stop_pointer.segment_index {
                     return Err(RunnerError::InvalidStopPointer("ec_op".to_string()));

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -96,7 +96,7 @@ impl HashBuiltinRunner {
             num_a.as_ref().map(|x| x.as_ref().map(|x| x.as_ref())),
             num_b.as_ref().map(|x| x.as_ref().map(|x| x.as_ref())),
         ) {
-            self.verified_addresses.borrow_mut().push(address.clone());
+            self.verified_addresses.borrow_mut().push(*address);
 
             //Convert MaybeRelocatable to FieldElement
             let a_string = num_a.to_str_radix(10);
@@ -170,9 +170,8 @@ impl HashBuiltinRunner {
         pointer: Relocatable,
     ) -> Result<(Relocatable, usize), RunnerError> {
         if self._included {
-            if let Ok(stop_pointer) = vm
-                .get_relocatable(&(pointer.sub(1)).map_err(|_| RunnerError::FinalStack)?)
-                .as_deref()
+            if let Ok(stop_pointer) =
+                vm.get_relocatable(&(pointer.sub(1)).map_err(|_| RunnerError::FinalStack)?)
             {
                 if self.base() != stop_pointer.segment_index {
                     return Err(RunnerError::InvalidStopPointer("pedersen".to_string()));

--- a/src/vm/runners/builtin_runner/keccak.rs
+++ b/src/vm/runners/builtin_runner/keccak.rs
@@ -95,7 +95,7 @@ impl KeccakBuiltinRunner {
         }
 
         for i in 0..self.n_input_cells {
-            match memory.get(&(&first_input_addr + i as usize)) {
+            match memory.get(&(first_input_addr + i as usize)) {
                 Err(_err) => return Ok(None),
                 Ok(None) => return Ok(None),
                 _ok => (),
@@ -104,7 +104,7 @@ impl KeccakBuiltinRunner {
 
         if let Some((i, bits)) = self.state_rep.iter().enumerate().next() {
             let value1 = memory
-                .get(&(&first_input_addr + i))
+                .get(&(first_input_addr + i))
                 .map_err(RunnerError::FailedMemoryGet)?
                 .ok_or(RunnerError::NonRelocatableAddress)?;
 
@@ -125,7 +125,7 @@ impl KeccakBuiltinRunner {
 
             for i in 0..self.n_input_cells {
                 let value2 = memory
-                    .get(&(first_input_addr.clone() + i as usize))
+                    .get(&(first_input_addr + i as usize))
                     .map_err(RunnerError::FailedMemoryGet)?;
 
                 input_felts.push(value2)
@@ -198,9 +198,8 @@ impl KeccakBuiltinRunner {
         pointer: Relocatable,
     ) -> Result<(Relocatable, usize), RunnerError> {
         if self._included {
-            if let Ok(stop_pointer) = vm
-                .get_relocatable(&(pointer.sub(1)).map_err(|_| RunnerError::FinalStack)?)
-                .as_deref()
+            if let Ok(stop_pointer) =
+                vm.get_relocatable(&(pointer.sub(1)).map_err(|_| RunnerError::FinalStack)?)
             {
                 if self.base() != stop_pointer.segment_index {
                     return Err(RunnerError::InvalidStopPointer("keccak".to_string()));

--- a/src/vm/runners/builtin_runner/output.rs
+++ b/src/vm/runners/builtin_runner/output.rs
@@ -89,9 +89,8 @@ impl OutputBuiltinRunner {
         pointer: Relocatable,
     ) -> Result<(Relocatable, usize), RunnerError> {
         if self._included {
-            if let Ok(stop_pointer) = vm
-                .get_relocatable(&(pointer.sub(1)).map_err(|_| RunnerError::FinalStack)?)
-                .as_deref()
+            if let Ok(stop_pointer) =
+                vm.get_relocatable(&(pointer.sub(1)).map_err(|_| RunnerError::FinalStack)?)
             {
                 if self.base() != stop_pointer.segment_index {
                     return Err(RunnerError::InvalidStopPointer("range_check".to_string()));

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -186,9 +186,8 @@ impl RangeCheckBuiltinRunner {
         pointer: Relocatable,
     ) -> Result<(Relocatable, usize), RunnerError> {
         if self._included {
-            if let Ok(stop_pointer) = vm
-                .get_relocatable(&(pointer.sub(1)).map_err(|_| RunnerError::FinalStack)?)
-                .as_deref()
+            if let Ok(stop_pointer) =
+                vm.get_relocatable(&(pointer.sub(1)).map_err(|_| RunnerError::FinalStack)?)
             {
                 if self.base() != stop_pointer.segment_index {
                     return Err(RunnerError::InvalidStopPointer("range_check".to_string()));

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -297,7 +297,7 @@ impl CairoRunner {
         entrypoint: usize,
         stack: Vec<MaybeRelocatable>,
     ) -> Result<(), RunnerError> {
-        if let Some(prog_base) = self.program_base.clone() {
+        if let Some(prog_base) = self.program_base {
             let initial_pc = Relocatable {
                 segment_index: prog_base.segment_index,
                 offset: prog_base.offset + entrypoint,
@@ -311,11 +311,11 @@ impl CairoRunner {
                 )
                 .map_err(RunnerError::MemoryInitializationError)?;
         }
-        if let Some(exec_base) = &self.execution_base {
+        if let Some(exec_base) = self.execution_base {
             vm.segments
                 .load_data(
                     &mut vm.memory,
-                    &MaybeRelocatable::RelocatableValue(exec_base.clone()),
+                    &MaybeRelocatable::RelocatableValue(exec_base),
                     stack,
                 )
                 .map_err(RunnerError::MemoryInitializationError)?;
@@ -335,19 +335,19 @@ impl CairoRunner {
         let end = vm.segments.add(&mut vm.memory);
         stack.append(&mut vec![
             return_fp,
-            MaybeRelocatable::RelocatableValue(end.clone()),
+            MaybeRelocatable::RelocatableValue(end),
         ]);
         if let Some(base) = &self.execution_base {
             self.initial_fp = Some(Relocatable {
                 segment_index: base.segment_index,
                 offset: base.offset + stack.len(),
             });
-            self.initial_ap = self.initial_fp.clone();
+            self.initial_ap = self.initial_fp;
         } else {
             return Err(RunnerError::NoExecBaseForEntrypoint);
         }
         self.initialize_state(vm, entrypoint, stack)?;
-        self.final_pc = Some(end.clone());
+        self.final_pc = Some(end);
         Ok(end)
     }
 
@@ -387,7 +387,7 @@ impl CairoRunner {
                     .ok_or(RunnerError::NoExecBase)?
                     + 2,
             );
-            self.initial_ap = self.initial_fp.clone();
+            self.initial_ap = self.initial_fp;
             return Ok(self.program_base.as_ref().ok_or(RunnerError::NoProgBase)?
                 + self.program.end.ok_or(RunnerError::NoProgramEnd)?);
         }
@@ -406,7 +406,7 @@ impl CairoRunner {
     }
 
     pub fn initialize_vm(&mut self, vm: &mut VirtualMachine) -> Result<(), RunnerError> {
-        vm.run_context.pc = self.initial_pc.as_ref().ok_or(RunnerError::NoPC)?.clone();
+        vm.run_context.pc = *self.initial_pc.as_ref().ok_or(RunnerError::NoPC)?;
         vm.run_context.ap = self.initial_ap.as_ref().ok_or(RunnerError::NoAP)?.offset;
         vm.run_context.fp = self.initial_fp.as_ref().ok_or(RunnerError::NoFP)?.offset;
         vm._program_base = Some(MaybeRelocatable::from(
@@ -435,7 +435,7 @@ impl CairoRunner {
     }
 
     pub fn get_initial_fp(&self) -> Option<Relocatable> {
-        self.initial_fp.clone()
+        self.initial_fp
     }
 
     pub fn get_reference_list(&self) -> HashMap<usize, HintReference> {
@@ -574,7 +574,7 @@ impl CairoRunner {
             .as_mut()
             .ok_or(VirtualMachineError::RunNotFinished)?;
 
-        accessed_addressess.extend((0..size).map(|i| &address + i));
+        accessed_addressess.extend((0..size).map(|i| address + i));
         Ok(())
     }
 
@@ -1064,7 +1064,7 @@ impl CairoRunner {
         vm: &mut VirtualMachine,
     ) -> Result<(), RunnerError> {
         self.initialize_all_builtins(vm)?;
-        self.initialize_segments(vm, self.program_base.clone());
+        self.initialize_segments(vm, self.program_base);
         Ok(())
     }
 
@@ -1105,11 +1105,10 @@ impl CairoRunner {
         if self.segments_finalized {
             return Err(RunnerError::FailedAddingReturnValues);
         }
-        let exec_base = self
+        let exec_base = *self
             .execution_base
             .as_ref()
-            .ok_or(RunnerError::NoExecBase)?
-            .clone();
+            .ok_or(RunnerError::NoExecBase)?;
         let begin = pointer.offset - exec_base.offset;
         let ap = vm.get_ap();
         let end = ap.offset - exec_base.offset;

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -199,7 +199,7 @@ impl VirtualMachine {
         let new_pc: Relocatable = match instruction.pc_update {
             PcUpdate::Regular => self.run_context.pc + instruction.size(),
             PcUpdate::Jump => match &operands.res {
-                Some(ref res) => *res.get_relocatable()?,
+                Some(ref res) => res.get_relocatable()?,
                 None => return Err(VirtualMachineError::UnconstrainedResJump),
             },
             PcUpdate::JumpRel => match &operands.res {

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -197,9 +197,9 @@ impl VirtualMachine {
         operands: &Operands,
     ) -> Result<(), VirtualMachineError> {
         let new_pc: Relocatable = match instruction.pc_update {
-            PcUpdate::Regular => &self.run_context.pc + instruction.size(),
+            PcUpdate::Regular => self.run_context.pc + instruction.size(),
             PcUpdate::Jump => match &operands.res {
-                Some(ref res) => res.get_relocatable()?.clone(),
+                Some(ref res) => *res.get_relocatable()?,
                 None => return Err(VirtualMachineError::UnconstrainedResJump),
             },
             PcUpdate::JumpRel => match &operands.res {
@@ -213,7 +213,7 @@ impl VirtualMachine {
                 None => return Err(VirtualMachineError::UnconstrainedResJumpRel),
             },
             PcUpdate::Jnz => match VirtualMachine::is_zero(&operands.dst)? {
-                true => &self.run_context.pc + instruction.size(),
+                true => self.run_context.pc + instruction.size(),
                 false => {
                     (self
                         .run_context
@@ -259,7 +259,7 @@ impl VirtualMachine {
             Opcode::Call => {
                 return Ok((
                     Some(MaybeRelocatable::from(
-                        &self.run_context.pc + instruction.size(),
+                        self.run_context.pc + instruction.size(),
                     )),
                     None,
                 ))
@@ -427,7 +427,7 @@ impl VirtualMachine {
                 Ok(())
             }
             Opcode::Call => {
-                let return_pc = MaybeRelocatable::from(&self.run_context.pc + instruction.size());
+                let return_pc = MaybeRelocatable::from(self.run_context.pc + instruction.size());
                 if operands.op0 != return_pc {
                     return Err(VirtualMachineError::CantWriteReturnPc(
                         operands.op0.clone(),
@@ -480,7 +480,7 @@ impl VirtualMachine {
 
         if let Some(ref mut trace) = &mut self.trace {
             trace.push(TraceEntry {
-                pc: self.run_context.pc.clone(),
+                pc: self.run_context.pc,
                 ap: self.run_context.get_ap(),
                 fp: self.run_context.get_fp(),
             });
@@ -492,7 +492,7 @@ impl VirtualMachine {
                 op_addrs.dst_addr,
                 op_addrs.op0_addr,
                 op_addrs.op1_addr,
-                self.run_context.pc.clone(),
+                self.run_context.pc,
             ];
             accessed_addresses.extend(addresses.into_iter());
         }
@@ -758,10 +758,7 @@ impl VirtualMachine {
     }
 
     ///Gets the relocatable value corresponding to the Relocatable address
-    pub fn get_relocatable(
-        &self,
-        key: &Relocatable,
-    ) -> Result<Cow<Relocatable>, VirtualMachineError> {
+    pub fn get_relocatable(&self, key: &Relocatable) -> Result<Relocatable, VirtualMachineError> {
         self.memory.get_relocatable(key)
     }
 

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -127,7 +127,7 @@ impl Memory {
         };
 
         Cow::Owned(
-            self.relocate_value(&MaybeRelocatable::RelocatableValue(relocation.clone()))
+            self.relocate_value(&relocation.into())
                 .add_usize_mod(value_relocation.offset, None),
         )
     }
@@ -250,13 +250,10 @@ impl Memory {
         }
     }
 
-    pub fn get_relocatable(
-        &self,
-        key: &Relocatable,
-    ) -> Result<Cow<Relocatable>, VirtualMachineError> {
+    pub fn get_relocatable(&self, key: &Relocatable) -> Result<Relocatable, VirtualMachineError> {
         match self.get(key).map_err(VirtualMachineError::MemoryError)? {
-            Some(Cow::Borrowed(MaybeRelocatable::RelocatableValue(rel))) => Ok(Cow::Borrowed(rel)),
-            Some(Cow::Owned(MaybeRelocatable::RelocatableValue(rel))) => Ok(Cow::Owned(rel)),
+            Some(Cow::Borrowed(MaybeRelocatable::RelocatableValue(rel))) => Ok(*rel),
+            Some(Cow::Owned(MaybeRelocatable::RelocatableValue(rel))) => Ok(rel),
             _ => Err(VirtualMachineError::ExpectedRelocatable(
                 MaybeRelocatable::from(key),
             )),

--- a/src/vm/vm_memory/memory_segments.rs
+++ b/src/vm/vm_memory/memory_segments.rs
@@ -144,7 +144,7 @@ impl MemorySegmentManager {
         for arg in args {
             if let Some(value) = arg.downcast_ref::<MaybeRelocatable>() {
                 cairo_args.push(match value {
-                    MaybeRelocatable::RelocatableValue(value) => value.clone().into(),
+                    MaybeRelocatable::RelocatableValue(value) => value.into(),
                     MaybeRelocatable::Int(value) => {
                         let value = value.mod_floor(vm.get_prime());
                         value.into()


### PR DESCRIPTION
The type is trivially copy because it's just two immediate machine words. Implementing `Copy` makes it more ergonomic to use due to reduced calls to `.clone`.