### PR TITLE
Default implementation of compile_hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,4 +13,4 @@
 
 * Default implementation of compile_hint [#680](https://github.com/lambdaclass/cairo-rs/pull/680)
     * Internal changes: 
-        * Make the `compile_hint` implementation which was in the `builtin_hint_processor` the default implementation in the trait. 
+        * Make the `compile_hint` implementation which was in the `BuiltinHintProcessor` the default implementation in the trait. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,7 @@
     * Public Api changes:
         * `VirtualMachineError` enum variants containing `MaybeRelocatable` and/or `Relocatable` values now use the `Display` format instead of `Debug` in their `Display` implementation
         * `get_traceback` now adds the source code line to each traceback entry
+
+* Default implementation of compile_hint [#680](https://github.com/lambdaclass/cairo-rs/pull/680)
+    * Internal changes: 
+        * Make the `compile_hint` implementation which was in the `builtin_hint_processor` the default implementation in the trait. 

--- a/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -1,4 +1,3 @@
-use crate::any_box;
 use crate::hint_processor::builtin_hint_processor::blake2s_utils::{
     blake2s_add_uint256, blake2s_add_uint256_bigend, compute_blake2s, finalize_blake2s,
 };
@@ -438,41 +437,6 @@ impl HintProcessor for BuiltinHintProcessor {
             code => Err(VirtualMachineError::UnknownHint(code.to_string())),
         }
     }
-
-    fn compile_hint(
-        &self,
-        code: &str,
-        ap_tracking: &ApTracking,
-        reference_ids: &HashMap<String, usize>,
-        references: &HashMap<usize, HintReference>,
-    ) -> Result<Box<dyn Any>, VirtualMachineError> {
-        Ok(any_box!(HintProcessorData {
-            code: code.to_string(),
-            ap_tracking: ap_tracking.clone(),
-            ids_data: get_ids_data(reference_ids, references)?,
-        }))
-    }
-}
-
-fn get_ids_data(
-    reference_ids: &HashMap<String, usize>,
-    references: &HashMap<usize, HintReference>,
-) -> Result<HashMap<String, HintReference>, VirtualMachineError> {
-    let mut ids_data = HashMap::<String, HintReference>::new();
-    for (path, ref_id) in reference_ids {
-        let name = path
-            .rsplit('.')
-            .next()
-            .ok_or(VirtualMachineError::FailedToGetIds)?;
-        ids_data.insert(
-            name.to_string(),
-            references
-                .get(ref_id)
-                .ok_or(VirtualMachineError::FailedToGetIds)?
-                .clone(),
-        );
-    }
-    Ok(ids_data)
 }
 
 #[cfg(test)]

--- a/src/hint_processor/hint_processor_definition.rs
+++ b/src/hint_processor/hint_processor_definition.rs
@@ -1,3 +1,4 @@
+use crate::any_box;
 use crate::serde::deserialize_program::ApTracking;
 use crate::serde::deserialize_program::OffsetValue;
 use crate::types::exec_scope::ExecutionScopes;
@@ -7,6 +8,8 @@ use crate::vm::vm_core::VirtualMachine;
 use num_bigint::BigInt;
 use std::any::Any;
 use std::collections::HashMap;
+
+use super::builtin_hint_processor::builtin_hint_processor_definition::HintProcessorData;
 
 pub trait HintProcessor {
     //Executes the hint which's data is provided by a dynamic structure previously created by compile_hint
@@ -36,7 +39,34 @@ pub trait HintProcessor {
         reference_ids: &HashMap<String, usize>,
         //List of all references (key corresponds to element of the previous dictionary)
         references: &HashMap<usize, HintReference>,
-    ) -> Result<Box<dyn Any>, VirtualMachineError>;
+    ) -> Result<Box<dyn Any>, VirtualMachineError> {
+        Ok(any_box!(HintProcessorData {
+            code: hint_code.to_string(),
+            ap_tracking: ap_tracking_data.clone(),
+            ids_data: get_ids_data(reference_ids, references)?,
+        }))
+    }
+}
+
+fn get_ids_data(
+    reference_ids: &HashMap<String, usize>,
+    references: &HashMap<usize, HintReference>,
+) -> Result<HashMap<String, HintReference>, VirtualMachineError> {
+    let mut ids_data = HashMap::<String, HintReference>::new();
+    for (path, ref_id) in reference_ids {
+        let name = path
+            .rsplit('.')
+            .next()
+            .ok_or(VirtualMachineError::FailedToGetIds)?;
+        ids_data.insert(
+            name.to_string(),
+            references
+                .get(ref_id)
+                .ok_or(VirtualMachineError::FailedToGetIds)?
+                .clone(),
+        );
+    }
+    Ok(ids_data)
 }
 
 #[derive(Debug, PartialEq, Clone)]


### PR DESCRIPTION
# Default implementation of compile_hint

## Description
make our actual implementation of compile_hint the default implementation in the hint processor trait
Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
