### PR TITLE
[WIP - Solving conflicts] Property based test for performing exponentiation with felts

### DIFF
--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -416,8 +416,7 @@ impl Pow<u32> for FeltBigInt {
 impl<'a> Pow<u32> for &'a FeltBigInt {
     type Output = FeltBigInt;
     fn pow(self, rhs: u32) -> Self::Output {
-        let x = &self.0;
-        FeltBigInt(x.pow(rhs).mod_floor(&CAIRO_PRIME))
+        FeltBigInt((&self.0).pow(rhs).mod_floor(&CAIRO_PRIME))
     }
 }
 

--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -415,8 +415,8 @@ impl Pow<u32> for FeltBigInt {
 
 impl<'a> Pow<u32> for &'a FeltBigInt {
     type Output = FeltBigInt;
-    let x = &self.0;
     fn pow(self, rhs: u32) -> Self::Output {
+        let x = &self.0;
         FeltBigInt(x.pow(rhs).mod_floor(&CAIRO_PRIME))
     }
 }

--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -415,8 +415,9 @@ impl Pow<u32> for FeltBigInt {
 
 impl<'a> Pow<u32> for &'a FeltBigInt {
     type Output = FeltBigInt;
+    let x = &self.0;
     fn pow(self, rhs: u32) -> Self::Output {
-        FeltBigInt((&self.0).pow(rhs).mod_floor(&CAIRO_PRIME))
+        FeltBigInt(x.pow(rhs).mod_floor(&CAIRO_PRIME))
     }
 }
 

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -199,7 +199,6 @@ mod test {
 
             let result = Pow::pow(base, exponent);
             let as_uint = &result.to_biguint();
-            println!("x: {}, y: {}, result: {}", base, exponent, result); //Testing
             prop_assert!(as_uint < p, "{}", as_uint);
         }
 

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -189,5 +189,18 @@ mod test {
             prop_assert!(as_uint < p, "{}", as_uint);
             prop_assert_eq!(&(q * y), x);
         }
+
+        #[test]
+         // Property-based test that ensures, for 100 values {x} that are randomly generated each time tests are run, that raising {x} to the {y}th power returns a result that is inside of the range [0, p].
+        fn pow_in_range(ref x in "(0|[1-9][0-9]*)", ref y in "[0-9]{1,3}"){
+            let x = &Felt::parse_bytes(x.as_bytes(), 10).unwrap();
+            let y = &Felt::parse_bytes(y.as_bytes(), 10).unwrap();
+            let p = &BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
+
+            let pow = x ** &y;
+            let as_uint = &pow.to_biguint();
+            println!("x: {}, y: {}, pow: {}", x, y, pow);
+            prop_assert!(as_uint < p, "{}", as_uint);
+        }
     }
 }

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -192,14 +192,14 @@ mod test {
 
         #[test]
          // Property-based test that ensures, for 100 values {x} that are randomly generated each time tests are run, that raising {x} to the {y}th power returns a result that is inside of the range [0, p].
-        fn pow_in_range(ref x in "(0|[1-9][0-9]*)", ref y in "[0-9]{1,3}"){
-            let x = &Felt::parse_bytes(x.as_bytes(), 10).unwrap();
-            let y = &Felt::parse_bytes(y.as_bytes(), 10).unwrap();
+        fn pow_in_range(ref x in "(0|[1-9][0-9]*)", ref y in "[0-9]{1,2}"){
+            let base = &Felt::parse_bytes(x.as_bytes(), 10).unwrap();
+            let exponent:u32 = y.parse()?;
             let p = &BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
 
-            let pow = x ** &y;
-            let as_uint = &pow.to_biguint();
-            println!("x: {}, y: {}, pow: {}", x, y, pow);
+            let result = Pow::pow(base, exponent);
+            let as_uint = &result.to_biguint();
+            println!("x: {}, y: {}, result: {}", base, exponent, result); //Testing
             prop_assert!(as_uint < p, "{}", as_uint);
         }
     }


### PR DESCRIPTION
# Property based test for performing exponentiation with felts

## Description

Property-based test that ensures, for 100 values `x` that are randomly generated each time tests are run, that raising `x` to the `y`th power returns a result that is inside of the range [0, p].


## Checklist
- [x] Linked to Github Issue: https://github.com/lambdaclass/cairo-rs/issues/700
- [x] Unit tests added
- [-] Integration tests added.
- [x] This change requires new documentation.
  - [x] Documentation has been added/updated. Documented in the test comments
