### PR TITLE
Neg prop test for felts

### DIFF
--- a/felt/proptest-regressions/lib.txt
+++ b/felt/proptest-regressions/lib.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 1bf12114a6bfc70e8f949318158595883c33bc6fb35862852bc5144547ac3557 # shrinks to ref x = "0"

--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -270,14 +270,22 @@ impl Sum for FeltBigInt {
 impl Neg for FeltBigInt {
     type Output = FeltBigInt;
     fn neg(self) -> Self::Output {
-        FeltBigInt(&*CAIRO_PRIME - self.0)
+        if self.is_zero() {
+            self
+        } else {
+            FeltBigInt(&*CAIRO_PRIME - self.0)
+        }
     }
 }
 
 impl<'a> Neg for &'a FeltBigInt {
     type Output = FeltBigInt;
     fn neg(self) -> Self::Output {
-        FeltBigInt(&*CAIRO_PRIME - &self.0)
+        if self.is_zero() {
+            self.clone()
+        } else {
+            FeltBigInt(&*CAIRO_PRIME - &self.0)
+        }
     }
 }
 

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -173,7 +173,7 @@ mod test {
             let p = &BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
             let neg = -x;
             let as_uint = &neg.to_biguint();
-            println!("x: {}, y: {}", x, neg);
+            println!("x: {}, neg: {}", x, neg);
             prop_assert!(as_uint < p);
         }
 

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -166,6 +166,16 @@ mod test {
             let p = &BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
             prop_assert!(&x.to_biguint() < p);
         }
+        #[test]
+        // Property-based test that ensures, for 100 felt values that are randomly generated each time tests are run, that the negative of a felt doesn't fall outside the range [0, p].
+        fn neg_in_range(ref x in "(0|[1-9][0-9]*)") {
+            let x = &Felt::parse_bytes(x.as_bytes(), 10).unwrap();
+            let p = &BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
+            let neg = -x;
+            let as_uint = &neg.to_biguint();
+            println!("x: {}, y: {}", x, neg);
+            prop_assert!(as_uint < p);
+        }
 
         #[test]
         // Property-based test that ensures, for 100 {x} and {y} values that are randomly generated each time tests are run, that a multiplication between two felts {x} and {y} and doesn't fall outside the range [0, p]. The values of {x} and {y} can be either [0] or a very large number.


### PR DESCRIPTION
# Neg prop test for felts

## Description

This PR is part of https://github.com/lambdaclass/cairo-rs/issues/700: Add property based testing using proptest to ensure operations done with felts are working correctly. These are all the current operations available for felts.

This PR adds the following operations:

- Negation

This PR also fixes a bug encountered while testing: the negative of 0 fell out of range as it returned the value of the prime. After this fix, the negative of 0 is 0.

## Checklist
- [x] Linked to Github Issue
- [x] Unit tests added
- [-] Integration tests added.
- [x] This change requires new documentation.
  - [x] Documentation has been added/updated. Documented in code comments
