### PR TITLE
Optimize accessed address tracking

### DIFF
--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -53,7 +53,6 @@ pub struct CairoRunner {
     initial_ap: Option<Relocatable>,
     initial_fp: Option<Relocatable>,
     initial_pc: Option<Relocatable>,
-    accessed_addresses: Option<HashSet<Relocatable>>,
     run_ended: bool,
     segments_finalized: bool,
     execution_public_memory: Option<Vec<usize>>,
@@ -89,7 +88,6 @@ impl CairoRunner {
             initial_ap: None,
             initial_fp: None,
             initial_pc: None,
-            accessed_addresses: None,
             run_ended: false,
             segments_finalized: false,
             proof_mode,
@@ -566,21 +564,6 @@ impl CairoRunner {
         self.run_until_steps(vm.current_step.next_power_of_two(), vm, hint_processor)
     }
 
-    /// Mark a memory address as accesed.
-    pub fn mark_as_accessed(
-        &mut self,
-        address: Relocatable,
-        size: usize,
-    ) -> Result<(), VirtualMachineError> {
-        let accessed_addressess = self
-            .accessed_addresses
-            .as_mut()
-            .ok_or(VirtualMachineError::RunNotFinished)?;
-
-        accessed_addressess.extend((0..size).map(|i| address + i));
-        Ok(())
-    }
-
     pub fn get_perm_range_check_limits(
         &self,
         vm: &VirtualMachine,
@@ -634,18 +617,31 @@ impl CairoRunner {
 
     /// Count the number of holes present in the segments.
     pub fn get_memory_holes(&self, vm: &VirtualMachine) -> Result<usize, MemoryError> {
-        let accessed_addresses = self
+        let program_addresses =
+            (0..self.program.data.len()).map(|offset| Relocatable::from((0, offset)));
+
+        let accessed_addresses = vm
             .accessed_addresses
             .as_ref()
-            .ok_or(MemoryError::MissingAccessedAddresses)?;
+            .ok_or(MemoryError::MissingAccessedAddresses)?
+            .iter()
+            .map(|addr| vm.memory.relocate_address(*addr));
 
-        let mut builtin_accessed_addresses = HashSet::new();
-        for (_, builtin_runner) in &vm.builtin_runners {
-            builtin_accessed_addresses.extend(builtin_runner.get_memory_accesses(vm)?.into_iter());
-        }
+        let builtin_addresses = vm
+            .builtin_runners
+            .iter()
+            .map(|(_, runner)| runner.base())
+            .collect::<Vec<_>>()
+            .into_iter()
+            .flat_map(|base| {
+                let size = vm.segments.get_segment_size(base as usize).unwrap();
+                (0..size).map(move |offset| Relocatable::from((base, offset)))
+            });
 
-        builtin_accessed_addresses.extend(accessed_addresses.iter().cloned());
-        vm.segments.get_memory_holes(&builtin_accessed_addresses)
+        let addresses = program_addresses
+            .chain(accessed_addresses)
+            .chain(builtin_addresses);
+        vm.segments.get_memory_holes(addresses)
     }
 
     /// Check if there are enough trace cells to fill the entire diluted checks.
@@ -693,25 +689,6 @@ impl CairoRunner {
         if self.run_ended {
             return Err(RunnerError::RunAlreadyFinished.into());
         }
-
-        // Process accessed_addresses.
-        self.accessed_addresses = Some({
-            let accessed_addresses = vm
-                .accessed_addresses
-                .as_ref()
-                .ok_or_else::<VirtualMachineError, _>(|| {
-                    MemoryError::MissingAccessedAddresses.into()
-                })?;
-            let mut new_accessed_addresses = HashSet::with_capacity(accessed_addresses.len());
-
-            for addr in accessed_addresses {
-                let relocated_addr = vm.memory.relocate_value(&addr.into()).into_owned();
-
-                new_accessed_addresses.insert(relocated_addr.try_into().unwrap());
-            }
-
-            new_accessed_addresses
-        });
 
         vm.memory.relocate_memory()?;
         vm.end_run(&self.exec_scopes)?;
@@ -1178,8 +1155,7 @@ mod tests {
     fn check_memory_usage_ok_case() {
         //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program!["range_check", "output"];
-        let mut cairo_runner = cairo_runner!(program);
-        cairo_runner.accessed_addresses = Some(HashSet::new());
+        let cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         vm.segments.segment_used_sizes = Some(vec![4]);
 
@@ -1190,11 +1166,10 @@ mod tests {
     fn check_memory_usage_err_case() {
         let program = program!();
 
-        let mut cairo_runner = cairo_runner!(program);
+        let cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
 
-        cairo_runner.accessed_addresses =
-            Some([(1, 0).into(), (1, 3).into()].into_iter().collect());
+        vm.accessed_addresses = Some(vec![(1, 0).into(), (1, 3).into()]);
         vm.builtin_runners = vec![{
             let mut builtin_runner: BuiltinRunner = OutputBuiltinRunner::new(true).into();
             builtin_runner.initialize_segments(&mut vm.segments, &mut vm.memory);
@@ -3073,48 +3048,12 @@ mod tests {
     }
 
     #[test]
-    fn mark_as_accessed() {
-        let program = program!();
-
-        let mut cairo_runner = cairo_runner!(program);
-
-        assert_eq!(
-            cairo_runner.mark_as_accessed((0, 0).into(), 3),
-            Err(VirtualMachineError::RunNotFinished),
-        );
-    }
-
-    #[test]
-    fn mark_as_accessed_missing_accessed_addresses() {
-        let program = program!();
-
-        let mut cairo_runner = cairo_runner!(program);
-
-        cairo_runner.accessed_addresses = Some(HashSet::new());
-        cairo_runner.mark_as_accessed((0, 0).into(), 3).unwrap();
-        cairo_runner.mark_as_accessed((0, 10).into(), 2).unwrap();
-        cairo_runner.mark_as_accessed((1, 1).into(), 1).unwrap();
-        assert_eq!(
-            cairo_runner.accessed_addresses.unwrap(),
-            [
-                (0, 0).into(),
-                (0, 1).into(),
-                (0, 2).into(),
-                (0, 10).into(),
-                (0, 11).into(),
-                (1, 1).into(),
-            ]
-            .into_iter()
-            .collect(),
-        );
-    }
-
-    #[test]
     fn get_memory_holes_missing_accessed_addresses() {
         let program = program!();
 
         let cairo_runner = cairo_runner!(program);
-        let vm = vm!();
+        let mut vm = vm!();
+        vm.accessed_addresses = None;
 
         assert_eq!(
             cairo_runner.get_memory_holes(&vm),
@@ -3126,10 +3065,9 @@ mod tests {
     fn get_memory_holes_missing_segment_used_sizes() {
         let program = program!();
 
-        let mut cairo_runner = cairo_runner!(program);
+        let cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
 
-        cairo_runner.accessed_addresses = Some(HashSet::new());
         vm.builtin_runners = Vec::new();
         assert_eq!(
             cairo_runner.get_memory_holes(&vm),
@@ -3141,10 +3079,9 @@ mod tests {
     fn get_memory_holes_empty() {
         let program = program!();
 
-        let mut cairo_runner = cairo_runner!(program);
+        let cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
 
-        cairo_runner.accessed_addresses = Some(HashSet::new());
         vm.builtin_runners = Vec::new();
         vm.segments.segment_used_sizes = Some(Vec::new());
         assert_eq!(cairo_runner.get_memory_holes(&vm), Ok(0));
@@ -3154,11 +3091,10 @@ mod tests {
     fn get_memory_holes_empty_builtins() {
         let program = program!();
 
-        let mut cairo_runner = cairo_runner!(program);
+        let cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
 
-        cairo_runner.accessed_addresses =
-            Some([(0, 0).into(), (0, 2).into()].into_iter().collect());
+        vm.accessed_addresses = Some(vec![(0, 0).into(), (0, 2).into()]);
         vm.builtin_runners = Vec::new();
         vm.segments.segment_used_sizes = Some(vec![4]);
         assert_eq!(cairo_runner.get_memory_holes(&vm), Ok(2));
@@ -3168,10 +3104,9 @@ mod tests {
     fn get_memory_holes_empty_accesses() {
         let program = program!();
 
-        let mut cairo_runner = cairo_runner!(program);
+        let cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
 
-        cairo_runner.accessed_addresses = Some(HashSet::new());
         vm.builtin_runners = vec![{
             let mut builtin_runner: BuiltinRunner = OutputBuiltinRunner::new(true).into();
             builtin_runner.initialize_segments(&mut vm.segments, &mut vm.memory);
@@ -3186,11 +3121,10 @@ mod tests {
     fn get_memory_holes() {
         let program = program!();
 
-        let mut cairo_runner = cairo_runner!(program);
+        let cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
 
-        cairo_runner.accessed_addresses =
-            Some([(1, 0).into(), (1, 2).into()].into_iter().collect());
+        vm.accessed_addresses = Some(vec![(1, 0).into(), (1, 2).into()]);
         vm.builtin_runners = vec![{
             let mut builtin_runner: BuiltinRunner = OutputBuiltinRunner::new(true).into();
             builtin_runner.initialize_segments(&mut vm.segments, &mut vm.memory);
@@ -3259,23 +3193,6 @@ mod tests {
             BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default(), true).into(),
         )];
         assert_eq!(cairo_runner.check_diluted_check_usage(&vm), Ok(()),);
-    }
-
-    /// Test that ensures end_run() returns an error when accessed_addresses are
-    /// missing.
-    #[test]
-    fn end_run_missing_accessed_addresses() {
-        let program = program!();
-
-        let mut hint_processor = BuiltinHintProcessor::new_empty();
-        let mut cairo_runner = cairo_runner!(program);
-        let mut vm = vm!();
-
-        vm.accessed_addresses = None;
-        assert_eq!(
-            cairo_runner.end_run(true, false, &mut vm, &mut hint_processor),
-            Err(MemoryError::MissingAccessedAddresses.into()),
-        );
     }
 
     #[test]
@@ -3372,10 +3289,9 @@ mod tests {
     fn get_execution_resources_trace_not_enabled() {
         let program = program!();
 
-        let mut cairo_runner = cairo_runner!(program);
+        let cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
 
-        cairo_runner.accessed_addresses = Some(HashSet::new());
         vm.segments.segment_used_sizes = Some(vec![4]);
         assert_eq!(
             cairo_runner.get_execution_resources(&vm),
@@ -3395,7 +3311,6 @@ mod tests {
         let mut vm = vm!();
 
         cairo_runner.original_steps = Some(10);
-        cairo_runner.accessed_addresses = Some(HashSet::new());
         vm.segments.segment_used_sizes = Some(vec![4]);
         assert_eq!(
             cairo_runner.get_execution_resources(&vm),
@@ -3415,7 +3330,6 @@ mod tests {
         let mut vm = vm!();
 
         cairo_runner.original_steps = Some(10);
-        cairo_runner.accessed_addresses = Some(HashSet::new());
         vm.segments.segment_used_sizes = Some(vec![4]);
         vm.builtin_runners = vec![{
             let mut builtin = OutputBuiltinRunner::new(true);
@@ -3858,7 +3772,6 @@ mod tests {
     fn check_used_cells_valid_case() {
         let program = program!["range_check", "output"];
         let mut cairo_runner = cairo_runner!(program);
-        cairo_runner.accessed_addresses = Some(HashSet::new());
         let mut vm = vm!();
         vm.segments.segment_used_sizes = Some(vec![4]);
         vm.trace = Some(vec![]);
@@ -3896,11 +3809,10 @@ mod tests {
     fn check_used_cells_check_memory_usage_error() {
         let program = program!();
 
-        let mut cairo_runner = cairo_runner!(program);
+        let cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
 
-        cairo_runner.accessed_addresses =
-            Some([(1, 0).into(), (1, 3).into()].into_iter().collect());
+        vm.accessed_addresses = Some(vec![(1, 0).into(), (1, 3).into()]);
         vm.builtin_runners = vec![{
             let mut builtin_runner: BuiltinRunner = OutputBuiltinRunner::new(true).into();
             builtin_runner.initialize_segments(&mut vm.segments, &mut vm.memory);
@@ -3921,8 +3833,7 @@ mod tests {
     #[test]
     fn check_used_cells_check_diluted_check_usage_error() {
         let program = program!["range_check", "output"];
-        let mut cairo_runner = cairo_runner!(program);
-        cairo_runner.accessed_addresses = Some(HashSet::new());
+        let cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         vm.segments.segment_used_sizes = Some(vec![4]);
         vm.trace = Some(vec![]);

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -24,6 +24,7 @@ use crate::{
         },
         security::verify_secure_runner,
         trace::get_perm_range_check_limits,
+        vm_memory::memory::RelocateValue,
         {
             runners::builtin_runner::{
                 BitwiseBuiltinRunner, BuiltinRunner, EcOpBuiltinRunner, HashBuiltinRunner,
@@ -625,7 +626,7 @@ impl CairoRunner {
             .as_ref()
             .ok_or(MemoryError::MissingAccessedAddresses)?
             .iter()
-            .map(|addr| vm.memory.relocate_address(*addr));
+            .map(|addr| vm.memory.relocate_value(*addr));
 
         let builtin_addresses = vm
             .builtin_runners

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -2725,7 +2725,6 @@ mod tests {
         let accessed_addresses = vm.accessed_addresses.as_ref().unwrap();
         assert!(accessed_addresses.contains(&Relocatable::from((1, 0))));
         assert!(accessed_addresses.contains(&Relocatable::from((1, 1))));
-        assert!(accessed_addresses.contains(&Relocatable::from((0, 0))));
     }
 
     #[test]
@@ -2825,20 +2824,15 @@ mod tests {
             .unwrap()
             .into_iter()
             .collect::<HashSet<Relocatable>>();
-        assert_eq!(accessed_addresses.len(), 14);
+        assert_eq!(accessed_addresses.len(), 9);
         //Check each element individually
         assert!(accessed_addresses.contains(&Relocatable::from((0, 1))));
-        assert!(accessed_addresses.contains(&Relocatable::from((0, 7))));
         assert!(accessed_addresses.contains(&Relocatable::from((1, 2))));
         assert!(accessed_addresses.contains(&Relocatable::from((0, 4))));
-        assert!(accessed_addresses.contains(&Relocatable::from((0, 0))));
         assert!(accessed_addresses.contains(&Relocatable::from((1, 5))));
         assert!(accessed_addresses.contains(&Relocatable::from((1, 1))));
-        assert!(accessed_addresses.contains(&Relocatable::from((0, 3))));
         assert!(accessed_addresses.contains(&Relocatable::from((1, 4))));
         assert!(accessed_addresses.contains(&Relocatable::from((0, 6))));
-        assert!(accessed_addresses.contains(&Relocatable::from((0, 2))));
-        assert!(accessed_addresses.contains(&Relocatable::from((0, 5))));
         assert!(accessed_addresses.contains(&Relocatable::from((1, 0))));
         assert!(accessed_addresses.contains(&Relocatable::from((1, 3))));
     }

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -739,11 +739,11 @@ impl VirtualMachine {
         base: Relocatable,
         len: usize,
     ) -> Result<(), VirtualMachineError> {
-        Ok(self
-            .accessed_addresses
+        self.accessed_addresses
             .as_mut()
             .ok_or(VirtualMachineError::RunNotFinished)?
-            .extend((0..len).map(|i: usize| base + i)))
+            .extend((0..len).map(|i: usize| base + i));
+        Ok(())
     }
 
     // Returns the values (fp, pc) corresponding to each call instruction in the traceback.

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -488,12 +488,7 @@ impl VirtualMachine {
 
         if let Some(ref mut accessed_addresses) = self.accessed_addresses {
             let op_addrs = operands_addresses;
-            let addresses = [
-                op_addrs.dst_addr,
-                op_addrs.op0_addr,
-                op_addrs.op1_addr,
-                self.run_context.pc,
-            ];
+            let addresses = [op_addrs.dst_addr, op_addrs.op0_addr, op_addrs.op1_addr];
             accessed_addresses.extend(addresses.into_iter());
         }
 

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -132,6 +132,21 @@ impl Memory {
         )
     }
 
+    /// Relocate a value according to the relocation rules.
+    pub fn relocate_address(&self, addr: Relocatable) -> Relocatable {
+        let segment_idx = addr.segment_index;
+        if segment_idx >= 0 {
+            return addr;
+        }
+
+        // Adjust the segment index to begin at zero, as per the struct field's
+        // comment.
+        match self.relocation_rules.get(&(-(segment_idx + 1) as usize)) {
+            Some(x) => x + addr.offset,
+            None => addr,
+        }
+    }
+
     /// Relocates the memory according to the relocation rules and clears `self.relocaction_rules`.
     pub fn relocate_memory(&mut self) -> Result<(), MemoryError> {
         if self.relocation_rules.is_empty() {

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -107,46 +107,6 @@ impl Memory {
         Ok(None)
     }
 
-    /// Relocate a value according to the relocation rules.
-    pub fn relocate_value<'a>(&self, value: &'a MaybeRelocatable) -> Cow<'a, MaybeRelocatable> {
-        let value_relocation = match value {
-            MaybeRelocatable::RelocatableValue(x) => x,
-            value => return Cow::Borrowed(value),
-        };
-
-        let segment_idx = value_relocation.segment_index;
-        if segment_idx >= 0 {
-            return Cow::Borrowed(value);
-        }
-
-        // Adjust the segment index to begin at zero, as per the struct field's
-        // comment.
-        let relocation = match self.relocation_rules.get(&(-(segment_idx + 1) as usize)) {
-            Some(x) => x,
-            None => return Cow::Borrowed(value),
-        };
-
-        Cow::Owned(
-            self.relocate_value(&relocation.into())
-                .add_usize_mod(value_relocation.offset, None),
-        )
-    }
-
-    /// Relocate a value according to the relocation rules.
-    pub fn relocate_address(&self, addr: Relocatable) -> Relocatable {
-        let segment_idx = addr.segment_index;
-        if segment_idx >= 0 {
-            return addr;
-        }
-
-        // Adjust the segment index to begin at zero, as per the struct field's
-        // comment.
-        match self.relocation_rules.get(&(-(segment_idx + 1) as usize)) {
-            Some(x) => x + addr.offset,
-            None => addr,
-        }
-    }
-
     /// Relocates the memory according to the relocation rules and clears `self.relocaction_rules`.
     pub fn relocate_memory(&mut self) -> Result<(), MemoryError> {
         if self.relocation_rules.is_empty() {
@@ -357,6 +317,43 @@ impl Memory {
         }
 
         Ok(values)
+    }
+}
+
+pub(crate) trait RelocateValue<'a, Input: 'a, Output: 'a> {
+    fn relocate_value(&self, value: Input) -> Output;
+}
+
+impl<'a> RelocateValue<'_, Relocatable, Relocatable> for Memory {
+    fn relocate_value(&self, addr: Relocatable) -> Relocatable {
+        let segment_idx = addr.segment_index;
+        if segment_idx >= 0 {
+            return addr;
+        }
+
+        // Adjust the segment index to begin at zero, as per the struct field's
+        // comment.
+        match self.relocation_rules.get(&(-(segment_idx + 1) as usize)) {
+            Some(x) => x + addr.offset,
+            None => addr,
+        }
+    }
+}
+
+impl<'a> RelocateValue<'a, &'a BigInt, &'a BigInt> for Memory {
+    fn relocate_value(&self, value: &'a BigInt) -> &'a BigInt {
+        value
+    }
+}
+
+impl<'a> RelocateValue<'a, &'a MaybeRelocatable, Cow<'a, MaybeRelocatable>> for Memory {
+    fn relocate_value(&self, value: &'a MaybeRelocatable) -> Cow<'a, MaybeRelocatable> {
+        match value {
+            MaybeRelocatable::Int(_) => Cow::Borrowed(value),
+            MaybeRelocatable::RelocatableValue(addr) => {
+                Cow::Owned(self.relocate_value(*addr).into())
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This commit does a few things:
- It uses chained iterators to avoid creating too many intermediary containers.
- It specializes relocation for addresses for ad-hoc use when computing memory holes. This saves lot's of back and forth conversions and makes the code more readable, at the cost of a little bit of duplication.
- Removes the `accessed_addresses` `HashMap` from `CairoRunner`. Filling it consumed almost half of the runtime in several programs.
- Replaces `CairoRunner::mark_as_accessed` with `VirtualMachine::mark_address_range_as_accessed` to keep up with the previous change.

TODO:
- Maybe go back with `relocate_address` or completely exploit the difference somehow.
- Update `cairo-rs-py` to use the new `VirtualMachine` method.
- Fix the new function to actually figure out if the run ended.

# TITLE

## Description

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
