### PR TITLE
Fix bug in  ASSERT_EQ case in opcode_assertions 

### DIFF
--- a/src/vm/errors/vm_errors.rs
+++ b/src/vm/errors/vm_errors.rs
@@ -28,8 +28,8 @@ pub enum VirtualMachineError {
     UnconstrainedResJumpRel,
     #[error("Res.UNCONSTRAINED cannot be used with Opcode.ASSERT_EQ")]
     UnconstrainedResAssertEq,
-    #[error("ASSERT_EQ instruction failed; {0} != {1}")]
-    DiffAssertValues(BigInt, BigInt),
+    #[error("ASSERT_EQ instruction failed; {0:?} != {1:?}")]
+    DiffAssertValues(MaybeRelocatable, MaybeRelocatable),
     #[error("Call failed to write return-pc (inconsistent op0): {0:?} != {1:?}. Did you forget to increment ap?")]
     CantWriteReturnPc(MaybeRelocatable, MaybeRelocatable),
     #[error("Call failed to write return-fp (inconsistent dst): {0:?} != {1:?}. Did you forget to increment ap?")]


### PR DESCRIPTION
In the ASSERT_EQ case of opcode_assertions, values are only compared if they are int values, which lead to assertions between relocatables to be skipped.
This PR fixes the method so that relocatables are also compared and adds a test for this case