### PR TITLE
Add property testing for Felt bit shifts

### DIFF
--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -191,7 +191,7 @@ mod test {
         }
 
         #[test]
-        fn shift_left_in_range(ref value in "(0|[1-9][0-9]*)", ref shift_amount in "[1-9][0-9]*"){
+        fn shift_left_in_range(ref value in "(0|[1-9][0-9]*)", ref shift_amount in "[1-9][0-9]{9}"){
             let value = Felt::parse_bytes(value.as_bytes(), 10).unwrap();
             let p = &BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
             let shift_amount:u32 = shift_amount.parse::<u32>().unwrap();

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -158,7 +158,8 @@ mod test {
     use proptest::prelude::*;
 
     proptest! {
-        #[test]
+        #[test] 
+        // Property-based test that ensures, for 100 felt values that are randomly generated each time tests are run, that a new felt doesn't fall outside the range [0, p]
         fn new_in_range(ref x in "(0|[1-9][0-9]*)") {
             let x = &Felt::parse_bytes(x.as_bytes(), 10).unwrap();
             let p = &BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
@@ -166,6 +167,8 @@ mod test {
         }
 
         #[test]
+        // Property-based test that ensures, for 100 {x} and {y} values that are randomly generated each time tests are run, that a multiplication between two felts {x} and {y} and doesn't fall outside the range [0, p]
+        
         fn mul_in_range(ref x in "(0|[1-9][0-9]*)", ref y in "(0|[1-9][0-9]*)") {
             let x = &Felt::parse_bytes(x.as_bytes(), 10).unwrap();
             let y = &Felt::parse_bytes(y.as_bytes(), 10).unwrap();
@@ -177,6 +180,8 @@ mod test {
         }
 
         #[test]
+        // Property-based test that ensures, for 100 {x} and {y} values that are randomly generated each time tests are run, that the result of the division of {x} by {y} is the inverse multiplicative of {x} --that is, multiplying the result by {y} returns the original number {x}.
+        
         fn div_is_mul_inv(ref x in "(0|[1-9][0-9]*)", ref y in "[1-9][0-9]*") {
             prop_assume!("0" != y);
 
@@ -191,7 +196,9 @@ mod test {
         }
 
         #[test]
-        fn shift_left_in_range(ref value in "(0|[1-9][0-9]*)", ref shift_amount in "[1-9][0-9]{2}"){
+         // Property-based test that ensures, for 100 {value}s that are randomly generated each time tests are run, that performing a bit shift to the left by {shift_amount} of bits (between 0 and 999) returns a result that is inside of the range [0, p]
+       
+        fn shift_left_in_range(ref value in "(0|[1-9][0-9]*)", ref shift_amount in "[0-9]{1,3}"){
             let value = Felt::parse_bytes(value.as_bytes(), 10).unwrap();
             let p = &BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
             let shift_amount:u32 = shift_amount.parse::<u32>().unwrap();
@@ -200,7 +207,9 @@ mod test {
         }
 
         #[test]
-        fn shift_right_in_range(ref value in "(0|[1-9][0-9]*)", ref shift_amount in "[1-9][0-9]{2}"){
+         // Property-based test that ensures, for 100 {value}s that are randomly generated each time tests are run, that performing a bit shift to the right by {shift_amount} of bits (between 0 and 999)returns a result that is inside of the range [0, p].
+
+        fn shift_right_in_range(ref value in "(0|[1-9][0-9]*)", ref shift_amount in "[0-9]{1,3}"){
             let value = Felt::parse_bytes(value.as_bytes(), 10).unwrap();
             let p = &BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
             let shift_amount:u32 = shift_amount.parse::<u32>().unwrap();

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -191,7 +191,7 @@ mod test {
         }
 
         #[test]
-        fn shift_left_in_range(ref value in "(0|[1-9][0-9]*)", ref shift_amount in "[1-9][0-9]{9}"){
+        fn shift_left_in_range(ref value in "(0|[1-9][0-9]*)", ref shift_amount in "[1-9][0-9]{2}"){
             let value = Felt::parse_bytes(value.as_bytes(), 10).unwrap();
             let p = &BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
             let shift_amount:u32 = shift_amount.parse::<u32>().unwrap();
@@ -200,7 +200,7 @@ mod test {
         }
 
         #[test]
-        fn shift_right_in_range(ref value in "(0|[1-9][0-9]*)", ref shift_amount in "[1-9][0-9]{9}"){
+        fn shift_right_in_range(ref value in "(0|[1-9][0-9]*)", ref shift_amount in "[1-9][0-9]{2}"){
             let value = Felt::parse_bytes(value.as_bytes(), 10).unwrap();
             let p = &BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
             let shift_amount:u32 = shift_amount.parse::<u32>().unwrap();

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -158,8 +158,9 @@ mod test {
     use proptest::prelude::*;
 
     proptest! {
-        #[test] 
-        // Property-based test that ensures, for 100 felt values that are randomly generated each time tests are run, that a new felt doesn't fall outside the range [0, p]
+        #[test]
+        // Property-based test that ensures, for 100 felt values that are randomly generated each time tests are run, that a new felt doesn't fall outside the range [0, p]. 
+        // In this and some of the following tests, The value of {x} can be either [0] or a very large number, in order to try to overflow the value of {p} and thus ensure the modular arithmetic is working correctly.
         fn new_in_range(ref x in "(0|[1-9][0-9]*)") {
             let x = &Felt::parse_bytes(x.as_bytes(), 10).unwrap();
             let p = &BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
@@ -167,8 +168,7 @@ mod test {
         }
 
         #[test]
-        // Property-based test that ensures, for 100 {x} and {y} values that are randomly generated each time tests are run, that a multiplication between two felts {x} and {y} and doesn't fall outside the range [0, p]
-        
+        // Property-based test that ensures, for 100 {x} and {y} values that are randomly generated each time tests are run, that a multiplication between two felts {x} and {y} and doesn't fall outside the range [0, p]. The values of {x} and {y} can be either [0] or a very large number.
         fn mul_in_range(ref x in "(0|[1-9][0-9]*)", ref y in "(0|[1-9][0-9]*)") {
             let x = &Felt::parse_bytes(x.as_bytes(), 10).unwrap();
             let y = &Felt::parse_bytes(y.as_bytes(), 10).unwrap();
@@ -180,8 +180,7 @@ mod test {
         }
 
         #[test]
-        // Property-based test that ensures, for 100 {x} and {y} values that are randomly generated each time tests are run, that the result of the division of {x} by {y} is the inverse multiplicative of {x} --that is, multiplying the result by {y} returns the original number {x}.
-        
+        // Property-based test that ensures, for 100 {x} and {y} values that are randomly generated each time tests are run, that the result of the division of {x} by {y} is the inverse multiplicative of {x} --that is, multiplying the result by {y} returns the original number {x}. The values of {x} and {y} can be either [0] or a very large number.
         fn div_is_mul_inv(ref x in "(0|[1-9][0-9]*)", ref y in "[1-9][0-9]*") {
             prop_assume!("0" != y);
 
@@ -196,8 +195,7 @@ mod test {
         }
 
         #[test]
-         // Property-based test that ensures, for 100 {value}s that are randomly generated each time tests are run, that performing a bit shift to the left by {shift_amount} of bits (between 0 and 999) returns a result that is inside of the range [0, p]
-       
+         // Property-based test that ensures, for 100 {value}s that are randomly generated each time tests are run, that performing a bit shift to the left by {shift_amount} of bits (between 0 and 999) returns a result that is inside of the range [0, p].
         fn shift_left_in_range(ref value in "(0|[1-9][0-9]*)", ref shift_amount in "[0-9]{1,3}"){
             let value = Felt::parse_bytes(value.as_bytes(), 10).unwrap();
             let p = &BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
@@ -208,7 +206,6 @@ mod test {
 
         #[test]
          // Property-based test that ensures, for 100 {value}s that are randomly generated each time tests are run, that performing a bit shift to the right by {shift_amount} of bits (between 0 and 999)returns a result that is inside of the range [0, p].
-
         fn shift_right_in_range(ref value in "(0|[1-9][0-9]*)", ref shift_amount in "[0-9]{1,3}"){
             let value = Felt::parse_bytes(value.as_bytes(), 10).unwrap();
             let p = &BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -212,6 +212,7 @@ mod test {
             let shift_amount:u32 = shift_amount.parse::<u32>().unwrap();
             let result = (value >> shift_amount).to_biguint();
             prop_assert!(&result < p);
+        }
 
          #[test]
          // Property-based test that ensures, for 100 {value}s that are randomly generated each time tests are run, that performing a bit shift to the right by {shift_amount} of bits (between 0 and 999), with assignment, returns a result that is inside of the range [0, p].

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -159,7 +159,7 @@ mod test {
 
     proptest! {
         #[test]
-        // Property-based test that ensures, for 100 felt values that are randomly generated each time tests are run, that a new felt doesn't fall outside the range [0, p]. 
+        // Property-based test that ensures, for 100 felt values that are randomly generated each time tests are run, that a new felt doesn't fall outside the range [0, p].
         // In this and some of the following tests, The value of {x} can be either [0] or a very large number, in order to try to overflow the value of {p} and thus ensure the modular arithmetic is working correctly.
         fn new_in_range(ref x in "(0|[1-9][0-9]*)") {
             let x = &Felt::parse_bytes(x.as_bytes(), 10).unwrap();
@@ -205,7 +205,7 @@ mod test {
         }
 
         #[test]
-         // Property-based test that ensures, for 100 {value}s that are randomly generated each time tests are run, that performing a bit shift to the right by {shift_amount} of bits (between 0 and 999)returns a result that is inside of the range [0, p].
+         // Property-based test that ensures, for 100 {value}s that are randomly generated each time tests are run, that performing a bit shift to the right by {shift_amount} of bits (between 0 and 999) returns a result that is inside of the range [0, p].
         fn shift_right_in_range(ref value in "(0|[1-9][0-9]*)", ref shift_amount in "[0-9]{1,3}"){
             let value = Felt::parse_bytes(value.as_bytes(), 10).unwrap();
             let p = &BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -225,7 +225,7 @@ mod test {
             value.to_biguint();
             prop_assert!(value < p);
         }
-        
+
         #[test]
          // Property-based test that ensures, for 100 values {x} that are randomly generated each time tests are run, that raising {x} to the {y}th power returns a result that is inside of the range [0, p].
         fn pow_in_range(ref x in "(0|[1-9][0-9]*)", ref y in "[0-9]{1,2}"){

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -198,5 +198,14 @@ mod test {
             let result = (value << shift_amount).to_biguint();
             prop_assert!(&result < p);
         }
+
+        #[test]
+        fn shift_right_in_range(ref value in "(0|[1-9][0-9]*)", ref shift_amount in "[1-9][0-9]{9}"){
+            let value = Felt::parse_bytes(value.as_bytes(), 10).unwrap();
+            let p = &BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
+            let shift_amount:u32 = shift_amount.parse::<u32>().unwrap();
+            let result = (value >> shift_amount).to_biguint();
+            prop_assert!(&result < p);
+        }
     }
 }

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -189,5 +189,14 @@ mod test {
             prop_assert!(as_uint < p, "{}", as_uint);
             prop_assert_eq!(&(q * y), x);
         }
+
+        #[test]
+        fn shift_left_in_range(ref value in "(0|[1-9][0-9]*)", ref shift_amount in "[1-9][0-9]*"){
+            let value = Felt::parse_bytes(value.as_bytes(), 10).unwrap();
+            let p = &BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
+            let shift_amount:u32 = shift_amount.parse::<u32>().unwrap();
+            let result = (value << shift_amount).to_biguint();
+            prop_assert!(&result < p);
+        }
     }
 }


### PR DESCRIPTION
# Add property testing for Felt bit shifts

## Description

Property-based test that ensures, for 100 `value`s that are randomly generated each time tests are run, that performing a bit shift to the left or to the right by `shift_amount` of bits (between 0 and 999) returns a result that is inside of the range [0, p].


## Checklist
- [x] Linked to Github Issue https://github.com/lambdaclass/cairo-rs/issues/700
- [x] Unit tests added
- [-] Integration tests added.
- [-] This change requires new documentation.
  - [-] Documentation has been added/updated.
