### PR TITLE
fixed bug in get_used_cells() test for Keccak

### DIFF
--- a/src/vm/runners/builtin_runner/keccak.rs
+++ b/src/vm/runners/builtin_runner/keccak.rs
@@ -407,7 +407,8 @@ mod tests {
 
     #[test]
     fn get_allocated_memory_units() {
-        let builtin:BuiltinRunner = KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10), true).into();
+        let builtin: BuiltinRunner =
+            KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10), true).into();
 
         let mut vm = vm!();
 
@@ -497,7 +498,8 @@ mod tests {
 
     #[test]
     fn get_used_cells_missing_segment_used_sizes() {
-        let builtin:BuiltinRunner = KeccakBuiltinRunner::new(&KeccakInstanceDef::default(), true).into();
+        let builtin: BuiltinRunner =
+            KeccakBuiltinRunner::new(&KeccakInstanceDef::default(), true).into();
         let vm = vm!();
 
         assert_eq!(
@@ -508,7 +510,8 @@ mod tests {
 
     #[test]
     fn get_used_cells_empty() {
-        let builtin:BuiltinRunner = KeccakBuiltinRunner::new(&KeccakInstanceDef::default(), true).into();
+        let builtin: BuiltinRunner =
+            KeccakBuiltinRunner::new(&KeccakInstanceDef::default(), true).into();
         let mut vm = vm!();
 
         vm.segments.segment_used_sizes = Some(vec![0]);
@@ -517,7 +520,8 @@ mod tests {
 
     #[test]
     fn get_used_cells() {
-        let builtin:BuiltinRunner = KeccakBuiltinRunner::new(&KeccakInstanceDef::default(), true).into();
+        let builtin: BuiltinRunner =
+            KeccakBuiltinRunner::new(&KeccakInstanceDef::default(), true).into();
         let mut vm = vm!();
 
         vm.segments.segment_used_sizes = Some(vec![4]);

--- a/src/vm/runners/builtin_runner/keccak.rs
+++ b/src/vm/runners/builtin_runner/keccak.rs
@@ -407,7 +407,7 @@ mod tests {
 
     #[test]
     fn get_allocated_memory_units() {
-        let builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10), true);
+        let builtin:BuiltinRunner = KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10), true).into();
 
         let mut vm = vm!();
 
@@ -497,7 +497,7 @@ mod tests {
 
     #[test]
     fn get_used_cells_missing_segment_used_sizes() {
-        let builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::default(), true);
+        let builtin:BuiltinRunner = KeccakBuiltinRunner::new(&KeccakInstanceDef::default(), true).into();
         let vm = vm!();
 
         assert_eq!(
@@ -508,7 +508,7 @@ mod tests {
 
     #[test]
     fn get_used_cells_empty() {
-        let builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::default(), true);
+        let builtin:BuiltinRunner = KeccakBuiltinRunner::new(&KeccakInstanceDef::default(), true).into();
         let mut vm = vm!();
 
         vm.segments.segment_used_sizes = Some(vec![0]);
@@ -517,7 +517,7 @@ mod tests {
 
     #[test]
     fn get_used_cells() {
-        let builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::default(), true);
+        let builtin:BuiltinRunner = KeccakBuiltinRunner::new(&KeccakInstanceDef::default(), true).into();
         let mut vm = vm!();
 
         vm.segments.segment_used_sizes = Some(vec![4]);


### PR DESCRIPTION
# fixed bug in get_used_cells() test for Keccak

## Description

The function get_used_cells()  in /src/vm/runners/builtin_runner/mod.rs is tested by three tests for each builtin runner, which it calls using an enum. These tests were not working for Keccak due to the enum not being called.

## Checklist
- [x] Linked to Github Issue: https://github.com/lambdaclass/cairo-rs/issues/667
- [x] Unit tests added - This is a testing PR
- [-] Integration tests added - Not needed
- [-] This change requires new documentation - Not needed
  - [-] Documentation has been added/updated.
