### PR TITLE
Add operand number and address to error message

### DIFF
--- a/src/vm/errors/vm_errors.rs
+++ b/src/vm/errors/vm_errors.rs
@@ -218,8 +218,8 @@ pub enum VirtualMachineError {
     NoImm,
     #[error("Tried to compute an address but there was no register in the reference.")]
     NoRegisterInReference,
-    #[error("Couldn't compute operands")]
-    FailedToComputeOperands,
+    #[error("Couldn't compute operand {0} at address {1:?}")]
+    FailedToComputeOperands(String, Relocatable),
     #[error("Custom Hint Error: {0}")]
     CustomHint(String),
     #[error("Arc too big, {0} must be <= {1} and {2} <= {3}")]

--- a/src/vm/errors/vm_exception.rs
+++ b/src/vm/errors/vm_exception.rs
@@ -90,6 +90,7 @@ mod test {
 
     use crate::serde::deserialize_program::{Attribute, InputFile};
     use crate::types::program::Program;
+    use crate::types::relocatable::Relocatable;
     use crate::utils::test_utils::*;
 
     use super::*;
@@ -164,14 +165,20 @@ mod test {
         let vm_excep = VmException {
             pc: 2,
             inst_location: None,
-            inner_exc: VirtualMachineError::FailedToComputeOperands,
+            inner_exc: VirtualMachineError::FailedToComputeOperands(
+                "op0".to_string(),
+                Relocatable::from((0, 4)),
+            ),
             error_attr_value: None,
         };
         assert_eq!(
             vm_excep.to_string(),
             format!(
                 "Error at pc=2:\n{}\n",
-                VirtualMachineError::FailedToComputeOperands
+                VirtualMachineError::FailedToComputeOperands(
+                    "op0".to_string(),
+                    Relocatable::from((0, 4))
+                )
             )
         )
     }
@@ -181,14 +188,20 @@ mod test {
         let vm_excep = VmException {
             pc: 2,
             inst_location: None,
-            inner_exc: VirtualMachineError::FailedToComputeOperands,
+            inner_exc: VirtualMachineError::FailedToComputeOperands(
+                "op0".to_string(),
+                Relocatable::from((0, 4)),
+            ),
             error_attr_value: Some(String::from("Error message: Block may fail\n")),
         };
         assert_eq!(
             vm_excep.to_string(),
             format!(
                 "Error message: Block may fail\nError at pc=2:\n{}\n",
-                VirtualMachineError::FailedToComputeOperands
+                VirtualMachineError::FailedToComputeOperands(
+                    "op0".to_string(),
+                    Relocatable::from((0, 4))
+                )
             )
         )
     }
@@ -208,14 +221,20 @@ mod test {
         let vm_excep = VmException {
             pc: 2,
             inst_location: Some(location),
-            inner_exc: VirtualMachineError::FailedToComputeOperands,
+            inner_exc: VirtualMachineError::FailedToComputeOperands(
+                "op0".to_string(),
+                Relocatable::from((0, 4)),
+            ),
             error_attr_value: None,
         };
         assert_eq!(
             vm_excep.to_string(),
             format!(
                 "Folder/file.cairo:1:1:Error at pc=2:\n{}\n",
-                VirtualMachineError::FailedToComputeOperands
+                VirtualMachineError::FailedToComputeOperands(
+                    "op0".to_string(),
+                    Relocatable::from((0, 4))
+                )
             )
         )
     }
@@ -247,14 +266,17 @@ mod test {
         let vm_excep = VmException {
             pc: 2,
             inst_location: Some(location),
-            inner_exc: VirtualMachineError::FailedToComputeOperands,
+            inner_exc: VirtualMachineError::FailedToComputeOperands(
+                "op0".to_string(),
+                Relocatable::from((0, 4)),
+            ),
             error_attr_value: None,
         };
         assert_eq!(
             vm_excep.to_string(),
             format!(
                 "Folder/file_b.cairo:2:2:While expanding the reference:\nFolder/file.cairo:1:1:Error at pc=2:\n{}\n",
-                VirtualMachineError::FailedToComputeOperands
+                VirtualMachineError::FailedToComputeOperands("op0".to_string(), Relocatable::from((0, 4)))
             )
         )
     }

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -576,7 +576,9 @@ impl VirtualMachine {
             }
             deduced_memory_cell => deduced_memory_cell,
         };
-        let op0 = op0_op.ok_or(VirtualMachineError::FailedToComputeOperands)?;
+        let op0 = op0_op.ok_or_else(|| {
+            VirtualMachineError::FailedToComputeOperands("op0".to_string(), *op0_addr)
+        })?;
         Ok(op0)
     }
 
@@ -599,7 +601,9 @@ impl VirtualMachine {
             }
             deduced_memory_cell => deduced_memory_cell,
         };
-        let op1 = op1_op.ok_or(VirtualMachineError::FailedToComputeOperands)?;
+        let op1 = op1_op.ok_or_else(|| {
+            VirtualMachineError::FailedToComputeOperands("op1".to_string(), *op1_addr)
+        })?;
         Ok(op1)
     }
 


### PR DESCRIPTION
# Add operand number and address to error message

## Description
When we fail with a failedToComputeOperands now it displays the operand that fails and it's address

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
