### PR TITLE
Fixes to be able to publish crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,13 +163,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
-name = "cairo-rs"
+name = "cairo-felt"
+version = "0.1.0"
+dependencies = [
+ "lazy_static",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "proptest",
+ "serde",
+]
+
+[[package]]
+name = "cairo-vm"
 version = "0.1.0"
 dependencies = [
  "bincode",
+ "cairo-felt",
  "clap 3.2.15",
  "criterion",
- "felt",
  "generic-array",
  "hex",
  "iai",
@@ -466,18 +478,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
-]
-
-[[package]]
-name = "felt"
-version = "0.1.0"
-dependencies = [
- "lazy_static",
- "num-bigint",
- "num-integer",
- "num-traits",
- "proptest",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,12 @@
 [workspace]
-members = [".", "felt"]
+members = [".", "felt", "./deps/parse-hyperlinks"]
 
 [package]
-name = "cairo-rs"
+name = "cairo-vm"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
+description = "Blazing fast Cairo interpreter"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -37,8 +39,8 @@ generic-array = "0.14.6"
 # There is a proposal for extending nom::delimited to use this function:
 # https://github.com/Geal/nom/issues/1253
 keccak = "0.1.2"
-parse-hyperlinks = { path = "./deps/parse-hyperlinks" }
-felt = { path = "./felt" }
+parse-hyperlinks = { path = "./deps/parse-hyperlinks", version = "0.23.4" }
+felt = { path = "./felt", version = "0.1.0" }
 
 [dev-dependencies]
 iai = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,14 +33,14 @@ nom = "7"
 sha2 = {version="0.10.2", features=["compress"]}
 thiserror = "1.0.32"
 generic-array = "0.14.6"
+keccak = "0.1.2"
 # This crate has only one function `take_until_unbalanced` that is
 # very useful for our parsing purposes:
 # https://stackoverflow.com/questions/70630556/parse-allowing-nested-parentheses-in-nom
 # There is a proposal for extending nom::delimited to use this function:
 # https://github.com/Geal/nom/issues/1253
-keccak = "0.1.2"
 parse-hyperlinks = { path = "./deps/parse-hyperlinks", version = "0.23.4" }
-felt = { path = "./felt", version = "0.1.0" }
+felt = { package = "cairo-felt", path = "./felt", version = "0.1.0" }
 
 [dev-dependencies]
 iai = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "felt", "./deps/parse-hyperlinks"]
 
 [package]
 name = "cairo-vm"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 description = "Blazing fast Cairo interpreter"

--- a/bench/criterion_benchmark.rs
+++ b/bench/criterion_benchmark.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use cairo_rs::{
+use cairo_vm::{
     cairo_run,
     hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor,
 };

--- a/bench/iai_benchmark.rs
+++ b/bench/iai_benchmark.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use cairo_rs::{
+use cairo_vm::{
     cairo_run::cairo_run,
     hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor,
     vm::errors::cairo_run_errors::CairoRunError, vm::runners::cairo_runner::CairoRunner,

--- a/custom_hint_example/src/main.rs
+++ b/custom_hint_example/src/main.rs
@@ -1,12 +1,12 @@
-use cairo_rs::cairo_run::cairo_run;
-use cairo_rs::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::{
+use cairo_vm::cairo_run::cairo_run;
+use cairo_vm::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::{
     BuiltinHintProcessor, HintFunc,
 };
-use cairo_rs::hint_processor::builtin_hint_processor::hint_utils::get_integer_from_var_name;
-use cairo_rs::hint_processor::hint_processor_definition::HintReference;
-use cairo_rs::types::exec_scope::ExecutionScopes;
-use cairo_rs::serde::deserialize_program::ApTracking;
-use cairo_rs::vm::{errors::hint_errors::HintError, vm_core::VirtualMachine};
+use cairo_vm::hint_processor::builtin_hint_processor::hint_utils::get_integer_from_var_name;
+use cairo_vm::hint_processor::hint_processor_definition::HintReference;
+use cairo_vm::types::exec_scope::ExecutionScopes;
+use cairo_vm::serde::deserialize_program::ApTracking;
+use cairo_vm::vm::{errors::hint_errors::HintError, vm_core::VirtualMachine};
 use num_bigint::BigInt;
 use std::collections::HashMap;
 use std::path::Path;

--- a/docs/hint_processor/builtin_hint_processor/README.md
+++ b/docs/hint_processor/builtin_hint_processor/README.md
@@ -60,7 +60,7 @@ let hint = HintFunc(Box::new(print_a_hint));
 #### Step 3: Instantiate the BuiltinHintProcessor and add your custom hint implementation
 Import the BuiltinHintProcessor from cairo-rs, instantiate it using the `new_empty()` method and the add your custom hint implementation using the method `add_hint`
 ```rust
-use cairo_rs::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor
+use cairo_vm::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor
 
 let mut hint_processor = BuiltinHintProcessor::new_empty();
 hint_processor.add_hint(String::from("print(ids.a)"), hint);
@@ -71,7 +71,7 @@ You can also create a dictionary of HintFunc and use the method `new()` to creat
 Import the function cairo_run from cairo-rs, and run your compiled program
 
 ```rust
-use cairo_rs::cairo_run::cairo_run;
+use cairo_vm::cairo_run::cairo_run;
 cairo_run(
         Path::new("custom_hint.json"),
         "main",

--- a/felt/Cargo.toml
+++ b/felt/Cargo.toml
@@ -2,6 +2,8 @@
 name = "felt"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
+description = "Field elements representation for the Cairo VM"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/felt/Cargo.toml
+++ b/felt/Cargo.toml
@@ -8,10 +8,10 @@ description = "Field elements representation for the Cairo VM"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-num-integer = "*"
+num-integer = "0.1.45"
 num-bigint = { version = "0.4", features = ["serde"] }
-num-traits = "*"
-lazy_static = "*"
+num-traits = "0.2.15"
+lazy_static = "1.4.0"
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]

--- a/felt/Cargo.toml
+++ b/felt/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "felt"
+name = "cairo-felt"
 version = "0.1.0"
 edition = "2021"
 license = "MIT"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
 #![deny(warnings)]
-use cairo_rs::cairo_run;
-use cairo_rs::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor;
-use cairo_rs::vm::errors::cairo_run_errors::CairoRunError;
-use cairo_rs::vm::errors::runner_errors::RunnerError;
-use cairo_rs::vm::errors::trace_errors::TraceError;
+use cairo_vm::cairo_run;
+use cairo_vm::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor;
+use cairo_vm::vm::errors::cairo_run_errors::CairoRunError;
+use cairo_vm::vm::errors::runner_errors::RunnerError;
+use cairo_vm::vm::errors::trace_errors::TraceError;
 use clap::{Parser, ValueHint};
 use std::path::PathBuf;
 

--- a/tests/bitwise_test.rs
+++ b/tests/bitwise_test.rs
@@ -1,4 +1,4 @@
-use cairo_rs::{
+use cairo_vm::{
     hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor,
     types::program::Program,
     vm::{

--- a/tests/cairo_run_test.rs
+++ b/tests/cairo_run_test.rs
@@ -1,5 +1,5 @@
-use cairo_rs::cairo_run;
-use cairo_rs::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor;
+use cairo_vm::cairo_run;
+use cairo_vm::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor;
 use std::path::Path;
 
 #[test]

--- a/tests/pedersen_test.rs
+++ b/tests/pedersen_test.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use cairo_rs::{
+use cairo_vm::{
     hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor,
     types::program::Program,
     vm::trace::trace_entry::RelocatedTraceEntry,

--- a/tests/struct_test.rs
+++ b/tests/struct_test.rs
@@ -1,10 +1,10 @@
-use cairo_rs::{
+use cairo_vm::{
     hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor,
     vm::vm_core::VirtualMachine,
 };
 use std::path::Path;
 
-use cairo_rs::{
+use cairo_vm::{
     types::program::Program,
     vm::{runners::cairo_runner::CairoRunner, trace::trace_entry::RelocatedTraceEntry},
 };


### PR DESCRIPTION
crates.io requires a few changes to our code (mostly to our manifests):
- We need to avoid name collisions with existing crates.
- The binary needs to call the library by its crate name.
- All crates in the workspace need to be published separately.
- Everything must be versioned.