### PR TITLE
SECP optimizations

### DIFF
--- a/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
@@ -353,7 +353,7 @@ pub fn fast_ec_add_assign_new_x(
         vm.get_prime(),
     );
 
-    let value = (slope.modpow(&bigint!(2), &secp_p) - &x0 - x1).mod_floor(&secp_p);
+    let value = (&slope * &slope - &x0 - &x1).mod_floor(&secp_p);
 
     //Assign variables to vm scope
     exec_scopes.insert_value("slope", slope);

--- a/src/math_utils.rs
+++ b/src/math_utils.rs
@@ -118,7 +118,7 @@ pub fn line_slope(
     point_b: &(BigInt, BigInt),
     prime: &BigInt,
 ) -> BigInt {
-    assert!(!(&point_a.0 - &point_b.0.mod_floor(prime)).is_zero());
+    debug_assert!(!(&point_a.0 - &point_b.0.mod_floor(prime)).is_zero());
     div_mod(
         &(&point_a.1 - &point_b.1),
         &(&point_a.0 - &point_b.0),
@@ -139,7 +139,7 @@ pub fn ec_double(point: (BigInt, BigInt), alpha: &BigInt, prime: &BigInt) -> (Bi
 /// the given point.
 /// Assumes the point is given in affine form (x, y) and has y != 0.
 pub fn ec_double_slope(point: (BigInt, BigInt), alpha: &BigInt, prime: &BigInt) -> BigInt {
-    assert!(!(&point.1.mod_floor(prime)).is_zero());
+    debug_assert!(!(&point.1.mod_floor(prime)).is_zero());
     div_mod(
         &(bigint!(3_i32) * &point.0 * &point.0 + alpha),
         &(bigint!(2_i32) * point.1),

--- a/src/math_utils.rs
+++ b/src/math_utils.rs
@@ -94,7 +94,7 @@ fn igcdex(num_a: &BigInt, num_b: &BigInt) -> (BigInt, BigInt, BigInt) {
 ///Finds a nonnegative integer x < p such that (m * x) % p == n.
 pub fn div_mod(n: &BigInt, m: &BigInt, p: &BigInt) -> BigInt {
     let (a, _, c) = igcdex(m, p);
-    assert_eq!(c, bigint!(1));
+    debug_assert_eq!(c, bigint!(1));
     (n * a).mod_floor(p)
 }
 

--- a/src/math_utils.rs
+++ b/src/math_utils.rs
@@ -84,7 +84,7 @@ fn igcdex(num_a: &BigInt, num_b: &BigInt) -> (BigInt, BigInt, BigInt) {
             );
             let (mut c, mut q);
             while !b.is_zero() {
-                (q, c) = (a.div_floor(&b), a.mod_floor(&b));
+                (q, c) = a.div_mod_floor(&b);
                 (a, b, r, s, x, y) = (b, c, x - &q * &r, y - q * &s, r, s)
             }
             (x * x_sign, y * y_sign, a)

--- a/src/math_utils.rs
+++ b/src/math_utils.rs
@@ -85,7 +85,9 @@ fn igcdex(num_a: &BigInt, num_b: &BigInt) -> (BigInt, BigInt, BigInt) {
             let (mut c, mut q);
             while !b.is_zero() {
                 (q, c) = a.div_mod_floor(&b);
-                (a, b, r, s, x, y) = (b, c, x - &q * &r, y - q * &s, r, s)
+                x -= &q * &r;
+                y -= &q * &s;
+                (a, b, r, s, x, y) = (b, c, x, y, r, s)
             }
             (x * x_sign, y * y_sign, a)
         }


### PR DESCRIPTION
- Instead of calling `div_floor` followed by `mod_floor` with the same arguments in a loop in `math_utils::igcdex`, call `div_mod_floor` once;
- Make substractions in the `igcdex` loop in-place for `x` and `y` to avoid creating temporary objects;
- Make the `assert_eq` that checks the input to `igcdex` and the prime are actually coprime run only on debug (testing) builds;
- Make the `assert` calls that validate inputs to `ec_double` and `line_slope` run only on debug builds;
- Square by product rather than `modpow`.

These changes make the SECP integration benchmark 12% faster when running 50 iterations, with 10 warmup runs and 100 effective runs on the benchmark server. (TODO: recheck cumulative change since latest commits)
Other benchmark programs seem completely unaffected.