### PR TITLE
Handle extra case in is_zero function

### DIFF
--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -248,7 +248,13 @@ impl VirtualMachine {
     fn is_zero(addr: &MaybeRelocatable) -> Result<bool, VirtualMachineError> {
         match addr {
             MaybeRelocatable::Int(num) => Ok(num.is_zero()),
-            MaybeRelocatable::RelocatableValue(_rel_value) => Err(VirtualMachineError::PureValue),
+            MaybeRelocatable::RelocatableValue(rel_value) => {
+                if rel_value.offset > 0 {
+                    return Ok(false);
+                } else {
+                    Err(VirtualMachineError::PureValue)
+                }
+            }
         }
     }
 

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -1720,15 +1720,12 @@ mod tests {
     #[test]
     fn is_zero_relocatable_value() {
         let value = MaybeRelocatable::from((1, 2));
-        assert_eq!(
-            Err(VirtualMachineError::PureValue),
-            VirtualMachine::is_zero(&value)
-        );
+        assert_eq!(Ok(false), VirtualMachine::is_zero(&value));
     }
 
     #[test]
     fn is_zero_relocatable_value_negative() {
-        let value = MaybeRelocatable::from((1, 1));
+        let value = MaybeRelocatable::from((1, 0));
         assert_eq!(
             Err(VirtualMachineError::PureValue),
             VirtualMachine::is_zero(&value)


### PR DESCRIPTION
# Handle extra case in is_zero function

## Description

Handle extra case when asking if a relocatable is zero so that it can return false according to the python implementation. 

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
