### PR TITLE
Proptest for felt bitwise operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-vm"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bincode",
  "cairo-felt",

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -185,7 +185,7 @@ mod test {
 
             let x = &Felt::parse_bytes(x.as_bytes(), 10).unwrap();
             let y = &Felt::parse_bytes(y.as_bytes(), 10).unwrap();
-            prop_assume!(&Felt::zero() != y);
+            prop_assume!(!y.is_zero());
             let p = &BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
 
             let q = x / y;

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -238,6 +238,30 @@ mod test {
         }
 
         #[test]
+        // Property based test that ensures, for a pair of 100 values {x} and {y} generated at random each time tests are run, that performing a BitOr operation between them returns a result that is inside of the range [0, p].
+        fn bitor_in_range(ref x in "(0|[1-9][0-9]*)", ref y in "(0|[1-9][0-9]*)"){
+            let x = Felt::parse_bytes(x.as_bytes(), 10).unwrap();
+            let y = Felt::parse_bytes(y.as_bytes(), 10).unwrap();
+            let p = FeltBigInt::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
+            let result = &x | &y;
+            println!("x: {}, y: {}, result: {}", x, y, result);
+            result.to_biguint();
+            prop_assert!(result < p);
+        }
+
+        #[test]
+        // Property based test that ensures, for a pair of 100 values {x} and {y} generated at random each time tests are run, that performing a BitXor operation between them returns a result that is inside of the range [0, p].
+        fn bitxor_in_range(ref x in "(0|[1-9][0-9]*)", ref y in "(0|[1-9][0-9]*)"){
+            let x = Felt::parse_bytes(x.as_bytes(), 10).unwrap();
+            let y = Felt::parse_bytes(y.as_bytes(), 10).unwrap();
+            let p = FeltBigInt::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
+            let result = &x ^ &y;
+            println!("x: {}, y: {}, result: {}", x, y, result);
+            result.to_biguint();
+            prop_assert!(result < p);
+        }
+
+        #[test]
          // Property-based test that ensures, for 100 values {x} that are randomly generated each time tests are run, that raising {x} to the {y}th power returns a result that is inside of the range [0, p].
         fn pow_in_range(ref x in "(0|[1-9][0-9]*)", ref y in "[0-9]{1,2}"){
             let base = &Felt::parse_bytes(x.as_bytes(), 10).unwrap();

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -227,6 +227,17 @@ mod test {
         }
 
         #[test]
+        // Property based test that ensures, for a pair of 100 values {x} and {y} generated at random each time tests are run, that performing a BitAnd operation between them returns a result that is inside of the range [0, p].
+        fn bitand_in_range(ref x in "(0|[1-9][0-9]*)", ref y in "(0|[1-9][0-9]*)"){
+            let x = Felt::parse_bytes(x.as_bytes(), 10).unwrap();
+            let y = Felt::parse_bytes(y.as_bytes(), 10).unwrap();
+            let p = FeltBigInt::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
+            let result = &x & &y;
+            result.to_biguint();
+            prop_assert!(result < p);
+        }
+
+        #[test]
          // Property-based test that ensures, for 100 values {x} that are randomly generated each time tests are run, that raising {x} to the {y}th power returns a result that is inside of the range [0, p].
         fn pow_in_range(ref x in "(0|[1-9][0-9]*)", ref y in "[0-9]{1,2}"){
             let base = &Felt::parse_bytes(x.as_bytes(), 10).unwrap();

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -182,10 +182,10 @@ mod test {
         #[test]
         // Property-based test that ensures, for 100 {x} and {y} values that are randomly generated each time tests are run, that the result of the division of {x} by {y} is the inverse multiplicative of {x} --that is, multiplying the result by {y} returns the original number {x}. The values of {x} and {y} can be either [0] or a very large number.
         fn div_is_mul_inv(ref x in "(0|[1-9][0-9]*)", ref y in "[1-9][0-9]*") {
-            prop_assume!("0" != y);
 
             let x = &Felt::parse_bytes(x.as_bytes(), 10).unwrap();
             let y = &Felt::parse_bytes(y.as_bytes(), 10).unwrap();
+            prop_assume!(&Felt::zero() != y);
             let p = &BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
 
             let q = x / y;


### PR DESCRIPTION
# Proptest for felt bitwise operations

## Description
This PR is part of https://github.com/lambdaclass/cairo-rs/issues/700: Add property based testing using proptest to ensure operations done with felts are working correctly. These are all the current operations available for felts. 

This PR adds the following operations
- BitAnd
- BitOr
- BitXor

## Checklist
- [x] Linked to Github Issue
- [x] Unit tests added
- [-] Integration tests added.
- [x] This change requires new documentation.
  - [x] Documentation has been added/updated. -- Tests are documented in code comments
