### PR TITLE
Use nextest as test runner

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,6 +24,9 @@ jobs:
       with:
         python-version: '3.9'
 
+    - name: Install Nextest
+      uses: taiki-e/install-action@nextest
+
     - name: Set up cargo cache
       uses: actions/cache@v3
       continue-on-error: false

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ cairo_trace: $(CAIRO_TRACE) $(CAIRO_MEM)
 cairo-rs_trace: $(CAIRO_RS_TRACE) $(CAIRO_RS_MEM)
 
 test: $(COMPILED_PROOF_TESTS) $(COMPILED_TESTS) $(COMPILED_BAD_TESTS) $(COMPILED_NORETROCOMPAT_TESTS)
-	cargo test --workspace --features test_utils
+	cargo nextest run --workspace --features test_utils
 
 clippy:
 	cargo clippy --tests --examples --all-features -- -D warnings

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ deps:
 	cargo install --version 1.1.0 cargo-criterion
 	cargo install --version 0.6.1 flamegraph
 	cargo install --version 1.14.0 hyperfine
+	cargo install --version 0.9.49 cargo-nextest
 	pyenv install pypy3.7-7.3.9
 	pyenv global pypy3.7-7.3.9
 	pip install cairo_lang


### PR DESCRIPTION
Change the default test runner to nextest for quicker CI, test timing and, in the future, improved coverage measurement.