### PR TITLE
Add proptest for felt subtraction

### DIFF
--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -168,6 +168,18 @@ mod test {
         }
 
         #[test]
+        // Property-based test that ensures, for 100 {x} and {y} values that are randomly generated each time tests are run, that a substraction between two felts {x} and {y} and doesn't fall outside the range [0, p]. The values of {x} and {y} can be either [0] or a very large number.
+        fn sub_in_range(ref x in "(0|[1-9][0-9]*)", ref y in "(0|[1-9][0-9]*)") {
+            let x = &Felt::parse_bytes(x.as_bytes(), 10).unwrap();
+            let y = &Felt::parse_bytes(y.as_bytes(), 10).unwrap();
+            let p = &BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
+
+            let sub = x - y;
+            let as_uint = &sub.to_biguint();
+            prop_assert!(as_uint < p, "{}", as_uint);
+        }
+
+        #[test]
         // Property-based test that ensures, for 100 {x} and {y} values that are randomly generated each time tests are run, that a multiplication between two felts {x} and {y} and doesn't fall outside the range [0, p]. The values of {x} and {y} can be either [0] or a very large number.
         fn mul_in_range(ref x in "(0|[1-9][0-9]*)", ref y in "(0|[1-9][0-9]*)") {
             let x = &Felt::parse_bytes(x.as_bytes(), 10).unwrap();

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -168,7 +168,7 @@ mod test {
         }
 
         #[test]
-        // Property-based test that ensures, for 100 {x} and {y} values that are randomly generated each time tests are run, that a substraction between two felts {x} and {y} and doesn't fall outside the range [0, p]. The values of {x} and {y} can be either [0] or a very large number.
+        // Property-based test that ensures, for 100 {x} and {y} values that are randomly generated each time tests are run, that a subtraction between two felts {x} and {y} and doesn't fall outside the range [0, p]. The values of {x} and {y} can be either [0] or a very large number.
         fn sub_in_range(ref x in "(0|[1-9][0-9]*)", ref y in "(0|[1-9][0-9]*)") {
             let x = &Felt::parse_bytes(x.as_bytes(), 10).unwrap();
             let y = &Felt::parse_bytes(y.as_bytes(), 10).unwrap();
@@ -176,6 +176,18 @@ mod test {
 
             let sub = x - y;
             let as_uint = &sub.to_biguint();
+            prop_assert!(as_uint < p, "{}", as_uint);
+        }
+
+        #[test]
+        // Property-based test that ensures, for 100 {x} and {y} values that are randomly generated each time tests are run, that a subtraction with assignment between two felts {x} and {y} and doesn't fall outside the range [0, p]. The values of {x} and {y} can be either [0] or a very large number.
+        fn sub_assign_in_range(ref x in "(0|[1-9][0-9]*)", ref y in "(0|[1-9][0-9]*)") {
+            let mut x = Felt::parse_bytes(x.as_bytes(), 10).unwrap();
+            let y = &Felt::parse_bytes(y.as_bytes(), 10).unwrap();
+            let p = &BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
+
+            x -= y;
+            let as_uint = &x.to_biguint();
             prop_assert!(as_uint < p, "{}", as_uint);
         }
 


### PR DESCRIPTION
# TITLE

## Add proptest for felt subtraction

This PR is part of https://github.com/lambdaclass/cairo-rs/issues/700: Add property based testing using proptest to ensure operations done with felts are working correctly. These are all the current operations available for felts.

This PR adds the following operations:

- Subtraction
- Subtraction with assignment


## Checklist
- [x] Linked to Github Issue
- [x] Unit tests added
- [-] Integration tests added.
- [x] This change requires new documentation.
  - [x] Documentation has been added/updated. The change is documented in code comments.
