### PR TITLE
Add traceback to VmException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,7 @@
-2022-12-28
-* Add traceback to VmException
-    * PR: [#657](https://github.com/lambdaclass/cairo-rs/pull/657)
-    * Main functionality changes: `VmException` now contains a traceback in the form of a String which lists the locations (consisting of filename, line, column and pc) of the calls leading to the error.
+* Add traceback to VmException [#657](https://github.com/lambdaclass/cairo-rs/pull/657)
     * Public API changes: 
         * `traceback` field added to `VmException` struct
-        * `VmException::from_vm_error()` signature changed from `pub fn from_vm_error(runner: &CairoRunner, error: VirtualMachineError, pc: usize) -> Self` to `pub fn from_vm_error(runner: &CairoRunner, vm: &VirtualMachine, error: VirtualMachineError) -> Self`
-        * `get_location()` signature changed from `pub fn get_location(pc: &usize, runner: &CairoRunner) -> Option<Location>` to `pub fn get_location(pc: usize, runner: &CairoRunner) -> Option<Location>`
-        * `decode_instruction()` signature changed from `pub fn decode_instruction(encoded_instr: i64, mut imm: Option<BigInt>) -> Result<instruction::Instruction, VirtualMachineError>` to `pub fn decode_instruction(encoded_instr: i64, mut imm: Option<&BigInt>) -> Result<instruction::Instruction, VirtualMachineError>`
-        * Minor changes in `VmExcepion` field's string format to mirror their cairo-lang conterparts.
+        * `pub fn from_vm_error(runner: &CairoRunner, error: VirtualMachineError, pc: usize) -> Self` is now `pub fn from_vm_error(runner: &CairoRunner, vm: &VirtualMachine, error: VirtualMachineError) -> Self`
+        * `pub fn get_location(pc: &usize, runner: &CairoRunner) -> Option<Location>` is now `pub fn get_location(pc: usize, runner: &CairoRunner) -> Option<Location>`
+        * `pub fn decode_instruction(encoded_instr: i64, mut imm: Option<BigInt>) -> Result<instruction::Instruction, VirtualMachineError>` is now `pub fn decode_instruction(encoded_instr: i64, mut imm: Option<&BigInt>) -> Result<instruction::Instruction, VirtualMachineError>`
+        * `VmExcepion` field's string format now mirror their cairo-lang conterparts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 2022-12-28
 * Add traceback to VmException
-    * PR: #657
+    * PR: [#657](https://github.com/lambdaclass/cairo-rs/pull/657)
     * Main functionality changes: `VmException` now contains a traceback in the form of a String which lists the locations (consisting of filename, line, column and pc) of the calls leading to the error.
     * Public API changes: 
         * `traceback` field added to `VmException` struct

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+2022-12-28
+* Add traceback to VmException
+    * PR: #657
+    * Main functionality changes: `VmException` now contains a traceback in the form of a String which lists the locations (consisting of filename, line, column and pc) of the calls leading to the error.
+    * Public API changes: 
+        * `traceback` field added to `VmException` struct
+        * `VmException::from_vm_error()` signature changed from `pub fn from_vm_error(runner: &CairoRunner, error: VirtualMachineError, pc: usize) -> Self` to `pub fn from_vm_error(runner: &CairoRunner, vm: &VirtualMachine, error: VirtualMachineError) -> Self`
+        * `get_location()` signature changed from `pub fn get_location(pc: &usize, runner: &CairoRunner) -> Option<Location>` to `pub fn get_location(pc: usize, runner: &CairoRunner) -> Option<Location>`
+        * `decode_instruction()` signature changed from `pub fn decode_instruction(encoded_instr: i64, mut imm: Option<BigInt>) -> Result<instruction::Instruction, VirtualMachineError>` to `pub fn decode_instruction(encoded_instr: i64, mut imm: Option<&BigInt>) -> Result<instruction::Instruction, VirtualMachineError>`
+        * Minor changes in `VmExcepion` field's string format to mirror their cairo-lang conterparts.

--- a/README.md
+++ b/README.md
@@ -163,3 +163,6 @@ StarkWare's STARK Math blog series:
 
 ### Possible changes for the future
 * Make the alloc functionality an internal feature of the VM rather than a hint.
+
+### Changelog
+Keep track of the latest changes [here](CHANGELOG.md).

--- a/src/cairo_run.rs
+++ b/src/cairo_run.rs
@@ -34,7 +34,7 @@ pub fn cairo_run(
 
     cairo_runner
         .run_until_pc(end, &mut vm, hint_executor)
-        .map_err(|err| VmException::from_vm_error(&cairo_runner, err, vm.run_context.pc.offset))?;
+        .map_err(|err| VmException::from_vm_error(&cairo_runner, &vm, err))?;
     cairo_runner.end_run(false, false, &mut vm, hint_executor)?;
 
     vm.verify_auto_deductions()?;

--- a/src/types/instruction.rs
+++ b/src/types/instruction.rs
@@ -1,5 +1,8 @@
 use num_bigint::BigInt;
+use num_traits::ToPrimitive;
 use serde::Deserialize;
+
+use crate::vm::decoding::decoder::decode_instruction;
 
 #[derive(Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum Register {
@@ -77,4 +80,21 @@ impl Instruction {
             None => 1,
         }
     }
+}
+
+// Returns True if the given instruction looks like a call instruction.
+pub(crate) fn is_call_instruction(encoded_instruction: BigInt, imm: Option<BigInt>) -> bool {
+    let encoded_i64_instruction = match encoded_instruction.to_i64() {
+        Some(num) => num,
+        None => return false,
+    };
+    let instruction = match decode_instruction(encoded_i64_instruction, imm) {
+        Ok(inst) => inst,
+        Err(_) => return false,
+    };
+    return instruction.res == Res::Op1
+        && (instruction.pc_update == PcUpdate::Jump || instruction.pc_update == PcUpdate::JumpRel)
+        && instruction.ap_update == ApUpdate::Add2
+        && instruction.fp_update == FpUpdate::APPlus2
+        && instruction.opcode == Opcode::Call;
 }

--- a/src/types/instruction.rs
+++ b/src/types/instruction.rs
@@ -83,12 +83,12 @@ impl Instruction {
 }
 
 // Returns True if the given instruction looks like a call instruction.
-pub(crate) fn is_call_instruction(encoded_instruction: &BigInt, imm: Option<BigInt>) -> bool {
+pub(crate) fn is_call_instruction(encoded_instruction: &BigInt, imm: Option<&BigInt>) -> bool {
     let encoded_i64_instruction: i64 = match encoded_instruction.to_i64() {
         Some(num) => num,
         None => return false,
     };
-    let instruction = match decode_instruction(encoded_i64_instruction, imm) {
+    let instruction = match decode_instruction(encoded_i64_instruction, imm.cloned()) {
         Ok(inst) => inst,
         Err(_) => return false,
     };
@@ -108,7 +108,7 @@ mod tests {
     #[test]
     fn is_call_instruction_true() {
         let encoded_instruction = bigint!(1226245742482522112_i64);
-        assert!(is_call_instruction(&encoded_instruction, Some(bigint!(2))));
+        assert!(is_call_instruction(&encoded_instruction, Some(&bigint!(2))));
     }
     #[test]
     fn is_call_instruction_false() {

--- a/src/types/instruction.rs
+++ b/src/types/instruction.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use num_bigint::BigInt;
 use num_traits::ToPrimitive;
 use serde::Deserialize;
@@ -83,8 +85,8 @@ impl Instruction {
 }
 
 // Returns True if the given instruction looks like a call instruction.
-pub(crate) fn is_call_instruction(encoded_instruction: BigInt, imm: Option<BigInt>) -> bool {
-    let encoded_i64_instruction = match encoded_instruction.to_i64() {
+pub(crate) fn is_call_instruction(encoded_instruction: &Cow<BigInt>, imm: Option<BigInt>) -> bool {
+    let encoded_i64_instruction: i64 = match encoded_instruction.to_i64() {
         Some(num) => num,
         None => return false,
     };

--- a/src/types/instruction.rs
+++ b/src/types/instruction.rs
@@ -88,7 +88,7 @@ pub(crate) fn is_call_instruction(encoded_instruction: &BigInt, imm: Option<&Big
         Some(num) => num,
         None => return false,
     };
-    let instruction = match decode_instruction(encoded_i64_instruction, imm.cloned()) {
+    let instruction = match decode_instruction(encoded_i64_instruction, imm) {
         Ok(inst) => inst,
         Err(_) => return false,
     };

--- a/src/types/instruction.rs
+++ b/src/types/instruction.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use num_bigint::BigInt;
 use num_traits::ToPrimitive;
 use serde::Deserialize;

--- a/src/types/instruction.rs
+++ b/src/types/instruction.rs
@@ -98,3 +98,21 @@ pub(crate) fn is_call_instruction(encoded_instruction: &BigInt, imm: Option<BigI
         && instruction.fp_update == FpUpdate::APPlus2
         && instruction.opcode == Opcode::Call
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::bigint;
+
+    use super::*;
+
+    #[test]
+    fn is_call_instruction_true() {
+        let encoded_instruction = bigint!(1226245742482522112_i64);
+        assert!(is_call_instruction(&encoded_instruction, Some(bigint!(2))));
+    }
+    #[test]
+    fn is_call_instruction_false() {
+        let encoded_instruction = bigint!(4612671187288031229_i64);
+        assert!(!is_call_instruction(&encoded_instruction, None));
+    }
+}

--- a/src/types/instruction.rs
+++ b/src/types/instruction.rs
@@ -85,7 +85,7 @@ impl Instruction {
 }
 
 // Returns True if the given instruction looks like a call instruction.
-pub(crate) fn is_call_instruction(encoded_instruction: &Cow<BigInt>, imm: Option<BigInt>) -> bool {
+pub(crate) fn is_call_instruction(encoded_instruction: &BigInt, imm: Option<BigInt>) -> bool {
     let encoded_i64_instruction: i64 = match encoded_instruction.to_i64() {
         Some(num) => num,
         None => return false,
@@ -94,9 +94,9 @@ pub(crate) fn is_call_instruction(encoded_instruction: &Cow<BigInt>, imm: Option
         Ok(inst) => inst,
         Err(_) => return false,
     };
-    return instruction.res == Res::Op1
+    instruction.res == Res::Op1
         && (instruction.pc_update == PcUpdate::Jump || instruction.pc_update == PcUpdate::JumpRel)
         && instruction.ap_update == ApUpdate::Add2
         && instruction.fp_update == FpUpdate::APPlus2
-        && instruction.opcode == Opcode::Call;
+        && instruction.opcode == Opcode::Call
 }

--- a/src/vm/decoding/decoder.rs
+++ b/src/vm/decoding/decoder.rs
@@ -1,5 +1,4 @@
-use crate::types::instruction;
-use crate::vm::errors::vm_errors::VirtualMachineError;
+use crate::{types::instruction, vm::errors::vm_errors::VirtualMachineError};
 use num_bigint::BigInt;
 
 //  0|  opcode|ap_update|pc_update|res_logic|op1_src|op0_reg|dst_reg

--- a/src/vm/decoding/decoder.rs
+++ b/src/vm/decoding/decoder.rs
@@ -7,7 +7,7 @@ use num_bigint::BigInt;
 /// Decodes an instruction. The encoding is little endian, so flags go from bit 63 to 48.
 pub fn decode_instruction(
     encoded_instr: i64,
-    mut imm: Option<BigInt>,
+    mut imm: Option<&BigInt>,
 ) -> Result<instruction::Instruction, VirtualMachineError> {
     const DST_REG_MASK: i64 = 0x0001;
     const DST_REG_OFF: i64 = 0;
@@ -118,7 +118,7 @@ pub fn decode_instruction(
         off0,
         off1,
         off2,
-        imm,
+        imm: imm.cloned(),
         dst_register,
         op0_register,
         op1_addr,
@@ -197,7 +197,7 @@ mod decoder_test {
         //   |    CALL|      ADD|     JUMP|      ADD|    IMM|     FP|     FP
         //  0  0  0  1      0  1   0  0  1      0  1 0  0  1       1       1
         //  0001 0100 1010 0111 = 0x14A7; offx = 0
-        let inst = decode_instruction(0x14A7800080008000, Some(bigint!(7))).unwrap();
+        let inst = decode_instruction(0x14A7800080008000, Some(&bigint!(7))).unwrap();
         assert!(matches!(inst.dst_register, instruction::Register::FP));
         assert!(matches!(inst.op0_register, instruction::Register::FP));
         assert!(matches!(inst.op1_addr, instruction::Op1Addr::Imm));

--- a/src/vm/errors/vm_exception.rs
+++ b/src/vm/errors/vm_exception.rs
@@ -22,7 +22,6 @@ impl VmException {
         runner: &CairoRunner,
         vm: &VirtualMachine,
         error: VirtualMachineError,
-        with_traceback: bool,
     ) -> Self {
         let error_attr_value = get_error_attr_value(vm.run_context.pc.offset, runner);
         VmException {
@@ -30,7 +29,7 @@ impl VmException {
             inst_location: get_location(vm.run_context.pc.offset, runner),
             inner_exc: error,
             error_attr_value,
-            traceback: with_traceback.then(|| get_traceback(vm, runner)).flatten(),
+            traceback: get_traceback(vm, runner),
         }
     }
 }
@@ -148,12 +147,7 @@ mod test {
             traceback: None,
         };
         assert_eq!(
-            VmException::from_vm_error(
-                &runner,
-                &vm!(),
-                VirtualMachineError::CouldntPopPositions,
-                false
-            ),
+            VmException::from_vm_error(&runner, &vm!(), VirtualMachineError::CouldntPopPositions,),
             vm_excep
         )
     }

--- a/src/vm/errors/vm_exception.rs
+++ b/src/vm/errors/vm_exception.rs
@@ -28,14 +28,14 @@ impl VmException {
     }
 }
 
-//MISSING LOGIC HERE -> fp param
 pub fn get_error_attr_value(pc: usize, runner: &CairoRunner) -> Option<String> {
+    let mut errors = String::new();
     for attribute in &runner.program.error_message_attributes {
         if attribute.start_pc <= pc && attribute.end_pc > pc {
-            return Some(format!("Error message: {}\n", attribute.value));
+            errors.push_str(&format!("Error message: {}\n", attribute.value));
         }
     }
-    None
+    (!errors.is_empty()).then(|| errors)
 }
 
 pub fn get_location(pc: &usize, runner: &CairoRunner) -> Option<Location> {
@@ -61,14 +61,8 @@ pub fn get_traceback(vm: &VirtualMachine, runner: &CairoRunner) -> Option<String
             None => traceback.push_str(&format!("Unknown location (pc={})\n", traceback_pc.offset)),
         }
     }
-    if traceback.is_empty() {
-        None
-    } else {
-        Some(format!(
-            "Cairo traceback (most recent call last):\n{}",
-            traceback
-        ))
-    }
+    (!traceback.is_empty())
+        .then(|| format!("Cairo traceback (most recent call last):\n{}", traceback))
 }
 
 impl Display for VmException {

--- a/src/vm/errors/vm_exception.rs
+++ b/src/vm/errors/vm_exception.rs
@@ -396,13 +396,13 @@ mod test {
         )
         .expect("Call to `Program::from_file()` failed.");
 
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
         let mut cairo_runner = cairo_runner!(program, "all", false);
         let mut vm = vm!();
 
         let end = cairo_runner.initialize(&mut vm).unwrap();
         assert!(cairo_runner
-            .run_until_pc(end, &mut vm, &hint_processor)
+            .run_until_pc(end, &mut vm, &mut hint_processor)
             .is_err());
         let expected_traceback = String::from("Cairo traceback (most recent call last):\ncairo_programs/bad_programs/bad_dict_update.cairo:10:5: (pc=0:34)\n");
         assert_eq!(get_traceback(&vm, &cairo_runner), Some(expected_traceback));
@@ -417,13 +417,13 @@ mod test {
         )
         .expect("Call to `Program::from_file()` failed.");
 
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
         let mut cairo_runner = cairo_runner!(program, "all", false);
         let mut vm = vm!();
 
         let end = cairo_runner.initialize(&mut vm).unwrap();
         assert!(cairo_runner
-            .run_until_pc(end, &mut vm, &hint_processor)
+            .run_until_pc(end, &mut vm, &mut hint_processor)
             .is_err());
         let expected_traceback = String::from("Cairo traceback (most recent call last):\ncairo_programs/bad_programs/bad_usort.cairo:91:48: (pc=0:97)\ncairo_programs/bad_programs/bad_usort.cairo:36:5: (pc=0:30)\ncairo_programs/bad_programs/bad_usort.cairo:64:5: (pc=0:60)\n");
         assert_eq!(get_traceback(&vm, &cairo_runner), Some(expected_traceback));

--- a/src/vm/errors/vm_exception.rs
+++ b/src/vm/errors/vm_exception.rs
@@ -97,6 +97,9 @@ impl Display for VmException {
         } else {
             error_msg.push_str(&format!("{}\n", message));
         }
+        if let Some(ref string) = self.traceback {
+            error_msg.push_str(&format!("{}\n", string));
+        }
         // Write error message
         write!(f, "{}", error_msg)
     }

--- a/src/vm/errors/vm_exception.rs
+++ b/src/vm/errors/vm_exception.rs
@@ -23,10 +23,11 @@ impl VmException {
         vm: &VirtualMachine,
         error: VirtualMachineError,
     ) -> Self {
-        let error_attr_value = get_error_attr_value(vm.run_context.pc.offset, runner);
+        let pc = vm.run_context.pc.offset;
+        let error_attr_value = get_error_attr_value(pc, runner);
         VmException {
-            pc: vm.run_context.pc.offset,
-            inst_location: get_location(vm.run_context.pc.offset, runner),
+            pc,
+            inst_location: get_location(pc, runner),
             inner_exc: error,
             error_attr_value,
             traceback: get_traceback(vm, runner),

--- a/src/vm/errors/vm_exception.rs
+++ b/src/vm/errors/vm_exception.rs
@@ -125,7 +125,7 @@ mod test {
     use super::*;
     #[test]
     fn get_vm_exception_from_vm_error() {
-        let pc = 1;
+        let pc = 0;
         let location = Location {
             end_line: 2,
             end_col: 2,

--- a/src/vm/trace/mod.rs
+++ b/src/vm/trace/mod.rs
@@ -34,7 +34,7 @@ pub fn get_perm_range_check_limits(
                 })
                 .transpose()?;
 
-            let decoded_instruction = decode_instruction(instruction, immediate)?;
+            let decoded_instruction = decode_instruction(instruction, immediate.as_ref())?;
             let off0 = decoded_instruction
                 .off0
                 .to_isize()

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -3913,13 +3913,13 @@ mod tests {
         )
         .expect("Call to `Program::from_file()` failed.");
 
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
         let mut cairo_runner = cairo_runner!(program, "all", false);
         let mut vm = vm!();
 
         let end = cairo_runner.initialize(&mut vm).unwrap();
         assert!(cairo_runner
-            .run_until_pc(end, &mut vm, &hint_processor)
+            .run_until_pc(end, &mut vm, &mut hint_processor)
             .is_err());
         let expected_traceback = vec![
             (Relocatable::from((1, 3)), Relocatable::from((0, 97))),
@@ -3937,13 +3937,13 @@ mod tests {
         )
         .expect("Call to `Program::from_file()` failed.");
 
-        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
         let mut cairo_runner = cairo_runner!(program, "all", false);
         let mut vm = vm!();
 
         let end = cairo_runner.initialize(&mut vm).unwrap();
         assert!(cairo_runner
-            .run_until_pc(end, &mut vm, &hint_processor)
+            .run_until_pc(end, &mut vm, &mut hint_processor)
             .is_err());
         let expected_traceback = vec![(Relocatable::from((1, 2)), Relocatable::from((0, 34)))];
         assert_eq!(vm.get_traceback_entries(), expected_traceback);

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -743,20 +743,12 @@ impl VirtualMachine {
         // Fetch the fp and pc traceback entries
         for _ in 0..MAX_TRACEBACK_ENTRIES {
             // First we get the fp traceback
-            match fp
-                .sub(2)
-                .ok()
-                .map(|ref r| self.memory.get_owned_relocatable(r))
-            {
+            match fp.sub(2).ok().map(|ref r| self.memory.get_relocatable(r)) {
                 Some(Ok(opt_fp)) if opt_fp != fp => fp = opt_fp,
                 _ => break,
             }
             // Then we get the pc traceback
-            let ret_pc = match fp
-                .sub(1)
-                .ok()
-                .map(|ref r| self.memory.get_owned_relocatable(r))
-            {
+            let ret_pc = match fp.sub(1).ok().map(|ref r| self.memory.get_relocatable(r)) {
                 Some(Ok(opt_pc)) => opt_pc,
                 _ => break,
             };

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -507,8 +507,7 @@ impl VirtualMachine {
         match instruction_ref.to_i64() {
             Some(instruction) => {
                 if let Some(MaybeRelocatable::Int(imm_ref)) = imm.as_ref().map(|x| x.as_ref()) {
-                    let decoded_instruction =
-                        decode_instruction(instruction, Some(imm_ref.clone()))?;
+                    let decoded_instruction = decode_instruction(instruction, Some(imm_ref))?;
                     return Ok(decoded_instruction);
                 }
                 let decoded_instruction = decode_instruction(instruction, None)?;

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -3932,4 +3932,24 @@ mod tests {
         ];
         assert_eq!(vm.get_traceback_entries(), expected_traceback);
     }
+
+    #[test]
+    fn get_traceback_entries_bad_dict_update() {
+        let program = Program::from_file(
+            Path::new("cairo_programs/bad_programs/bad_dict_update.json"),
+            Some("main"),
+        )
+        .expect("Call to `Program::from_file()` failed.");
+
+        let hint_processor = BuiltinHintProcessor::new_empty();
+        let mut cairo_runner = cairo_runner!(program, "all", false);
+        let mut vm = vm!();
+
+        let end = cairo_runner.initialize(&mut vm).unwrap();
+        assert!(cairo_runner
+            .run_until_pc(end, &mut vm, &hint_processor)
+            .is_err());
+        let expected_traceback = vec![(Relocatable::from((1, 2)), Relocatable::from((0, 34)))];
+        assert_eq!(vm.get_traceback_entries(), expected_traceback);
+    }
 }

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -734,7 +734,7 @@ impl VirtualMachine {
     // The returned values consist of the offsets, not the full addresses as the index is constant
     pub(crate) fn get_traceback_entries(&self) -> Vec<(usize, usize)> {
         let entries = Vec::<(usize, usize)>::new();
-        let fp = Relocatable::from((1, self.run_context.fp));
+        let mut fp = Relocatable::from((1, self.run_context.fp));
         for _ in 0..MAX_TRACEBACK_ENTRIES {
             if let (Some(Ok(opt_fp)), Some(Ok(opt_ret_pc))) = (
                 fp.sub(2)
@@ -748,6 +748,15 @@ impl VirtualMachine {
                 if opt_fp == fp {
                     break;
                 };
+                fp = opt_fp;
+                let ret_pc = opt_ret_pc;
+                if let (Some(Ok(instruction0)), Some(Ok(instruction1))) = (
+                    ret_pc.sub(2).ok().map(|ref r| self.memory.get_integer(r)),
+                    ret_pc.sub(1).ok().map(|ref r| self.memory.get_integer(r)),
+                ) {
+                } else {
+                    break;
+                }
             } else {
                 break;
             }

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -761,10 +761,7 @@ impl VirtualMachine {
                         false => {
                             match ret_pc.sub(2).ok().map(|ref r| self.memory.get_integer(r)) {
                                 Some(Ok(instruction0)) => {
-                                    match is_call_instruction(
-                                        &instruction0,
-                                        Some(instruction1.into_owned()),
-                                    ) {
+                                    match is_call_instruction(&instruction0, Some(&instruction1)) {
                                         true => ret_pc.sub(2).unwrap(), // This unwrap wont fail as it is checked before
                                         false => break,
                                     }

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -260,19 +260,6 @@ impl Memory {
         }
     }
 
-    pub fn get_owned_relocatable(
-        &self,
-        key: &Relocatable,
-    ) -> Result<Relocatable, VirtualMachineError> {
-        match self.get(key).map_err(VirtualMachineError::MemoryError)? {
-            Some(Cow::Borrowed(MaybeRelocatable::RelocatableValue(rel))) => Ok(rel.clone()),
-            Some(Cow::Owned(MaybeRelocatable::RelocatableValue(rel))) => Ok(rel),
-            _ => Err(VirtualMachineError::ExpectedRelocatable(
-                MaybeRelocatable::from(key),
-            )),
-        }
-    }
-
     pub fn insert_value<T: Into<MaybeRelocatable>>(
         &mut self,
         key: &Relocatable,

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -263,6 +263,19 @@ impl Memory {
         }
     }
 
+    pub fn get_owned_relocatable(
+        &self,
+        key: &Relocatable,
+    ) -> Result<Relocatable, VirtualMachineError> {
+        match self.get(key).map_err(VirtualMachineError::MemoryError)? {
+            Some(Cow::Borrowed(MaybeRelocatable::RelocatableValue(rel))) => Ok(rel.clone()),
+            Some(Cow::Owned(MaybeRelocatable::RelocatableValue(rel))) => Ok(rel),
+            _ => Err(VirtualMachineError::ExpectedRelocatable(
+                MaybeRelocatable::from(key),
+            )),
+        }
+    }
+
     pub fn insert_value<T: Into<MaybeRelocatable>>(
         &mut self,
         key: &Relocatable,


### PR DESCRIPTION
- Add the `traceback` field to `VmException`
- Add logic necessary to construct the traceback
- Add tests for new/changed methods
- Add changelog
The following will be added in a later PR:
- Improving the function `get_error_attr_value` by adding the method `substitute_error_message_references`.

This PR will not add/process the following information:
- hints field of debug_info.inst_location
- input_file contents
- notes
This may be added in the future in terms of priority
