### PR TITLE
Change execute_hint to receive mutable self reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ let mut vm = VirtualMachine::new(
 
 let mut cairo_runner = CairoRunner::new(&$program, "all", false);
 
-let hint_processor = BuiltinHintProcessor::new_empty();
+let mut hint_processor = BuiltinHintProcessor::new_empty();
 
 let entrypoint = program
         .identifiers
@@ -70,7 +70,7 @@ When using cairo-rs with the starknet devnet there are additional parameters tha
             true,
             true,
             &mut vm,
-            &hint_processor,
+            &mut hint_processor,
         );
 ```
 

--- a/bench/criterion_benchmark.rs
+++ b/bench/criterion_benchmark.rs
@@ -26,7 +26,7 @@ const BENCH_NAMES: &[&str] = &[
 const BENCH_PATH: &str = "cairo_programs/benchmarks/";
 
 pub fn criterion_benchmarks(c: &mut Criterion) {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     for benchmark_name in build_bench_strings() {
         c.bench_function(&benchmark_name.0, |b| {
             b.iter(|| {
@@ -37,7 +37,7 @@ pub fn criterion_benchmarks(c: &mut Criterion) {
                     false,
                     "all",
                     false,
-                    &hint_executor,
+                    &mut hint_executor,
                 )
             })
         });

--- a/bench/iai_benchmark.rs
+++ b/bench/iai_benchmark.rs
@@ -10,7 +10,7 @@ use iai::{black_box, main};
 macro_rules! iai_bench_expand_prog {
     ($val: ident) => {
         fn $val() -> Result<CairoRunner, CairoRunError> {
-            let hint_executor = BuiltinHintProcessor::new_empty();
+            let mut hint_executor = BuiltinHintProcessor::new_empty();
             let path = Path::new(concat!(
                 "cairo_programs/benchmarks/",
                 stringify!($val),
@@ -23,7 +23,7 @@ macro_rules! iai_bench_expand_prog {
                 false,
                 "all",
                 false,
-                &hint_executor,
+                &mut hint_executor,
             )
         }
     };

--- a/custom_hint_example/src/main.rs
+++ b/custom_hint_example/src/main.rs
@@ -40,7 +40,7 @@ fn main() {
         "main",
         false,
         false,
-        &hint_processor,
+        &mut hint_processor,
     )
     .expect("Couldn't run program");
 }

--- a/docs/hint_processor/README.md
+++ b/docs/hint_processor/README.md
@@ -91,7 +91,7 @@ impl HintProcessor for MyHintProcessor {
     }
 
     fn execute_hint(
-        &self,
+        &mut self,
         vm_proxy: &mut VMProxy,
         exec_scopes_proxy: &mut ExecutionScopesProxy,
         hint_data: &Box<dyn Any>,

--- a/docs/hint_processor/builtin_hint_processor/README.md
+++ b/docs/hint_processor/builtin_hint_processor/README.md
@@ -77,7 +77,7 @@ cairo_run(
         "main",
         false,
         false,
-        &hint_processor,
+        &mut hint_processor,
     )
     .expect("Couldn't run program");
 ```

--- a/src/cairo_run.rs
+++ b/src/cairo_run.rs
@@ -17,7 +17,7 @@ pub fn cairo_run(
     print_output: bool,
     layout: &str,
     proof_mode: bool,
-    hint_executor: &dyn HintProcessor,
+    hint_executor: &mut dyn HintProcessor,
 ) -> Result<CairoRunner, CairoRunError> {
     let program = match Program::from_file(path, Some(entrypoint)) {
         Ok(program) => program,
@@ -142,7 +142,7 @@ mod tests {
 
     fn run_test_program(
         program_path: &Path,
-        hint_processor: &dyn HintProcessor,
+        hint_processor: &mut dyn HintProcessor,
     ) -> Result<(CairoRunner, VirtualMachine), CairoRunError> {
         let program =
             Program::from_file(program_path, Some("main")).map_err(CairoRunError::Program)?;
@@ -165,12 +165,12 @@ mod tests {
         let program_path = Path::new("cairo_programs/not_main.json");
         let program = Program::from_file(program_path, Some("not_main")).unwrap();
         let mut vm = vm!();
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
         let mut cairo_runner = cairo_runner!(program);
 
         let end = cairo_runner.initialize(&mut vm).unwrap();
         assert!(cairo_runner
-            .run_until_pc(end, &mut vm, &hint_processor)
+            .run_until_pc(end, &mut vm, &mut hint_processor)
             .is_ok());
         assert!(cairo_runner.relocate(&mut vm).is_ok());
         // `main` returns without doing nothing, but `not_main` sets `[ap]` to `1`
@@ -200,7 +200,7 @@ mod tests {
     fn cairo_run_with_no_data_program() {
         // a compiled program with no `data` key.
         // it should fail when the program is loaded.
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
         let no_data_program_path = Path::new("cairo_programs/no_data_program.json");
         assert!(cairo_run(
             no_data_program_path,
@@ -209,7 +209,7 @@ mod tests {
             false,
             "plain",
             false,
-            &hint_processor
+            &mut hint_processor
         )
         .is_err());
     }
@@ -218,7 +218,7 @@ mod tests {
     fn cairo_run_with_no_main_program() {
         // a compiled program with no main scope
         // it should fail when trying to run initialize_main_entrypoint.
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
         let no_main_program_path = Path::new("cairo_programs/no_main_program.json");
         assert!(cairo_run(
             no_main_program_path,
@@ -227,7 +227,7 @@ mod tests {
             false,
             "plain",
             false,
-            &hint_processor
+            &mut hint_processor
         )
         .is_err());
     }
@@ -236,7 +236,7 @@ mod tests {
     fn cairo_run_with_invalid_memory() {
         // the program invalid_memory.json has an invalid memory cell and errors when trying to
         // decode the instruction.
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
         let invalid_memory = Path::new("cairo_programs/invalid_memory.json");
         assert!(cairo_run(
             invalid_memory,
@@ -245,7 +245,7 @@ mod tests {
             false,
             "plain",
             false,
-            &hint_processor
+            &mut hint_processor
         )
         .is_err());
     }
@@ -253,8 +253,8 @@ mod tests {
     #[test]
     fn write_output_program() {
         let program_path = Path::new("cairo_programs/bitwise_output.json");
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        let (mut cairo_runner, mut vm) = run_test_program(program_path, &hint_processor)
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
+        let (mut cairo_runner, mut vm) = run_test_program(program_path, &mut hint_processor)
             .expect("Couldn't initialize cairo runner");
         assert!(write_output(&mut cairo_runner, &mut vm).is_ok());
     }
@@ -266,8 +266,8 @@ mod tests {
         let cairo_rs_trace_path = Path::new("cairo_programs/trace_memory/struct_cairo_rs.trace");
 
         // run test program until the end
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        let cairo_runner_result = run_test_program(program_path, &hint_processor);
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
+        let cairo_runner_result = run_test_program(program_path, &mut hint_processor);
         let (mut cairo_runner, mut vm) = cairo_runner_result.unwrap();
 
         // relocate memory so we can dump it to file
@@ -291,8 +291,8 @@ mod tests {
         let cairo_rs_memory_path = Path::new("cairo_programs/trace_memory/struct_cairo_rs.memory");
 
         // run test program until the end
-        let hint_processor = BuiltinHintProcessor::new_empty();
-        let cairo_runner_result = run_test_program(program_path, &hint_processor);
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
+        let cairo_runner_result = run_test_program(program_path, &mut hint_processor);
         let (mut cairo_runner, mut vm) = cairo_runner_result.unwrap();
 
         // relocate memory so we can dump it to file
@@ -309,12 +309,12 @@ mod tests {
     fn run_with_no_trace() {
         let program_path = Path::new("cairo_programs/struct.json");
         let program = Program::from_file(program_path, Some("main")).unwrap();
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         let end = cairo_runner.initialize(&mut vm).unwrap();
         assert!(cairo_runner
-            .run_until_pc(end, &mut vm, &hint_processor)
+            .run_until_pc(end, &mut vm, &mut hint_processor)
             .is_ok());
         assert!(vm.trace.is_none());
     }

--- a/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -116,7 +116,7 @@ impl BuiltinHintProcessor {
 
 impl HintProcessor for BuiltinHintProcessor {
     fn execute_hint(
-        &self,
+        &mut self,
         vm: &mut VirtualMachine,
         exec_scopes: &mut ExecutionScopes,
         hint_data: &Box<dyn Any>,

--- a/src/hint_processor/hint_processor_definition.rs
+++ b/src/hint_processor/hint_processor_definition.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 pub trait HintProcessor {
     //Executes the hint which's data is provided by a dynamic structure previously created by compile_hint
     fn execute_hint(
-        &self,
+        &mut self,
         //Proxy to VM, contains refrences to necessary data
         //+ MemoryProxy, which provides the necessary methods to manipulate memory
         vm: &mut VirtualMachine,

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ fn validate_layout(value: &str) -> Result<(), String> {
 fn main() -> Result<(), CairoRunError> {
     let args = Args::parse();
     let trace_enabled = args.trace_file.is_some();
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     let cairo_runner = match cairo_run::cairo_run(
         &args.filename,
         &args.entrypoint,
@@ -54,7 +54,7 @@ fn main() -> Result<(), CairoRunError> {
         args.print_output,
         &args.layout,
         args.proof_mode,
-        &hint_executor,
+        &mut hint_executor,
     ) {
         Ok(runner) => runner,
         Err(error) => return Err(error),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -352,12 +352,12 @@ pub mod test_utils {
     macro_rules! run_hint {
         ($vm:expr, $ids_data:expr, $hint_code:expr, $exec_scopes:expr, $constants:expr) => {{
             let hint_data = HintProcessorData::new_default($hint_code.to_string(), $ids_data);
-            let hint_processor = BuiltinHintProcessor::new_empty();
+            let mut hint_processor = BuiltinHintProcessor::new_empty();
             hint_processor.execute_hint(&mut $vm, $exec_scopes, &any_box!(hint_data), $constants)
         }};
         ($vm:expr, $ids_data:expr, $hint_code:expr, $exec_scopes:expr) => {{
             let hint_data = HintProcessorData::new_default($hint_code.to_string(), $ids_data);
-            let hint_processor = BuiltinHintProcessor::new_empty();
+            let mut hint_processor = BuiltinHintProcessor::new_empty();
             hint_processor.execute_hint(
                 &mut $vm,
                 $exec_scopes,
@@ -367,7 +367,7 @@ pub mod test_utils {
         }};
         ($vm:expr, $ids_data:expr, $hint_code:expr) => {{
             let hint_data = HintProcessorData::new_default($hint_code.to_string(), $ids_data);
-            let hint_processor = BuiltinHintProcessor::new_empty();
+            let mut hint_processor = BuiltinHintProcessor::new_empty();
             hint_processor.execute_hint(
                 &mut $vm,
                 exec_scopes_ref!(),

--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -369,12 +369,12 @@ mod tests {
 
         let mut cairo_runner = cairo_runner!(program);
 
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
 
         let address = cairo_runner.initialize(&mut vm).unwrap();
 
         cairo_runner
-            .run_until_pc(address, &mut vm, &hint_processor)
+            .run_until_pc(address, &mut vm, &mut hint_processor)
             .unwrap();
 
         assert_eq!(builtin.get_used_cells_and_allocated_size(&vm), Ok((0, 5)));
@@ -412,12 +412,12 @@ mod tests {
 
         let mut cairo_runner = cairo_runner!(program);
 
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
 
         let address = cairo_runner.initialize(&mut vm).unwrap();
 
         cairo_runner
-            .run_until_pc(address, &mut vm, &hint_processor)
+            .run_until_pc(address, &mut vm, &mut hint_processor)
             .unwrap();
 
         assert_eq!(builtin.get_allocated_memory_units(&vm), Ok(5));

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -437,12 +437,12 @@ mod tests {
         );
         let mut cairo_runner = cairo_runner!(program);
 
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
 
         let address = cairo_runner.initialize(&mut vm).unwrap();
 
         cairo_runner
-            .run_until_pc(address, &mut vm, &hint_processor)
+            .run_until_pc(address, &mut vm, &mut hint_processor)
             .unwrap();
 
         assert_eq!(builtin.get_used_cells_and_allocated_size(&vm), Ok((0, 7)));
@@ -480,12 +480,12 @@ mod tests {
 
         let mut cairo_runner = cairo_runner!(program);
 
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
 
         let address = cairo_runner.initialize(&mut vm).unwrap();
 
         cairo_runner
-            .run_until_pc(address, &mut vm, &hint_processor)
+            .run_until_pc(address, &mut vm, &mut hint_processor)
             .unwrap();
 
         assert_eq!(builtin.get_allocated_memory_units(&vm), Ok(7));

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -357,12 +357,12 @@ mod tests {
 
         let mut cairo_runner = cairo_runner!(program);
 
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
 
         let address = cairo_runner.initialize(&mut vm).unwrap();
 
         cairo_runner
-            .run_until_pc(address, &mut vm, &hint_processor)
+            .run_until_pc(address, &mut vm, &mut hint_processor)
             .unwrap();
 
         assert_eq!(builtin.get_used_cells_and_allocated_size(&vm), Ok((0, 3)));
@@ -400,12 +400,12 @@ mod tests {
 
         let mut cairo_runner = cairo_runner!(program);
 
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
 
         let address = cairo_runner.initialize(&mut vm).unwrap();
 
         cairo_runner
-            .run_until_pc(address, &mut vm, &hint_processor)
+            .run_until_pc(address, &mut vm, &mut hint_processor)
             .unwrap();
 
         assert_eq!(builtin.get_allocated_memory_units(&vm), Ok(3));

--- a/src/vm/runners/builtin_runner/keccak.rs
+++ b/src/vm/runners/builtin_runner/keccak.rs
@@ -399,12 +399,12 @@ mod tests {
 
         let mut cairo_runner = cairo_runner!(program, "recursive");
 
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
 
         let address = cairo_runner.initialize(&mut vm).unwrap();
 
         cairo_runner
-            .run_until_pc(address, &mut vm, &hint_processor)
+            .run_until_pc(address, &mut vm, &mut hint_processor)
             .unwrap();
 
         assert_eq!(
@@ -445,12 +445,12 @@ mod tests {
 
         let mut cairo_runner = cairo_runner!(program, "recursive");
 
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
 
         let address = cairo_runner.initialize(&mut vm).unwrap();
 
         cairo_runner
-            .run_until_pc(address, &mut vm, &hint_processor)
+            .run_until_pc(address, &mut vm, &mut hint_processor)
             .unwrap();
 
         assert_eq!(builtin.get_allocated_memory_units(&vm), Ok(16));

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -517,12 +517,12 @@ mod tests {
 
         let mut cairo_runner = cairo_runner!(program);
 
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
 
         let address = cairo_runner.initialize(&mut vm).unwrap();
 
         cairo_runner
-            .run_until_pc(address, &mut vm, &hint_processor)
+            .run_until_pc(address, &mut vm, &mut hint_processor)
             .unwrap();
 
         assert_eq!(builtin.get_allocated_memory_units(&vm), Ok(5));
@@ -560,12 +560,12 @@ mod tests {
 
         let mut cairo_runner = cairo_runner!(program);
 
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
 
         let address = cairo_runner.initialize(&mut vm).unwrap();
 
         cairo_runner
-            .run_until_pc(address, &mut vm, &hint_processor)
+            .run_until_pc(address, &mut vm, &mut hint_processor)
             .unwrap();
 
         assert_eq!(builtin.get_allocated_memory_units(&vm), Ok(7));
@@ -603,12 +603,12 @@ mod tests {
 
         let mut cairo_runner = cairo_runner!(program);
 
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
 
         let address = cairo_runner.initialize(&mut vm).unwrap();
 
         cairo_runner
-            .run_until_pc(address, &mut vm, &hint_processor)
+            .run_until_pc(address, &mut vm, &mut hint_processor)
             .unwrap();
 
         assert_eq!(builtin.get_allocated_memory_units(&vm), Ok(3));
@@ -646,12 +646,12 @@ mod tests {
 
         let mut cairo_runner = cairo_runner!(program);
 
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
 
         let address = cairo_runner.initialize(&mut vm).unwrap();
 
         cairo_runner
-            .run_until_pc(address, &mut vm, &hint_processor)
+            .run_until_pc(address, &mut vm, &mut hint_processor)
             .unwrap();
 
         assert_eq!(builtin.get_allocated_memory_units(&vm), Ok(1));

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -380,12 +380,12 @@ mod tests {
 
         let mut cairo_runner = cairo_runner!(program);
 
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
 
         let address = cairo_runner.initialize(&mut vm).unwrap();
 
         cairo_runner
-            .run_until_pc(address, &mut vm, &hint_processor)
+            .run_until_pc(address, &mut vm, &mut hint_processor)
             .unwrap();
 
         assert_eq!(builtin.get_used_cells_and_allocated_size(&vm), Ok((0, 1)));
@@ -423,12 +423,12 @@ mod tests {
 
         let mut cairo_runner = cairo_runner!(program);
 
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
 
         let address = cairo_runner.initialize(&mut vm).unwrap();
 
         cairo_runner
-            .run_until_pc(address, &mut vm, &hint_processor)
+            .run_until_pc(address, &mut vm, &mut hint_processor)
             .unwrap();
 
         assert_eq!(builtin.get_allocated_memory_units(&vm), Ok(1));

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -468,7 +468,7 @@ impl CairoRunner {
     pub fn get_hint_data_dictionary(
         &self,
         references: &HashMap<usize, HintReference>,
-        hint_executor: &dyn HintProcessor,
+        hint_executor: &mut dyn HintProcessor,
     ) -> Result<HashMap<usize, Vec<Box<dyn Any>>>, VirtualMachineError> {
         let mut hint_data_dictionary = HashMap::<usize, Vec<Box<dyn Any>>>::new();
         for (hint_index, hints) in self.program.hints.iter() {
@@ -503,7 +503,7 @@ impl CairoRunner {
         &mut self,
         address: Relocatable,
         vm: &mut VirtualMachine,
-        hint_processor: &dyn HintProcessor,
+        hint_processor: &mut dyn HintProcessor,
     ) -> Result<(), VirtualMachineError> {
         let references = self.get_reference_list();
         let hint_data_dictionary = self.get_hint_data_dictionary(&references, hint_processor)?;
@@ -523,7 +523,7 @@ impl CairoRunner {
         &mut self,
         steps: usize,
         vm: &mut VirtualMachine,
-        hint_processor: &dyn HintProcessor,
+        hint_processor: &mut dyn HintProcessor,
     ) -> Result<(), VirtualMachineError> {
         let references = self.get_reference_list();
         let hint_data_dictionary = self.get_hint_data_dictionary(&references, hint_processor)?;
@@ -549,7 +549,7 @@ impl CairoRunner {
         &mut self,
         steps: usize,
         vm: &mut VirtualMachine,
-        hint_processor: &dyn HintProcessor,
+        hint_processor: &mut dyn HintProcessor,
     ) -> Result<(), VirtualMachineError> {
         self.run_for_steps(steps.saturating_sub(vm.current_step), vm, hint_processor)
     }
@@ -558,7 +558,7 @@ impl CairoRunner {
     pub fn run_until_next_power_of_2(
         &mut self,
         vm: &mut VirtualMachine,
-        hint_processor: &dyn HintProcessor,
+        hint_processor: &mut dyn HintProcessor,
     ) -> Result<(), VirtualMachineError> {
         self.run_until_steps(vm.current_step.next_power_of_two(), vm, hint_processor)
     }
@@ -685,7 +685,7 @@ impl CairoRunner {
         disable_trace_padding: bool,
         disable_finalize_all: bool,
         vm: &mut VirtualMachine,
-        hint_processor: &dyn HintProcessor,
+        hint_processor: &mut dyn HintProcessor,
     ) -> Result<(), VirtualMachineError> {
         if self.run_ended {
             return Err(RunnerError::RunAlreadyFinished.into());
@@ -969,7 +969,7 @@ impl CairoRunner {
         verify_secure: bool,
         apply_modulo_to_args: bool,
         vm: &mut VirtualMachine,
-        hint_processor: &dyn HintProcessor,
+        hint_processor: &mut dyn HintProcessor,
     ) -> Result<(), VirtualMachineError> {
         let stack = if typed_args {
             if args.len() != 1 {
@@ -1834,7 +1834,7 @@ mod tests {
             ),
             main = Some(3),
         );
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!(true);
         cairo_runner.initialize_segments(&mut vm, None);
@@ -1843,7 +1843,7 @@ mod tests {
         cairo_runner.initialize_vm(&mut vm).unwrap();
         //Execution Phase
         assert_eq!(
-            cairo_runner.run_until_pc(end, &mut vm, &hint_processor),
+            cairo_runner.run_until_pc(end, &mut vm, &mut hint_processor),
             Ok(())
         );
         //Check final values against Python VM
@@ -1915,7 +1915,7 @@ mod tests {
             ),
             main = Some(8),
         );
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!(true);
         cairo_runner.initialize_builtins(&mut vm).unwrap();
@@ -1924,7 +1924,7 @@ mod tests {
         cairo_runner.initialize_vm(&mut vm).unwrap();
         //Execution Phase
         assert_eq!(
-            cairo_runner.run_until_pc(end, &mut vm, &hint_processor),
+            cairo_runner.run_until_pc(end, &mut vm, &mut hint_processor),
             Ok(())
         );
         //Check final values against Python VM
@@ -2021,7 +2021,7 @@ mod tests {
             ),
             main = Some(4),
         );
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!(true);
         cairo_runner.initialize_builtins(&mut vm).unwrap();
@@ -2030,7 +2030,7 @@ mod tests {
         cairo_runner.initialize_vm(&mut vm).unwrap();
         //Execution Phase
         assert_eq!(
-            cairo_runner.run_until_pc(end, &mut vm, &hint_processor),
+            cairo_runner.run_until_pc(end, &mut vm, &mut hint_processor),
             Ok(())
         );
         //Check final values against Python VM
@@ -2155,7 +2155,7 @@ mod tests {
             ),
             main = Some(13),
         );
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!(true);
         cairo_runner.initialize_builtins(&mut vm).unwrap();
@@ -2164,7 +2164,7 @@ mod tests {
         cairo_runner.initialize_vm(&mut vm).unwrap();
         //Execution Phase
         assert_eq!(
-            cairo_runner.run_until_pc(end, &mut vm, &hint_processor),
+            cairo_runner.run_until_pc(end, &mut vm, &mut hint_processor),
             Ok(())
         );
         //Check final values against Python VM
@@ -2385,7 +2385,7 @@ mod tests {
             ),
             main = Some(4),
         );
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!(true);
         cairo_runner.initialize_builtins(&mut vm).unwrap();
@@ -2393,7 +2393,7 @@ mod tests {
         let end = cairo_runner.initialize_main_entrypoint(&mut vm).unwrap();
         cairo_runner.initialize_vm(&mut vm).unwrap();
         assert_eq!(
-            cairo_runner.run_until_pc(end, &mut vm, &hint_processor),
+            cairo_runner.run_until_pc(end, &mut vm, &mut hint_processor),
             Ok(())
         );
         vm.segments.compute_effective_sizes(&vm.memory);
@@ -2520,7 +2520,7 @@ mod tests {
             ),
             main = Some(4),
         );
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!(true);
         cairo_runner.initialize_builtins(&mut vm).unwrap();
@@ -2528,7 +2528,7 @@ mod tests {
         let end = cairo_runner.initialize_main_entrypoint(&mut vm).unwrap();
         cairo_runner.initialize_vm(&mut vm).unwrap();
         assert_eq!(
-            cairo_runner.run_until_pc(end, &mut vm, &hint_processor),
+            cairo_runner.run_until_pc(end, &mut vm, &mut hint_processor),
             Ok(())
         );
         vm.segments.compute_effective_sizes(&vm.memory);
@@ -2700,9 +2700,9 @@ mod tests {
         let end = cairo_runner.initialize_main_entrypoint(&mut vm).unwrap();
         cairo_runner.initialize_vm(&mut vm).unwrap();
         //Execution Phase
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            cairo_runner.run_until_pc(end, &mut vm, &hint_processor),
+            cairo_runner.run_until_pc(end, &mut vm, &mut hint_processor),
             Ok(())
         );
 
@@ -2788,9 +2788,9 @@ mod tests {
             .initialize_vm(&mut vm)
             .expect("Couldn't initialize the VM.");
 
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
-            cairo_runner.run_until_pc(end, &mut vm, &hint_processor),
+            cairo_runner.run_until_pc(end, &mut vm, &mut hint_processor),
             Ok(())
         );
 
@@ -2859,7 +2859,7 @@ mod tests {
             main = Some(8),
         );
 
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
         let mut cairo_runner = cairo_runner!(&program);
 
         let mut vm = vm!(true);
@@ -2871,11 +2871,11 @@ mod tests {
 
         // Full takes 10 steps.
         assert_eq!(
-            cairo_runner.run_for_steps(8, &mut vm, &hint_processor),
+            cairo_runner.run_for_steps(8, &mut vm, &mut hint_processor),
             Ok(())
         );
         assert_eq!(
-            cairo_runner.run_for_steps(8, &mut vm, &hint_processor),
+            cairo_runner.run_for_steps(8, &mut vm, &mut hint_processor),
             Err(VirtualMachineError::EndOfProgram(8 - 2))
         );
     }
@@ -2925,7 +2925,7 @@ mod tests {
             main = Some(8),
         );
 
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
         let mut cairo_runner = cairo_runner!(&program);
 
         let mut vm = vm!(true);
@@ -2937,15 +2937,15 @@ mod tests {
 
         // Full takes 10 steps.
         assert_eq!(
-            cairo_runner.run_until_steps(8, &mut vm, &hint_processor),
+            cairo_runner.run_until_steps(8, &mut vm, &mut hint_processor),
             Ok(())
         );
         assert_eq!(
-            cairo_runner.run_until_steps(10, &mut vm, &hint_processor),
+            cairo_runner.run_until_steps(10, &mut vm, &mut hint_processor),
             Ok(())
         );
         assert_eq!(
-            cairo_runner.run_until_steps(11, &mut vm, &hint_processor),
+            cairo_runner.run_until_steps(11, &mut vm, &mut hint_processor),
             Err(VirtualMachineError::EndOfProgram(1)),
         );
     }
@@ -2997,7 +2997,7 @@ mod tests {
             main = Some(8),
         );
 
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
         let mut cairo_runner = cairo_runner!(&program);
 
         let mut vm = vm!(true);
@@ -3009,51 +3009,51 @@ mod tests {
 
         // Full takes 10 steps.
         assert_eq!(
-            cairo_runner.run_for_steps(1, &mut vm, &hint_processor),
+            cairo_runner.run_for_steps(1, &mut vm, &mut hint_processor),
             Ok(()),
         );
         assert_eq!(
-            cairo_runner.run_until_next_power_of_2(&mut vm, &hint_processor),
+            cairo_runner.run_until_next_power_of_2(&mut vm, &mut hint_processor),
             Ok(())
         );
         assert_eq!(vm.current_step, 1);
 
         assert_eq!(
-            cairo_runner.run_for_steps(1, &mut vm, &hint_processor),
+            cairo_runner.run_for_steps(1, &mut vm, &mut hint_processor),
             Ok(()),
         );
         assert_eq!(
-            cairo_runner.run_until_next_power_of_2(&mut vm, &hint_processor),
+            cairo_runner.run_until_next_power_of_2(&mut vm, &mut hint_processor),
             Ok(())
         );
         assert_eq!(vm.current_step, 2);
 
         assert_eq!(
-            cairo_runner.run_for_steps(1, &mut vm, &hint_processor),
+            cairo_runner.run_for_steps(1, &mut vm, &mut hint_processor),
             Ok(()),
         );
         assert_eq!(
-            cairo_runner.run_until_next_power_of_2(&mut vm, &hint_processor),
+            cairo_runner.run_until_next_power_of_2(&mut vm, &mut hint_processor),
             Ok(())
         );
         assert_eq!(vm.current_step, 4);
 
         assert_eq!(
-            cairo_runner.run_for_steps(1, &mut vm, &hint_processor),
+            cairo_runner.run_for_steps(1, &mut vm, &mut hint_processor),
             Ok(()),
         );
         assert_eq!(
-            cairo_runner.run_until_next_power_of_2(&mut vm, &hint_processor),
+            cairo_runner.run_until_next_power_of_2(&mut vm, &mut hint_processor),
             Ok(())
         );
         assert_eq!(vm.current_step, 8);
 
         assert_eq!(
-            cairo_runner.run_for_steps(1, &mut vm, &hint_processor),
+            cairo_runner.run_for_steps(1, &mut vm, &mut hint_processor),
             Ok(()),
         );
         assert_eq!(
-            cairo_runner.run_until_next_power_of_2(&mut vm, &hint_processor),
+            cairo_runner.run_until_next_power_of_2(&mut vm, &mut hint_processor),
             Err(VirtualMachineError::EndOfProgram(6)),
         );
         assert_eq!(vm.current_step, 10);
@@ -3265,13 +3265,13 @@ mod tests {
     fn end_run_missing_accessed_addresses() {
         let program = program!();
 
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
 
         vm.accessed_addresses = None;
         assert_eq!(
-            cairo_runner.end_run(true, false, &mut vm, &hint_processor),
+            cairo_runner.end_run(true, false, &mut vm, &mut hint_processor),
             Err(MemoryError::MissingAccessedAddresses.into()),
         );
     }
@@ -3280,13 +3280,13 @@ mod tests {
     fn end_run_run_already_finished() {
         let program = program!();
 
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
 
         cairo_runner.run_ended = true;
         assert_eq!(
-            cairo_runner.end_run(true, false, &mut vm, &hint_processor),
+            cairo_runner.end_run(true, false, &mut vm, &mut hint_processor),
             Err(RunnerError::RunAlreadyFinished.into()),
         );
     }
@@ -3295,20 +3295,20 @@ mod tests {
     fn end_run() {
         let program = program!();
 
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
 
         vm.accessed_addresses = Some(Vec::new());
         assert_eq!(
-            cairo_runner.end_run(true, false, &mut vm, &hint_processor),
+            cairo_runner.end_run(true, false, &mut vm, &mut hint_processor),
             Ok(()),
         );
 
         cairo_runner.run_ended = false;
         cairo_runner.relocated_memory.clear();
         assert_eq!(
-            cairo_runner.end_run(true, true, &mut vm, &hint_processor),
+            cairo_runner.end_run(true, true, &mut vm, &mut hint_processor),
             Ok(()),
         );
         assert!(!cairo_runner.run_ended);
@@ -3322,16 +3322,16 @@ mod tests {
         )
         .expect("Call to `Program::from_file()` failed.");
 
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
         let mut cairo_runner = cairo_runner!(program, "all", true);
         let mut vm = vm!(true);
 
         let end = cairo_runner.initialize(&mut vm).unwrap();
         cairo_runner
-            .run_until_pc(end, &mut vm, &hint_processor)
+            .run_until_pc(end, &mut vm, &mut hint_processor)
             .expect("Call to `CairoRunner::run_until_pc()` failed.");
         assert_eq!(
-            cairo_runner.end_run(false, false, &mut vm, &hint_processor),
+            cairo_runner.end_run(false, false, &mut vm, &mut hint_processor),
             Ok(()),
         );
     }
@@ -3439,7 +3439,7 @@ mod tests {
             Program::from_file(Path::new("cairo_programs/not_main.json"), Some("main")).unwrap();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
 
         let entrypoint = program
             .identifiers
@@ -3455,7 +3455,7 @@ mod tests {
                 true,
                 true,
                 &mut vm,
-                &hint_processor,
+                &mut hint_processor,
             ),
             Err(VirtualMachineError::InvalidArgCount(1, 0)),
         );
@@ -3467,7 +3467,7 @@ mod tests {
                 true,
                 true,
                 &mut vm,
-                &hint_processor,
+                &mut hint_processor,
             ),
             Err(VirtualMachineError::InvalidArgCount(1, 2)),
         );
@@ -3481,7 +3481,7 @@ mod tests {
             Program::from_file(Path::new("cairo_programs/not_main.json"), Some("main")).unwrap();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
 
         let entrypoint = program
             .identifiers
@@ -3501,7 +3501,7 @@ mod tests {
                 true,
                 true,
                 &mut vm,
-                &hint_processor,
+                &mut hint_processor,
             ),
             Ok(()),
         );
@@ -3515,7 +3515,7 @@ mod tests {
             Program::from_file(Path::new("cairo_programs/not_main.json"), Some("main")).unwrap();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
 
         let entrypoint = program
             .identifiers
@@ -3535,7 +3535,7 @@ mod tests {
                 true,
                 true,
                 &mut vm,
-                &hint_processor,
+                &mut hint_processor,
             ),
             Ok(()),
         );
@@ -4314,7 +4314,7 @@ mod tests {
             Program::from_file(Path::new("cairo_programs/example_program.json"), None).unwrap();
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!(true); //this true expression dictates that the trace is enabled
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
 
         //this entrypoint tells which function to run in the cairo program
         let main_entrypoint = program
@@ -4335,14 +4335,14 @@ mod tests {
                 true,
                 true,
                 &mut vm,
-                &hint_processor,
+                &mut hint_processor,
             ),
             Ok(()),
         );
 
         let mut new_cairo_runner = cairo_runner!(program);
         let mut new_vm = vm!(true); //this true expression dictates that the trace is enabled
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
 
         new_vm.accessed_addresses = Some(Vec::new());
         new_cairo_runner.initialize_builtins(&mut new_vm).unwrap();
@@ -4363,7 +4363,7 @@ mod tests {
                 true,
                 true,
                 &mut new_vm,
-                &hint_processor,
+                &mut hint_processor,
             ),
             Ok(()),
         );

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -516,7 +516,7 @@ impl VirtualMachine {
 
     pub fn step_hint(
         &mut self,
-        hint_executor: &dyn HintProcessor,
+        hint_executor: &mut dyn HintProcessor,
         exec_scopes: &mut ExecutionScopes,
         hint_data_dictionary: &HashMap<usize, Vec<Box<dyn Any>>>,
         constants: &HashMap<String, BigInt>,
@@ -551,7 +551,7 @@ impl VirtualMachine {
 
     pub fn step(
         &mut self,
-        hint_executor: &dyn HintProcessor,
+        hint_executor: &mut dyn HintProcessor,
         exec_scopes: &mut ExecutionScopes,
         hint_data_dictionary: &HashMap<usize, Vec<Box<dyn Any>>>,
         constants: &HashMap<String, BigInt>,
@@ -2408,10 +2408,10 @@ mod tests {
         let (operands, addresses, _) = vm.compute_operands(&instruction).unwrap();
         assert!(operands == expected_operands);
         assert!(addresses == expected_addresses);
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
             vm.step(
-                &hint_processor,
+                &mut hint_processor,
                 exec_scopes_ref!(),
                 &HashMap::new(),
                 &HashMap::new()
@@ -2638,7 +2638,7 @@ mod tests {
         let mut vm = vm!(true);
         vm.accessed_addresses = Some(Vec::new());
 
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
 
         run_context!(vm, 0, 2, 2);
 
@@ -2650,7 +2650,7 @@ mod tests {
 
         assert_eq!(
             vm.step(
-                &hint_processor,
+                &mut hint_processor,
                 exec_scopes_ref!(),
                 &HashMap::new(),
                 &HashMap::new()
@@ -2726,12 +2726,12 @@ mod tests {
         ];
 
         let final_pc = Relocatable::from((3, 0));
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
         //Run steps
         while vm.run_context.pc != final_pc {
             assert_eq!(
                 vm.step(
-                    &hint_processor,
+                    &mut hint_processor,
                     exec_scopes_ref!(),
                     &HashMap::new(),
                     &HashMap::new()
@@ -2829,10 +2829,10 @@ mod tests {
 
         assert_eq!(vm.run_context.pc, Relocatable::from((0, 0)));
         assert_eq!(vm.run_context.ap, 2);
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
             vm.step(
-                &hint_processor,
+                &mut hint_processor,
                 exec_scopes_ref!(),
                 &HashMap::new(),
                 &HashMap::new()
@@ -2850,10 +2850,10 @@ mod tests {
                 .as_ref(),
             &MaybeRelocatable::Int(bigint!(0x4)),
         );
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
             vm.step(
-                &hint_processor,
+                &mut hint_processor,
                 exec_scopes_ref!(),
                 &HashMap::new(),
                 &HashMap::new()
@@ -2872,10 +2872,10 @@ mod tests {
             &MaybeRelocatable::Int(bigint!(0x5))
         );
 
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
         assert_eq!(
             vm.step(
-                &hint_processor,
+                &mut hint_processor,
                 exec_scopes_ref!(),
                 &HashMap::new(),
                 &HashMap::new()
@@ -3387,7 +3387,7 @@ mod tests {
         }
         //Initialize memory
 
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
 
         vm.memory = memory![
             ((0, 0), 290341444919459839_i64),
@@ -3413,7 +3413,7 @@ mod tests {
         for _ in 0..6 {
             assert_eq!(
                 vm.step(
-                    &hint_processor,
+                    &mut hint_processor,
                     exec_scopes_ref!(),
                     &hint_data_dictionary,
                     &HashMap::new()

--- a/tests/bitwise_test.rs
+++ b/tests/bitwise_test.rs
@@ -15,7 +15,7 @@ fn bitwise_integration_test() {
         Some("main"),
     )
     .expect("Failed to deserialize program");
-    let hint_processor = BuiltinHintProcessor::new_empty();
+    let mut hint_processor = BuiltinHintProcessor::new_empty();
     let mut cairo_runner = CairoRunner::new(&program, "all", false).unwrap();
     let mut vm = VirtualMachine::new(
         BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
@@ -24,7 +24,7 @@ fn bitwise_integration_test() {
     );
     let end = cairo_runner.initialize(&mut vm).unwrap();
     assert!(
-        cairo_runner.run_until_pc(end, &mut vm, &hint_processor) == Ok(()),
+        cairo_runner.run_until_pc(end, &mut vm, &mut hint_processor) == Ok(()),
         "Execution failed"
     );
     assert!(

--- a/tests/cairo_run_test.rs
+++ b/tests/cairo_run_test.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 #[test]
 fn cairo_run_test() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/fibonacci.json"),
         "main",
@@ -12,14 +12,14 @@ fn cairo_run_test() {
         false,
         "small",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_array_sum() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/array_sum.json"),
         "main",
@@ -27,14 +27,14 @@ fn cairo_run_array_sum() {
         false,
         "small",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_big_struct() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/big_struct.json"),
         "main",
@@ -42,14 +42,14 @@ fn cairo_run_big_struct() {
         false,
         "small",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_call_function_assign_param_by_name() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/call_function_assign_param_by_name.json"),
         "main",
@@ -57,14 +57,14 @@ fn cairo_run_call_function_assign_param_by_name() {
         false,
         "small",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_function_return() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/function_return.json"),
         "main",
@@ -72,14 +72,14 @@ fn cairo_run_function_return() {
         false,
         "small",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_function_return_if_print() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/function_return_if_print.json"),
         "main",
@@ -87,14 +87,14 @@ fn cairo_run_function_return_if_print() {
         false,
         "small",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_function_return_to_variable() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/function_return_to_variable.json"),
         "main",
@@ -102,14 +102,14 @@ fn cairo_run_function_return_to_variable() {
         false,
         "small",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_if_and_prime() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/if_and_prime.json"),
         "main",
@@ -117,14 +117,14 @@ fn cairo_run_if_and_prime() {
         false,
         "small",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_if_in_function() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/if_in_function.json"),
         "main",
@@ -132,14 +132,14 @@ fn cairo_run_if_in_function() {
         false,
         "small",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_if_list() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/if_list.json"),
         "main",
@@ -147,14 +147,14 @@ fn cairo_run_if_list() {
         false,
         "small",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_jmp() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/jmp.json"),
         "main",
@@ -162,14 +162,14 @@ fn cairo_run_jmp() {
         false,
         "small",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_jmp_if_condition() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/jmp_if_condition.json"),
         "main",
@@ -177,14 +177,14 @@ fn cairo_run_jmp_if_condition() {
         false,
         "small",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_pointers() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/pointers.json"),
         "main",
@@ -192,14 +192,14 @@ fn cairo_run_pointers() {
         false,
         "small",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_print() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/print.json"),
         "main",
@@ -207,14 +207,14 @@ fn cairo_run_print() {
         false,
         "small",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_return() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/return.json"),
         "main",
@@ -222,14 +222,14 @@ fn cairo_run_return() {
         false,
         "small",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_reversed_register_instructions() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/reversed_register_instructions.json"),
         "main",
@@ -237,14 +237,14 @@ fn cairo_run_reversed_register_instructions() {
         false,
         "small",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_simple_print() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/simple_print.json"),
         "main",
@@ -252,14 +252,14 @@ fn cairo_run_simple_print() {
         false,
         "small",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_test_addition_if() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/test_addition_if.json"),
         "main",
@@ -267,14 +267,14 @@ fn cairo_run_test_addition_if() {
         false,
         "small",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_test_reverse_if() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/test_reverse_if.json"),
         "main",
@@ -282,14 +282,14 @@ fn cairo_run_test_reverse_if() {
         false,
         "small",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_test_subtraction_if() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/test_subtraction_if.json"),
         "main",
@@ -297,14 +297,14 @@ fn cairo_run_test_subtraction_if() {
         false,
         "small",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_use_imported_module() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/use_imported_module.json"),
         "main",
@@ -312,14 +312,14 @@ fn cairo_run_use_imported_module() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_bitwise_output() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/bitwise_output.json"),
         "main",
@@ -327,14 +327,14 @@ fn cairo_run_bitwise_output() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_bitwise_recursion() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/bitwise_recursion.json"),
         "main",
@@ -342,14 +342,14 @@ fn cairo_run_bitwise_recursion() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_integration() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/integration.json"),
         "main",
@@ -357,14 +357,14 @@ fn cairo_run_integration() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_integration_with_alloc_locals() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/integration_with_alloc_locals.json"),
         "main",
@@ -372,14 +372,14 @@ fn cairo_run_integration_with_alloc_locals() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_compare_arrays() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/compare_arrays.json"),
         "main",
@@ -387,14 +387,14 @@ fn cairo_run_compare_arrays() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_compare_greater_array() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/compare_greater_array.json"),
         "main",
@@ -402,14 +402,14 @@ fn cairo_run_compare_greater_array() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_compare_lesser_array() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/compare_lesser_array.json"),
         "main",
@@ -417,14 +417,14 @@ fn cairo_run_compare_lesser_array() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_assert_le_felt_hint() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/assert_le_felt_hint.json"),
         "main",
@@ -432,14 +432,14 @@ fn cairo_run_assert_le_felt_hint() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_assert_250_bit_element_array() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/assert_250_bit_element_array.json"),
         "main",
@@ -447,14 +447,14 @@ fn cairo_run_assert_250_bit_element_array() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_abs_value() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/abs_value_array.json"),
         "main",
@@ -462,14 +462,14 @@ fn cairo_abs_value() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_compare_different_arrays() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/compare_different_arrays.json"),
         "main",
@@ -477,14 +477,14 @@ fn cairo_run_compare_different_arrays() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_assert_nn() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/assert_nn.json"),
         "main",
@@ -492,14 +492,14 @@ fn cairo_run_assert_nn() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_sqrt() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/sqrt.json"),
         "main",
@@ -507,14 +507,14 @@ fn cairo_run_sqrt() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_assert_not_zero() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/assert_not_zero.json"),
         "main",
@@ -522,14 +522,14 @@ fn cairo_run_assert_not_zero() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_split_int() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/split_int.json"),
         "main",
@@ -537,14 +537,14 @@ fn cairo_run_split_int() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_split_int_big() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/split_int_big.json"),
         "main",
@@ -552,14 +552,14 @@ fn cairo_run_split_int_big() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_split_felt() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/split_felt.json"),
         "main",
@@ -567,14 +567,14 @@ fn cairo_run_split_felt() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_math_cmp() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/math_cmp.json"),
         "main",
@@ -582,14 +582,14 @@ fn cairo_run_math_cmp() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_unsigned_div_rem() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/unsigned_div_rem.json"),
         "main",
@@ -597,14 +597,14 @@ fn cairo_run_unsigned_div_rem() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_signed_div_rem() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/signed_div_rem.json"),
         "main",
@@ -612,14 +612,14 @@ fn cairo_run_signed_div_rem() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_assert_lt_felt() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/assert_lt_felt.json"),
         "main",
@@ -627,14 +627,14 @@ fn cairo_run_assert_lt_felt() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_memcpy() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/memcpy_test.json"),
         "main",
@@ -642,14 +642,14 @@ fn cairo_run_memcpy() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_memset() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/memset.json"),
         "main",
@@ -657,14 +657,14 @@ fn cairo_run_memset() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_pow() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/pow.json"),
         "main",
@@ -672,14 +672,14 @@ fn cairo_run_pow() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_dict() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/dict.json"),
         "main",
@@ -687,14 +687,14 @@ fn cairo_run_dict() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_dict_update() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/dict_update.json"),
         "main",
@@ -702,14 +702,14 @@ fn cairo_run_dict_update() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_uint256() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/uint256.json"),
         "main",
@@ -717,14 +717,14 @@ fn cairo_run_uint256() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_find_element() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/find_element.json"),
         "main",
@@ -732,14 +732,14 @@ fn cairo_run_find_element() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_search_sorted_lower() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/search_sorted_lower.json"),
         "main",
@@ -747,14 +747,14 @@ fn cairo_run_search_sorted_lower() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_usort() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/usort.json"),
         "main",
@@ -762,14 +762,14 @@ fn cairo_run_usort() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_usort_bad() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     let err = cairo_run::cairo_run(
         Path::new("cairo_programs/bad_programs/bad_usort.json"),
         "main",
@@ -777,7 +777,7 @@ fn cairo_run_usort_bad() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     );
     assert!(err.is_err());
     assert!(err
@@ -789,7 +789,7 @@ fn cairo_run_usort_bad() {
 
 #[test]
 fn cairo_run_dict_write_bad() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     assert!(cairo_run::cairo_run(
         Path::new("cairo_programs/bad_programs/bad_dict_new.json"),
         "main",
@@ -797,7 +797,7 @@ fn cairo_run_dict_write_bad() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .is_err());
 
@@ -808,7 +808,7 @@ fn cairo_run_dict_write_bad() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .err();
     assert!(err
@@ -819,7 +819,7 @@ fn cairo_run_dict_write_bad() {
 
 #[test]
 fn cairo_run_dict_update_bad() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     assert!(cairo_run::cairo_run(
         Path::new("cairo_programs/bad_programs/bad_dict_update.json"),
         "main",
@@ -827,7 +827,7 @@ fn cairo_run_dict_update_bad() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .is_err());
     let err = cairo_run::cairo_run(
@@ -837,7 +837,7 @@ fn cairo_run_dict_update_bad() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .err();
     assert!(err.unwrap().to_string().contains(
@@ -847,7 +847,7 @@ fn cairo_run_dict_update_bad() {
 
 #[test]
 fn cairo_run_squash_dict() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/squash_dict.json"),
         "main",
@@ -855,14 +855,14 @@ fn cairo_run_squash_dict() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_dict_squash() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/dict_squash.json"),
         "main",
@@ -870,14 +870,14 @@ fn cairo_run_dict_squash() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_set_add() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/set_add.json"),
         "main",
@@ -885,14 +885,14 @@ fn cairo_run_set_add() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_secp() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/secp.json"),
         "main",
@@ -900,14 +900,14 @@ fn cairo_run_secp() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_signature() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/signature.json"),
         "main",
@@ -915,14 +915,14 @@ fn cairo_run_signature() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_secp_ec() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/secp_ec.json"),
         "main",
@@ -930,14 +930,14 @@ fn cairo_run_secp_ec() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_blake2s_hello_world_hash() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/blake2s_hello_world_hash.json"),
         "main",
@@ -945,14 +945,14 @@ fn cairo_run_blake2s_hello_world_hash() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_finalize_blake2s() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/finalize_blake2s.json"),
         "main",
@@ -960,13 +960,13 @@ fn cairo_run_finalize_blake2s() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 #[test]
 fn cairo_run_unsafe_keccak() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/unsafe_keccak.json"),
         "main",
@@ -974,14 +974,14 @@ fn cairo_run_unsafe_keccak() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_blake2s_felts() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/blake2s_felts.json"),
         "main",
@@ -989,14 +989,14 @@ fn cairo_run_blake2s_felts() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_unsafe_keccak_finalize() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/unsafe_keccak_finalize.json"),
         "main",
@@ -1004,14 +1004,14 @@ fn cairo_run_unsafe_keccak_finalize() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_keccak_add_uint256() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/keccak_add_uint256.json"),
         "main",
@@ -1019,14 +1019,14 @@ fn cairo_run_keccak_add_uint256() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_private_keccak() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/_keccak.json"),
         "main",
@@ -1034,14 +1034,14 @@ fn cairo_run_private_keccak() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_keccak_copy_inputs() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/keccak_copy_inputs.json"),
         "main",
@@ -1049,14 +1049,14 @@ fn cairo_run_keccak_copy_inputs() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_finalize_keccak() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/cairo_finalize_keccak.json"),
         "main",
@@ -1064,14 +1064,14 @@ fn cairo_run_finalize_keccak() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_operations_with_data() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/operations_with_data_structures.json"),
         "main",
@@ -1079,14 +1079,14 @@ fn cairo_run_operations_with_data() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_sha256() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/sha256.json"),
         "main",
@@ -1094,14 +1094,14 @@ fn cairo_run_sha256() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_math_cmp_and_pow_integration() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/math_cmp_and_pow_integration_tests.json"),
         "main",
@@ -1109,14 +1109,14 @@ fn cairo_run_math_cmp_and_pow_integration() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_uint256_integration() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/uint256_integration_tests.json"),
         "main",
@@ -1124,14 +1124,14 @@ fn cairo_run_uint256_integration() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_set_integration() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/set_integration_tests.json"),
         "main",
@@ -1139,14 +1139,14 @@ fn cairo_run_set_integration() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_memory_module_integration() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/memory_integration_tests.json"),
         "main",
@@ -1154,14 +1154,14 @@ fn cairo_run_memory_module_integration() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_dict_integration() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/dict_integration_tests.json"),
         "main",
@@ -1169,14 +1169,14 @@ fn cairo_run_dict_integration() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_secp_integration() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/secp_integration_tests.json"),
         "main",
@@ -1184,14 +1184,14 @@ fn cairo_run_secp_integration() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_keccak_integration() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/keccak_integration_tests.json"),
         "main",
@@ -1199,14 +1199,14 @@ fn cairo_run_keccak_integration() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_blake2s_integration() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/blake2s_integration_tests.json"),
         "main",
@@ -1214,14 +1214,14 @@ fn cairo_run_blake2s_integration() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 
 #[test]
 fn cairo_run_relocate_segments() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     cairo_run::cairo_run(
         Path::new("cairo_programs/relocate_segments.json"),
         "main",
@@ -1229,13 +1229,13 @@ fn cairo_run_relocate_segments() {
         false,
         "small",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .expect("Couldn't run program");
 }
 #[test]
 fn cairo_run_error_msg_attr() {
-    let hint_executor = BuiltinHintProcessor::new_empty();
+    let mut hint_executor = BuiltinHintProcessor::new_empty();
     let err = cairo_run::cairo_run(
         Path::new("cairo_programs/bad_programs/error_msg_attr.json"),
         "main",
@@ -1243,7 +1243,7 @@ fn cairo_run_error_msg_attr() {
         false,
         "all",
         false,
-        &hint_executor,
+        &mut hint_executor,
     )
     .err()
     .unwrap();

--- a/tests/pedersen_test.rs
+++ b/tests/pedersen_test.rs
@@ -12,7 +12,7 @@ use num_bigint::{BigInt, Sign};
 fn pedersen_integration_test() {
     let program = Program::from_file(Path::new("cairo_programs/pedersen_test.json"), Some("main"))
         .expect("Failed to deserialize program");
-    let hint_processor = BuiltinHintProcessor::new_empty();
+    let mut hint_processor = BuiltinHintProcessor::new_empty();
     let mut cairo_runner = CairoRunner::new(&program, "all", false).unwrap();
     let mut vm = VirtualMachine::new(
         BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
@@ -21,7 +21,7 @@ fn pedersen_integration_test() {
     );
     let end = cairo_runner.initialize(&mut vm).unwrap();
     assert_eq!(
-        cairo_runner.run_until_pc(end, &mut vm, &hint_processor),
+        cairo_runner.run_until_pc(end, &mut vm, &mut hint_processor),
         Ok(())
     );
     assert!(cairo_runner.relocate(&mut vm) == Ok(()), "Execution failed");

--- a/tests/struct_test.rs
+++ b/tests/struct_test.rs
@@ -14,7 +14,7 @@ use cairo_rs::{
 fn struct_integration_test() {
     let program = Program::from_file(Path::new("cairo_programs/struct.json"), Some("main"))
         .expect("Failed to deserialize program");
-    let hint_processor = BuiltinHintProcessor::new_empty();
+    let mut hint_processor = BuiltinHintProcessor::new_empty();
     let mut cairo_runner = CairoRunner::new(&program, "all", false).unwrap();
     let mut vm = VirtualMachine::new(
         BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
@@ -24,7 +24,7 @@ fn struct_integration_test() {
     let end = cairo_runner.initialize(&mut vm).unwrap();
 
     assert!(
-        cairo_runner.run_until_pc(end, &mut vm, &hint_processor) == Ok(()),
+        cairo_runner.run_until_pc(end, &mut vm, &mut hint_processor) == Ok(()),
         "Execution failed"
     );
     assert!(cairo_runner.relocate(&mut vm) == Ok(()), "Execution failed");


### PR DESCRIPTION
# Change execute_hint to receive a mutable self reference

## Description
This change is in line with what the sequencer needs, to be able to make changes to the hint_processor while executing hints.

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
