### PR TITLE
update ymls to Rust version 1.66.1

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -14,10 +14,10 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-    - name: Install Rust 1.62.1 
+    - name: Install Rust 1.66.1 
       uses: actions-rs/toolchain@v1
       with:
-          toolchain: 1.62.1 
+          toolchain: 1.66.1 
           override: true
           components: rustfmt, clippy
     - uses: actions/checkout@v3

--- a/.github/workflows/bench_pull_request.yml
+++ b/.github/workflows/bench_pull_request.yml
@@ -8,10 +8,10 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-    - name: Install Rust 1.62.1 
+    - name: Install Rust 1.66.1 
       uses: actions-rs/toolchain@v1
       with:
-          toolchain: 1.62.1 
+          toolchain: 1.66.1 
           override: true
           components: rustfmt, clippy
     - uses: actions/checkout@v3

--- a/.github/workflows/iai_main.yml
+++ b/.github/workflows/iai_main.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-          toolchain: 1.61.0
+          toolchain: 1.66.1
           override: true
           profile: minimal
     - name: Python3 Build

--- a/.github/workflows/iai_pr.yml
+++ b/.github/workflows/iai_pr.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-          toolchain: 1.61.0
+          toolchain: 1.66.1
           override: true
           profile: minimal
     - name: Python3 Build

--- a/.github/workflows/iai_pr.yml
+++ b/.github/workflows/iai_pr.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-          toolchain: 1.61.0
+          toolchain: 1.66.1
           override: true
           profile: minimal
     - name: Python3 Build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,10 +13,10 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-    - name: Install Rust 1.61.0
+    - name: Install Rust 1.66.1
       uses: actions-rs/toolchain@v1
       with:
-          toolchain: 1.61.0
+          toolchain: 1.66.1
           override: true
           components: rustfmt, clippy
     - name: Python3 Build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -795,9 +795,9 @@ checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
 
 [[package]]
 name = "pest"
-version = "2.5.2"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6e86fb9e7026527a0d46bc308b841d73170ef8f443e1807f6ef88526a816d4"
+checksum = "4257b4a04d91f7e9e6290be5d3da4804dd5784fafde3a497d73eb2b4a158c30a"
 dependencies = [
  "thiserror",
  "ucd-trie",

--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -416,7 +416,7 @@ impl Pow<u32> for FeltBigInt {
 impl<'a> Pow<u32> for &'a FeltBigInt {
     type Output = FeltBigInt;
     fn pow(self, rhs: u32) -> Self::Output {
-        FeltBigInt((self.0).pow(rhs).mod_floor(&CAIRO_PRIME))
+        FeltBigInt((&self.0).pow(rhs).mod_floor(&CAIRO_PRIME))
     }
 }
 

--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -415,7 +415,7 @@ impl Pow<u32> for FeltBigInt {
 
 impl<'a> Pow<u32> for &'a FeltBigInt {
     type Output = FeltBigInt;
-    #[allow(clippy::needless_borrowed_reference)] // the borrow of self.0 is necessary becase it's of the type BigUInt, which doesn't implement the Copy trait
+    #[allow(clippy::needless_borrow)] // the borrow of self.0 is necessary becase it's of the type BigUInt, which doesn't implement the Copy trait
     fn pow(self, rhs: u32) -> Self::Output {
         FeltBigInt((&self.0).pow(rhs).mod_floor(&CAIRO_PRIME))
     }

--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -415,7 +415,7 @@ impl Pow<u32> for FeltBigInt {
 
 impl<'a> Pow<u32> for &'a FeltBigInt {
     type Output = FeltBigInt;
-    #[allow(clippy::needless_borrow)] // the borrow of self.0 is necessary becase it's of the type BigUInt, which doesn't implement the Copy trait
+    #[allow(clippy::needless_borrowed_reference)] // the borrow of self.0 is necessary becase it's of the type BigUInt, which doesn't implement the Copy trait
     fn pow(self, rhs: u32) -> Self::Output {
         FeltBigInt((&self.0).pow(rhs).mod_floor(&CAIRO_PRIME))
     }
@@ -428,7 +428,7 @@ impl Div for FeltBigInt {
     fn div(self, rhs: Self) -> Self::Output {
         let x = rhs
             .0
-            .to_bigint() // Always succeeds for BitUint -> BigInt
+            .to_bigint() // Always succeeds for BigUint -> BigInt
             .unwrap()
             .extended_gcd(&CAIRO_SIGNED_PRIME)
             .x;

--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -317,7 +317,7 @@ impl<'a> Sub for &'a FeltBigInt {
 impl Sub<u32> for FeltBigInt {
     type Output = FeltBigInt;
     fn sub(self, rhs: u32) -> Self {
-        match (&self.0).to_u32() {
+        match (self.0).to_u32() {
             Some(num) if num < rhs => Self(&*CAIRO_PRIME - (rhs - self.0)),
             _ => Self(self.0 - rhs),
         }
@@ -327,7 +327,7 @@ impl Sub<u32> for FeltBigInt {
 impl<'a> Sub<u32> for &'a FeltBigInt {
     type Output = FeltBigInt;
     fn sub(self, rhs: u32) -> Self::Output {
-        match (&self.0).to_u32() {
+        match (self.0).to_u32() {
             Some(num) if num < rhs => FeltBigInt(&*CAIRO_PRIME - (rhs - &self.0)),
             _ => FeltBigInt(&self.0 - rhs),
         }
@@ -337,7 +337,7 @@ impl<'a> Sub<u32> for &'a FeltBigInt {
 impl Sub<usize> for FeltBigInt {
     type Output = FeltBigInt;
     fn sub(self, rhs: usize) -> Self {
-        match (&self.0).to_usize() {
+        match (self.0).to_usize() {
             Some(num) if num < rhs => FeltBigInt(&*CAIRO_PRIME - (rhs - num)),
             _ => FeltBigInt(self.0 - rhs),
         }
@@ -366,7 +366,7 @@ impl Sub<FeltBigInt> for usize {
 impl Sub<&FeltBigInt> for usize {
     type Output = FeltBigInt;
     fn sub(self, rhs: &FeltBigInt) -> Self::Output {
-        match (&rhs.0).to_usize() {
+        match (rhs.0).to_usize() {
             Some(num) => {
                 if num > self {
                     FeltBigInt(&*CAIRO_PRIME - (num - self))
@@ -416,7 +416,7 @@ impl Pow<u32> for FeltBigInt {
 impl<'a> Pow<u32> for &'a FeltBigInt {
     type Output = FeltBigInt;
     fn pow(self, rhs: u32) -> Self::Output {
-        FeltBigInt((&self.0).pow(rhs).mod_floor(&CAIRO_PRIME))
+        FeltBigInt((self.0).pow(rhs).mod_floor(&CAIRO_PRIME))
     }
 }
 

--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -416,7 +416,7 @@ impl Pow<u32> for FeltBigInt {
 impl<'a> Pow<u32> for &'a FeltBigInt {
     type Output = FeltBigInt;
     fn pow(self, rhs: u32) -> Self::Output {
-        #[warn(clippy::needless_borrow)]
+        #[allow(clippy::needless_borrow)]
         FeltBigInt((&self.0).pow(rhs).mod_floor(&CAIRO_PRIME))
     }
 }

--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -415,8 +415,8 @@ impl Pow<u32> for FeltBigInt {
 
 impl<'a> Pow<u32> for &'a FeltBigInt {
     type Output = FeltBigInt;
+    #[allow(clippy::needless_borrow)] // the borrow of self.0 is necessary becase it's of the type BigUInt, which doesn't implement the Copy trait
     fn pow(self, rhs: u32) -> Self::Output {
-        #[allow(clippy::needless_borrow)]
         FeltBigInt((&self.0).pow(rhs).mod_floor(&CAIRO_PRIME))
     }
 }

--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -416,6 +416,7 @@ impl Pow<u32> for FeltBigInt {
 impl<'a> Pow<u32> for &'a FeltBigInt {
     type Output = FeltBigInt;
     fn pow(self, rhs: u32) -> Self::Output {
+        #[warn(clippy::needless_borrow)]
         FeltBigInt((&self.0).pow(rhs).mod_floor(&CAIRO_PRIME))
     }
 }

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -19,7 +19,7 @@ pub type Felt = FeltBigInt;
 pub const PRIME_STR: &str = "0x800000000000011000000000000000000000000000000000000000000000001";
 pub const FIELD: (u128, u128) = ((1 << 123) + (17 << 64), 1);
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ParseFeltError;
 
 pub trait NewFelt {

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.61.0"
+channel = "1.64.0"
 components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.64.0"
+channel = "1.66.1"
 components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/src/hint_processor/builtin_hint_processor/blake2s_hash.rs
+++ b/src/hint_processor/builtin_hint_processor/blake2s_hash.rs
@@ -18,7 +18,7 @@ const SIGMA: [[usize; 16]; 10] = [
 ];
 
 fn right_rot(value: u32, n: u32) -> u32 {
-    (value >> n) | ((value & (1_u32.shl(n as u32) - 1)) << (32 - n))
+    (value >> n) | ((value & (1_u32.shl(n) - 1)) << (32 - n))
 }
 
 fn mix(a: u32, b: u32, c: u32, d: u32, m0: u32, m1: u32) -> (u32, u32, u32, u32) {

--- a/src/hint_processor/builtin_hint_processor/blake2s_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/blake2s_utils.rs
@@ -187,7 +187,7 @@ pub fn blake2s_add_uint256_bigend(
     let high = vm.get_integer(&high_addr)?.into_owned();
     //Main logic
     //Declare constant
-    const MASK: u32 = u32::MAX as u32;
+    const MASK: u32 = u32::MAX;
     const B: u32 = 32;
     //Convert MASK to felt
     let mask = Felt::new(MASK);

--- a/src/hint_processor/builtin_hint_processor/cairo_keccak/keccak_hints.rs
+++ b/src/hint_processor/builtin_hint_processor/cairo_keccak/keccak_hints.rs
@@ -239,7 +239,7 @@ pub(crate) fn maybe_reloc_vec_to_u64_array(
                 num.to_u64().ok_or(VirtualMachineError::BigintToU64Fail)
             }
             _ => Err(VirtualMachineError::ExpectedIntAtRange(
-                n.as_ref().map(|x| x.to_owned().into_owned()),
+                n.as_ref().map(|x| x.as_ref().to_owned()),
             )),
         })
         .collect::<Result<Vec<u64>, VirtualMachineError>>()?;

--- a/src/hint_processor/builtin_hint_processor/dict_manager.rs
+++ b/src/hint_processor/builtin_hint_processor/dict_manager.rs
@@ -10,14 +10,14 @@ use crate::{
     },
 };
 
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 ///Manages dictionaries in a Cairo program.
 ///Uses the segment index to associate the corresponding python dict with the Cairo dict.
 pub struct DictManager {
     pub trackers: HashMap<isize, DictTracker>,
 }
 
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 ///Tracks the python dict associated with a Cairo dict.
 pub struct DictTracker {
     //Dictionary.
@@ -26,7 +26,7 @@ pub struct DictTracker {
     pub current_ptr: Relocatable,
 }
 
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub enum Dictionary {
     SimpleDictionary(HashMap<MaybeRelocatable, MaybeRelocatable>),
     DefaultDictionary {

--- a/src/hint_processor/builtin_hint_processor/keccak_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/keccak_utils.rs
@@ -88,7 +88,7 @@ pub fn unsafe_keccak(
         let mut bytes = word.to_bytes_be();
         let mut bytes = {
             let n_word_bytes = &bytes.len();
-            left_pad(&mut bytes, (n_bytes as usize - n_word_bytes) as usize)
+            left_pad(&mut bytes, n_bytes as usize - n_word_bytes)
         };
 
         keccak_input.append(&mut bytes);

--- a/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
@@ -60,7 +60,7 @@ pub fn bigint_to_uint256(
     let base_86 = constants
         .get(BASE_86)
         .ok_or(HintError::MissingConstant(BASE_86))?;
-    let low = (d0 + &(d1 * &*base_86)) & &Felt::new(u128::MAX);
+    let low = (d0 + &(d1 * base_86)) & &Felt::new(u128::MAX);
     insert_value_from_var_name("low", low, vm, ids_data, ap_tracking)
 }
 

--- a/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
@@ -237,7 +237,7 @@ pub fn ec_double_assign_new_x(
     let x = pack(x_d0.as_ref(), x_d1.as_ref(), x_d2.as_ref());
     let y = pack(y_d0.as_ref(), y_d1.as_ref(), y_d2.as_ref());
 
-    let value = ((&slope).pow(2) - (&x << 1u32)).mod_floor(&secp_p);
+    let value = (slope.pow(2) - (&x << 1u32)).mod_floor(&secp_p);
 
     //Assign variables to vm scope
     exec_scopes.insert_value("slope", slope);

--- a/src/hint_processor/builtin_hint_processor/set.rs
+++ b/src/hint_processor/builtin_hint_processor/set.rs
@@ -46,7 +46,7 @@ pub fn set_add(
 
     for i in (0..range_limit).step_by(elm_size) {
         let set_iter = vm
-            .get_range(&MaybeRelocatable::from(set_ptr + i as usize), elm_size)
+            .get_range(&MaybeRelocatable::from(set_ptr + i), elm_size)
             .map_err(VirtualMachineError::MemoryError)?;
 
         if set_iter == elm {

--- a/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
@@ -271,7 +271,7 @@ pub fn squash_dict(
             .map_err(|_| VirtualMachineError::ExpectedInteger(MaybeRelocatable::from(key_addr)))?;
         access_indices
             .entry(key.into_owned())
-            .or_insert(Vec::<Felt>::new())
+            .or_default()
             .push(Felt::new(i));
     }
     //Descending list of keys.

--- a/src/hint_processor/builtin_hint_processor/usort.rs
+++ b/src/hint_processor/builtin_hint_processor/usort.rs
@@ -52,7 +52,7 @@ pub fn usort_body(
         if let Err(output_index) = output.binary_search(&val) {
             output.insert(output_index, val.clone());
         }
-        positions_dict.entry(val).or_insert(Vec::new()).push(i);
+        positions_dict.entry(val).or_default().push(i);
     }
 
     let mut multiplicities: Vec<usize> = Vec::new();

--- a/src/hint_processor/hint_processor_definition.rs
+++ b/src/hint_processor/hint_processor_definition.rs
@@ -67,7 +67,7 @@ fn get_ids_data(
     Ok(ids_data)
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct HintReference {
     pub offset1: OffsetValue,
     pub offset2: OffsetValue,

--- a/src/hint_processor/hint_processor_utils.rs
+++ b/src/hint_processor/hint_processor_utils.rs
@@ -177,7 +177,7 @@ fn get_offset_value_reference(
         apply_ap_tracking_correction(&vm.get_ap(), var_ap_trackig, hint_ap_tracking)?
     };
 
-    if offset.is_negative() && base_addr.offset < offset.abs() as usize {
+    if offset.is_negative() && base_addr.offset < offset.unsigned_abs() as usize {
         return Err(HintError::FailedToGetIds);
     }
 

--- a/src/math_utils.rs
+++ b/src/math_utils.rs
@@ -28,7 +28,7 @@ pub fn isqrt(n: &BigUint) -> Result<BigUint, VirtualMachineError> {
         y = (&x + n.div_floor(&x)).shr(1_u32);
     }
 
-    if !(&(&x).pow(2) <= n && n < &(&x + 1_u32).pow(2_u32)) {
+    if !(&x.pow(2) <= n && n < &(&x + 1_u32).pow(2_u32)) {
         return Err(VirtualMachineError::FailedToGetSqrt(n.clone()));
     };
     Ok(x)
@@ -167,7 +167,7 @@ pub fn ec_double(point: (BigInt, BigInt), alpha: &BigInt, prime: &BigInt) -> (Bi
 /// the given point.
 /// Assumes the point is given in affine form (x, y) and has y != 0.
 pub fn ec_double_slope(point: &(BigInt, BigInt), alpha: &BigInt, prime: &BigInt) -> BigInt {
-    debug_assert!(!(&point.1.mod_floor(prime)).is_zero());
+    debug_assert!(!point.1.mod_floor(prime).is_zero());
     div_mod(
         &(3_i32 * &point.0 * &point.0 + alpha),
         &(2_i32 * &point.1),
@@ -555,7 +555,7 @@ mod tests {
     #[test]
     fn calculate_isqrt_b() {
         let n = biguint_str!("4573659632505831259480");
-        assert_eq!(isqrt(&(&n).pow(2_u32)), Ok(n));
+        assert_eq!(isqrt(&n.pow(2_u32)), Ok(n));
     }
 
     #[test]
@@ -563,7 +563,7 @@ mod tests {
         let n = biguint_str!(
             "3618502788666131213697322783095070105623107215331596699973092056135872020481"
         );
-        assert_eq!(isqrt(&(&n).pow(2_u32)), Ok(n));
+        assert_eq!(isqrt(&n.pow(2_u32)), Ok(n));
     }
 
     #[test]

--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -95,7 +95,7 @@ pub struct Location {
     pub start_col: u32,
 }
 
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, PartialEq, Eq)]
 pub struct DebugInfo {
     instruction_locations: HashMap<usize, InstructionLocation>,
 }
@@ -190,7 +190,7 @@ impl<'de> de::Visitor<'de> for FeltVisitor {
         if let Some(no_prefix_hex) = value.strip_prefix("0x") {
             // Add padding if necessary
             let no_prefix_hex = deserialize_utils::maybe_add_padding(no_prefix_hex.to_string());
-            let decoded_result: Result<Vec<u8>, hex::FromHexError> = hex::decode(&no_prefix_hex);
+            let decoded_result: Result<Vec<u8>, hex::FromHexError> = hex::decode(no_prefix_hex);
 
             match decoded_result {
                 Ok(decoded_hex) => Ok(Felt::from_bytes_be(&decoded_hex)),
@@ -221,8 +221,7 @@ impl<'de> de::Visitor<'de> for MaybeRelocatableVisitor {
             if let Some(no_prefix_hex) = value.strip_prefix("0x") {
                 // Add padding if necessary
                 let no_prefix_hex = deserialize_utils::maybe_add_padding(no_prefix_hex.to_string());
-                let decoded_result: Result<Vec<u8>, hex::FromHexError> =
-                    hex::decode(&no_prefix_hex);
+                let decoded_result: Result<Vec<u8>, hex::FromHexError> = hex::decode(no_prefix_hex);
 
                 match decoded_result {
                     Ok(decoded_hex) => {

--- a/src/serde/deserialize_utils.rs
+++ b/src/serde/deserialize_utils.rs
@@ -19,7 +19,7 @@ use num_integer::Integer;
 use parse_hyperlinks::take_until_unbalanced;
 use std::{fmt, num::ParseIntError, str::FromStr};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ReferenceParseError {
     IntError(ParseIntError),
     FeltError(ParseFeltError),

--- a/src/types/instruction.rs
+++ b/src/types/instruction.rs
@@ -10,7 +10,7 @@ pub enum Register {
     FP,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Instruction {
     pub off0: isize,
     pub off1: isize,
@@ -26,7 +26,7 @@ pub struct Instruction {
     pub opcode: Opcode,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Op1Addr {
     Imm,
     AP,
@@ -34,7 +34,7 @@ pub enum Op1Addr {
     Op0,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Res {
     Op1,
     Add,
@@ -42,7 +42,7 @@ pub enum Res {
     Unconstrained,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum PcUpdate {
     Regular,
     Jump,
@@ -50,7 +50,7 @@ pub enum PcUpdate {
     Jnz,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ApUpdate {
     Regular,
     Add,
@@ -58,14 +58,14 @@ pub enum ApUpdate {
     Add2,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum FpUpdate {
     Regular,
     APPlus2,
     Dst,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Opcode {
     NOp,
     AssertEq,

--- a/src/types/relocatable.rs
+++ b/src/types/relocatable.rs
@@ -100,7 +100,10 @@ impl Add<i32> for Relocatable {
         if other >= 0 {
             relocatable!(self.segment_index, self.offset + other as usize)
         } else {
-            relocatable!(self.segment_index, self.offset - other.abs() as usize)
+            relocatable!(
+                self.segment_index,
+                self.offset - other.unsigned_abs() as usize
+            )
         }
     }
 }
@@ -111,7 +114,10 @@ impl Add<i32> for &Relocatable {
         if other >= 0 {
             relocatable!(self.segment_index, self.offset + other as usize)
         } else {
-            relocatable!(self.segment_index, self.offset - other.abs() as usize)
+            relocatable!(
+                self.segment_index,
+                self.offset - other.unsigned_abs() as usize
+            )
         }
     }
 }
@@ -349,10 +355,7 @@ pub fn relocate_address(
     relocation_table: &Vec<usize>,
 ) -> Result<usize, MemoryError> {
     let (segment_index, offset) = if relocatable.segment_index >= 0 {
-        (
-            relocatable.segment_index as usize,
-            relocatable.offset as usize,
-        )
+        (relocatable.segment_index as usize, relocatable.offset)
     } else {
         return Err(MemoryError::TemporarySegmentInRelocation(
             relocatable.segment_index,
@@ -486,7 +489,7 @@ mod tests {
             "800000000000011000000000000000000000000000000000000000000000001",
             16
         ));
-        let added_addr = addr_a.add(&addr_b);
+        let added_addr = addr_a.add(addr_b);
         assert_eq!(
             Ok(MaybeRelocatable::RelocatableValue(relocatable!(7, 14))),
             added_addr

--- a/src/vm/errors/memory_errors.rs
+++ b/src/vm/errors/memory_errors.rs
@@ -2,7 +2,7 @@ use thiserror::Error;
 
 use crate::types::relocatable::{MaybeRelocatable, Relocatable};
 
-#[derive(Debug, PartialEq, Error)]
+#[derive(Debug, PartialEq, Eq, Error)]
 pub enum MemoryError {
     #[error("Can't insert into segment #{0}; memory only has {1} segment")]
     UnallocatedSegment(usize, usize),

--- a/src/vm/errors/runner_errors.rs
+++ b/src/vm/errors/runner_errors.rs
@@ -5,7 +5,7 @@ use crate::types::relocatable::MaybeRelocatable;
 use felt::Felt;
 use thiserror::Error;
 
-#[derive(Debug, PartialEq, Error)]
+#[derive(Debug, PartialEq, Eq, Error)]
 pub enum RunnerError {
     #[error("Can't initialize state without an execution base")]
     NoExecBase,
@@ -49,18 +49,8 @@ pub enum RunnerError {
     DisorderedBuiltins,
     #[error("Expected integer at address {0:?} to be smaller than 2^{1}, Got {2}")]
     IntegerBiggerThanPowerOfTwo(MaybeRelocatable, u32, Felt),
-    #[error(
-        "Cannot apply EC operation: computation reched two points with the same x coordinate. \n
-    Attempting to compute P + m * Q where:\n
-    P = {0:?} \n
-    m = {1}\n
-    Q = {2:?}."
-    )]
-    EcOpSameXCoordinate(
-        (num_bigint::BigInt, num_bigint::BigInt),
-        num_bigint::BigInt,
-        (num_bigint::BigInt, num_bigint::BigInt),
-    ),
+    #[error("{0}")]
+    EcOpSameXCoordinate(String),
     #[error("EcOpBuiltin: point {0:?} is not on the curve")]
     PointNotOnCurve((usize, usize)),
     #[error("Builtin(s) {0:?} not present in layout {1}")]

--- a/src/vm/errors/trace_errors.rs
+++ b/src/vm/errors/trace_errors.rs
@@ -1,7 +1,7 @@
 use crate::vm::errors::memory_errors::MemoryError;
 use thiserror::Error;
 
-#[derive(Debug, PartialEq, Error)]
+#[derive(Debug, PartialEq, Eq, Error)]
 pub enum TraceError {
     #[error("Trace is not enabled for this run")]
     TraceNotEnabled,

--- a/src/vm/errors/vm_exception.rs
+++ b/src/vm/errors/vm_exception.rs
@@ -52,7 +52,7 @@ pub fn get_error_attr_value(pc: usize, runner: &CairoRunner) -> Option<String> {
             errors.push_str(&format!("Error message: {}\n", attribute.value));
         }
     }
-    (!errors.is_empty()).then(|| errors)
+    (!errors.is_empty()).then_some(errors)
 }
 
 pub fn get_location(

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -169,12 +169,12 @@ impl EcOpBuiltinRunner {
             .map_err(|_| RunnerError::CouldntParsePrime)?;
         let result = EcOpBuiltinRunner::ec_op_impl(
             (
-                input_cells[0].to_owned().into_owned(),
-                input_cells[1].to_owned().into_owned(),
+                input_cells[0].as_ref().to_owned(),
+                input_cells[1].as_ref().to_owned(),
             ),
             (
-                input_cells[2].to_owned().into_owned(),
-                input_cells[3].to_owned().into_owned(),
+                input_cells[2].as_ref().to_owned(),
+                input_cells[3].as_ref().to_owned(),
             ),
             input_cells[4].as_ref(),
             &alpha.to_bigint(),

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -65,11 +65,11 @@ impl EcOpBuiltinRunner {
         let mut doubled_point_b = (doubled_point.0.to_bigint(), doubled_point.1.to_bigint());
         for _ in 0..height {
             if (doubled_point_b.0.clone() - partial_sum_b.0.clone()).is_zero() {
-                return Err(RunnerError::EcOpSameXCoordinate(
+                return Err(RunnerError::EcOpSameXCoordinate(Self::format_ec_op_error(
                     partial_sum_b,
                     m.clone().to_bigint(),
                     doubled_point_b,
-                ));
+                )));
             };
             if !(slope.clone() & &BigInt::one()).is_zero() {
                 partial_sum_b = ec_add(partial_sum_b, doubled_point_b.clone(), prime);
@@ -177,7 +177,7 @@ impl EcOpBuiltinRunner {
                 input_cells[3].to_owned().into_owned(),
             ),
             input_cells[4].as_ref(),
-            &(&alpha).to_bigint(),
+            &alpha.to_bigint(),
             &prime,
             self.ec_op_builtin.scalar_height,
         )?;
@@ -267,6 +267,18 @@ impl EcOpBuiltinRunner {
             Ok((pointer, stop_ptr))
         }
     }
+
+    pub fn format_ec_op_error(
+        p: (num_bigint::BigInt, num_bigint::BigInt),
+        m: num_bigint::BigInt,
+        q: (num_bigint::BigInt, num_bigint::BigInt),
+    ) -> String {
+        format!("Cannot apply EC operation: computation reched two points with the same x coordinate. \n
+    Attempting to compute P + m * Q where:\n
+    P = {p:?} \n
+    m = {m:?}\n
+    Q = {q:?}.")
+    }
 }
 
 #[cfg(test)]
@@ -282,6 +294,7 @@ mod tests {
         vm_core::VirtualMachine,
     };
     use felt::felt_str;
+    use EcOpBuiltinRunner;
 
     #[test]
     fn get_used_instances() {
@@ -639,9 +652,11 @@ mod tests {
         assert_eq!(
             result,
             Err(RunnerError::EcOpSameXCoordinate(
-                (partial_sum.0.to_bigint(), partial_sum.1.to_bigint()),
-                m.to_bigint(),
-                (doubled_point.0.to_bigint(), doubled_point.1.to_bigint())
+                EcOpBuiltinRunner::format_ec_op_error(
+                    (partial_sum.0.to_bigint(), partial_sum.1.to_bigint()),
+                    m.to_bigint(),
+                    (doubled_point.0.to_bigint(), doubled_point.1.to_bigint())
+                )
             ))
         );
     }

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -150,7 +150,7 @@ impl HashBuiltinRunner {
         } else {
             let used = self.get_used_cells(vm)?;
             let size = cells_per_instance as usize
-                * safe_div_usize(vm.current_step, ratio as usize)
+                * safe_div_usize(vm.current_step, ratio)
                     .map_err(|_| MemoryError::InsufficientAllocatedCells)?;
             if used > size {
                 return Err(MemoryError::InsufficientAllocatedCells);

--- a/src/vm/runners/builtin_runner/keccak.rs
+++ b/src/vm/runners/builtin_runner/keccak.rs
@@ -112,7 +112,7 @@ impl KeccakBuiltinRunner {
             if val >= &(Felt::one() << *bits) {
                 return Err(RunnerError::IntegerBiggerThanPowerOfTwo(
                     value1.clone().into_owned(),
-                    *bits as u32,
+                    *bits,
                     val.clone(),
                 ));
             }

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -307,7 +307,7 @@ impl BuiltinRunner {
         // enough to check if the values are present.
         let mut offsets_iter = offsets.iter().copied().peekable();
         let mut missing_offsets = Vec::new();
-        for i in 0..n as usize {
+        for i in 0..n {
             let offset = cells_per_instance as usize * i;
             for j in 0..n_input_cells as usize {
                 let offset = offset + j;

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -153,7 +153,7 @@ impl RangeCheckBuiltinRunner {
         } else {
             let used = self.get_used_cells(vm)?;
             let size = cells_per_instance as usize
-                * safe_div_usize(vm.current_step, ratio as usize)
+                * safe_div_usize(vm.current_step, ratio)
                     .map_err(|_| MemoryError::InsufficientAllocatedCells)?;
             if used > size {
                 return Err(MemoryError::InsufficientAllocatedCells);

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -208,7 +208,7 @@ impl CairoRunner {
             return Err(RunnerError::NoBuiltinForInstance(
                 program_builtins
                     .difference(&inserted_builtins)
-                    .map(|x| (&(**x).clone()).clone())
+                    .map(|x| (**x).clone())
                     .collect(),
                 self.layout._name.clone(),
             ));

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -22,7 +22,7 @@ use crate::{
         },
         security::verify_secure_runner,
         trace::get_perm_range_check_limits,
-        vm_memory::memory::RelocateValue,
+        vm_memory::{memory::RelocateValue, memory_segments::gen_typed_args},
         {
             runners::builtin_runner::{
                 BitwiseBuiltinRunner, BuiltinRunner, EcOpBuiltinRunner, HashBuiltinRunner,
@@ -480,13 +480,10 @@ impl CairoRunner {
                     &hint.flow_tracking_data.reference_ids,
                     references,
                 );
-                hint_data_dictionary
-                    .entry(*hint_index)
-                    .or_insert(vec![])
-                    .push(
-                        hint_data
-                            .map_err(|_| VirtualMachineError::CompileHintFail(hint.code.clone()))?,
-                    );
+                hint_data_dictionary.entry(*hint_index).or_default().push(
+                    hint_data
+                        .map_err(|_| VirtualMachineError::CompileHintFail(hint.code.clone()))?,
+                );
             }
         }
         Ok(hint_data_dictionary)
@@ -952,7 +949,7 @@ impl CairoRunner {
                 return Err(VirtualMachineError::InvalidArgCount(1, args.len()));
             }
 
-            vm.segments.gen_typed_args(args, vm)?
+            gen_typed_args(args)?
         } else {
             let mut stack = Vec::new();
             for arg in args {

--- a/src/vm/trace/trace_entry.rs
+++ b/src/vm/trace/trace_entry.rs
@@ -4,14 +4,14 @@ use serde::{Deserialize, Serialize};
 
 ///A trace entry for every instruction that was executed.
 ///Holds the register values before the instruction was executed.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct TraceEntry {
     pub pc: Relocatable,
     pub ap: Relocatable,
     pub fp: Relocatable,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RelocatedTraceEntry {
     pub ap: usize,
     pub fp: usize,

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -26,7 +26,7 @@ use std::{any::Any, borrow::Cow, collections::HashMap};
 
 const MAX_TRACEBACK_ENTRIES: u32 = 20;
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub struct Operands {
     dst: MaybeRelocatable,
     res: Option<MaybeRelocatable>,
@@ -34,7 +34,7 @@ pub struct Operands {
     op1: MaybeRelocatable,
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub struct OperandsAddresses {
     dst_addr: Relocatable,
     op0_addr: Relocatable,
@@ -686,7 +686,7 @@ impl VirtualMachine {
                     .deduce_memory_cell(&Relocatable::from((index as isize, offset)), &self.memory)
                     .map_err(VirtualMachineError::RunnerError)?
                 {
-                    if Some(&deduced_memory_cell) != value.as_ref() && value != &None {
+                    if Some(&deduced_memory_cell) != value.as_ref() && value.is_some() {
                         return Err(VirtualMachineError::InconsistentAutoDeduction(
                             name.to_owned(),
                             deduced_memory_cell,

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -24,6 +24,8 @@ use felt::Felt;
 use num_traits::{ToPrimitive, Zero};
 use std::{any::Any, borrow::Cow, collections::HashMap};
 
+use super::vm_memory::memory_segments::gen_typed_args;
+
 const MAX_TRACEBACK_ENTRIES: u32 = 20;
 
 #[derive(PartialEq, Eq, Debug)]
@@ -969,7 +971,7 @@ impl VirtualMachine {
         &self,
         args: Vec<&dyn Any>,
     ) -> Result<Vec<MaybeRelocatable>, VirtualMachineError> {
-        self.segments.gen_typed_args(args, self)
+        gen_typed_args(args)
     }
 
     pub fn gen_arg(&mut self, arg: &dyn Any) -> Result<MaybeRelocatable, VirtualMachineError> {
@@ -3785,19 +3787,15 @@ mod tests {
 
     #[test]
     fn gen_typed_args_empty() {
-        let vm = vm!();
-
-        assert_eq!(vm.gen_typed_args(vec![]), Ok(vec![]));
+        assert_eq!(gen_typed_args(vec![]), Ok(vec![]));
     }
 
     /// Test that the call to .gen_typed_args() with an unsupported vector
     /// returns a not implemented error.
     #[test]
     fn gen_typed_args_not_implemented() {
-        let vm = vm!();
-
         assert_eq!(
-            vm.gen_typed_args(vec![&0usize]),
+            gen_typed_args(vec![&0usize]),
             Err(VirtualMachineError::NotImplemented),
         );
     }
@@ -3806,10 +3804,8 @@ mod tests {
     /// with a relocatables returns the original contents.
     #[test]
     fn gen_typed_args_relocatable_slice() {
-        let vm = vm!();
-
         assert_eq!(
-            vm.gen_typed_args(vec![&[
+            gen_typed_args(vec![&[
                 mayberelocatable!(0, 0),
                 mayberelocatable!(0, 1),
                 mayberelocatable!(0, 2),

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -143,10 +143,7 @@ impl Memory {
                         .into_iter()
                         .enumerate()
                         .map(move |(cell_offset, cell_data)| {
-                            (
-                                Relocatable::from((segment_index as isize, cell_offset)),
-                                cell_data,
-                            )
+                            (Relocatable::from((segment_index, cell_offset)), cell_data)
                         })
                 },
             ));
@@ -174,7 +171,7 @@ impl Memory {
             }
 
             let segment_data = &mut self.data[new_addr.segment_index as usize];
-            if new_addr.offset as usize >= segment_data.len() {
+            if new_addr.offset >= segment_data.len() {
                 segment_data.resize(new_addr.offset + 1, None);
             }
 
@@ -328,7 +325,7 @@ pub(crate) trait RelocateValue<'a, Input: 'a, Output: 'a> {
     fn relocate_value(&self, value: Input) -> Output;
 }
 
-impl<'a> RelocateValue<'_, Relocatable, Relocatable> for Memory {
+impl RelocateValue<'_, Relocatable, Relocatable> for Memory {
     fn relocate_value(&self, addr: Relocatable) -> Relocatable {
         let segment_idx = addr.segment_index;
         if segment_idx >= 0 {

--- a/src/vm/vm_memory/memory_segments.rs
+++ b/src/vm/vm_memory/memory_segments.rs
@@ -3,7 +3,7 @@ use crate::{
     utils::from_relocatable_to_indexes,
     vm::{
         errors::memory_errors::MemoryError, errors::vm_errors::VirtualMachineError,
-        vm_core::VirtualMachine, vm_memory::memory::Memory,
+        vm_memory::memory::Memory,
     },
 };
 
@@ -130,26 +130,6 @@ impl MemorySegmentManager {
         }
     }
 
-    pub fn gen_typed_args(
-        &self,
-        args: Vec<&dyn Any>,
-        vm: &VirtualMachine,
-    ) -> Result<Vec<MaybeRelocatable>, VirtualMachineError> {
-        let mut cairo_args = Vec::new();
-        for arg in args {
-            if let Some(value) = arg.downcast_ref::<MaybeRelocatable>() {
-                cairo_args.push(value.into());
-            } else if let Some(value) = arg.downcast_ref::<Vec<MaybeRelocatable>>() {
-                let value = value.iter().map(|x| x as &dyn Any).collect::<Vec<_>>();
-                cairo_args.extend(self.gen_typed_args(value, vm)?.into_iter());
-            } else {
-                return Err(VirtualMachineError::NotImplemented);
-            }
-        }
-
-        Ok(cairo_args)
-    }
-
     pub fn write_arg(
         &mut self,
         memory: &mut Memory,
@@ -250,6 +230,22 @@ impl MemorySegmentManager {
     }
 }
 
+pub fn gen_typed_args(args: Vec<&dyn Any>) -> Result<Vec<MaybeRelocatable>, VirtualMachineError> {
+    let mut cairo_args = Vec::new();
+    for arg in args {
+        if let Some(value) = arg.downcast_ref::<MaybeRelocatable>() {
+            cairo_args.push(value.into());
+        } else if let Some(value) = arg.downcast_ref::<Vec<MaybeRelocatable>>() {
+            let value = value.iter().map(|x| x as &dyn Any).collect::<Vec<_>>();
+            cairo_args.extend(gen_typed_args(value)?.into_iter());
+        } else {
+            return Err(VirtualMachineError::NotImplemented);
+        }
+    }
+
+    Ok(cairo_args)
+}
+
 impl Default for MemorySegmentManager {
     fn default() -> Self {
         Self::new()
@@ -259,6 +255,7 @@ impl Default for MemorySegmentManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vm::vm_core::VirtualMachine;
     use crate::{relocatable, utils::test_utils::*};
     use felt::{Felt, NewFelt};
     use num_traits::Num;
@@ -815,24 +812,15 @@ mod tests {
     /// empty vector.
     #[test]
     fn gen_typed_args_empty() {
-        let memory_segment_manager = MemorySegmentManager::new();
-        let vm = vm!();
-
-        assert_eq!(
-            memory_segment_manager.gen_typed_args(vec![], &vm),
-            Ok(vec![])
-        );
+        assert_eq!(gen_typed_args(vec![]), Ok(vec![]));
     }
 
     /// Test that the call to .gen_typed_args() with an unsupported vector
     /// returns a not implemented error.
     #[test]
     fn gen_typed_args_not_implemented() {
-        let memory_segment_manager = MemorySegmentManager::new();
-        let vm = vm!();
-
         assert_eq!(
-            memory_segment_manager.gen_typed_args(vec![&0usize], &vm),
+            gen_typed_args(vec![&0usize]),
             Err(VirtualMachineError::NotImplemented),
         );
     }
@@ -841,20 +829,14 @@ mod tests {
     /// with a relocatables returns the original contents.
     #[test]
     fn gen_typed_args_relocatable_slice() {
-        let memory_segment_manager = MemorySegmentManager::new();
-        let vm = vm!();
-
         assert_eq!(
-            memory_segment_manager.gen_typed_args(
-                vec![&[
-                    mayberelocatable!(0, 0),
-                    mayberelocatable!(0, 1),
-                    mayberelocatable!(0, 2),
-                ]
-                .into_iter()
-                .collect::<Vec<MaybeRelocatable>>(),],
-                &vm,
-            ),
+            gen_typed_args(vec![&[
+                mayberelocatable!(0, 0),
+                mayberelocatable!(0, 1),
+                mayberelocatable!(0, 2),
+            ]
+            .into_iter()
+            .collect::<Vec<MaybeRelocatable>>(),],),
             Ok(vec![
                 mayberelocatable!(0, 0),
                 mayberelocatable!(0, 1),


### PR DESCRIPTION
# Update ymls to Rust version 1.66.1

## Description

The Rust team has announced a vulnerability that exposes "all Rust versions containing Cargo before 1.66.1" to man in the middle attacks.

As of now, version 1.66.1 is out and they "recommend everyone to upgrade as soon as possible".

This PR aims to update Rust to fix this vulnerability.

## Checklist
- [x] Linked to Github Issue: https://github.com/lambdaclass/cairo-rs/issues/705
- [-] Unit tests added
- [-] Integration tests added.
- [-] This change requires new documentation.
  - [-] Documentation has been added/updated.