### PR TITLE
add test for right bit shift with assignment

### DIFF
--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -189,5 +189,16 @@ mod test {
             prop_assert!(as_uint < p, "{}", as_uint);
             prop_assert_eq!(&(q * y), x);
         }
+
+        #[test]
+         // Property-based test that ensures, for 100 {value}s that are randomly generated each time tests are run, that performing a bit shift to the left by {shift_amount} of bits (between 0 and 999) returns a result that is inside of the range [0, p].
+         fn shift_right_assign_in_range(ref value in "(0|[1-9][0-9]*)", ref shift_amount in "[0-9]{1,3}"){
+            let mut value = Felt::parse_bytes(value.as_bytes(), 10).unwrap();
+            let p = FeltBigInt::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
+            let shift_amount:usize = shift_amount.parse::<usize>().unwrap();
+            value >>= shift_amount;
+            value.to_biguint();
+            prop_assert!(value < p);
+        }
     }
 }

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -191,7 +191,8 @@ mod test {
         }
 
         #[test]
-         // Property-based test that ensures, for 100 {value}s that are randomly generated each time tests are run, that performing a bit shift to the left by {shift_amount} of bits (between 0 and 999) returns a result that is inside of the range [0, p].
+         // Property-based test that ensures, for 100 {value}s that are randomly generated each time tests are run, that performing a bit shift to the right by {shift_amount} of bits (between 0 and 999), with assignment, returns a result that is inside of the range [0, p].
+         // "With assignment" means that the result of the operation is autommatically assigned to the variable value, replacing its previous content.
          fn shift_right_assign_in_range(ref value in "(0|[1-9][0-9]*)", ref shift_amount in "[0-9]{1,3}"){
             let mut value = Felt::parse_bytes(value.as_bytes(), 10).unwrap();
             let p = FeltBigInt::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();


### PR DESCRIPTION
# Add test for right bit shift with assignment

## Description

Property-based test that ensures, for 100 `value`s that are randomly generated each time tests are run, that performing a bit shift to the right with assignment  by `shift_amount` of bits (between 0 and 999) returns a result that is inside of the range [0, p]. "With assignment" means that the result of the operation is autommatically assigned to the variable `value`, replacing its previous content.

## Checklist
- [x] Linked to Github Issue. https://github.com/lambdaclass/cairo-rs/issues/700
- [x] Unit tests added
- [-] Integration tests added.
- [x] This change requires new documentation.
  - [x] Documentation has been added/updated. - The test is documented in code comments.
