### PR TITLE
Fix EC ops detection of elements in curve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "parse-hyperlinks",
+ "proptest",
  "rand_core",
  "rusty-hook",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ felt = { package = "cairo-felt", path = "./felt", version = "0.1.0" }
 
 [dev-dependencies]
 iai = "0.1"
+proptest = "1.0.0"
 
 [dev-dependencies.rusty-hook]
 version = "0.11"

--- a/cairo_programs/bad_programs/ec_op_not_in_curve.cairo
+++ b/cairo_programs/bad_programs/ec_op_not_in_curve.cairo
@@ -1,0 +1,36 @@
+%builtins ec_op
+
+from starkware.cairo.common.cairo_builtins import EcOpBuiltin, SignatureBuiltin
+from starkware.cairo.common.ec_point import (
+    EcPoint,
+)
+from starkware.cairo.common.cairo_secp.ec import (
+    ec_negate,
+    compute_doubling_slope,
+    compute_slope,
+    ec_double,
+    fast_ec_add,
+    ec_mul_inner,
+)
+from starkware.cairo.common.cairo_secp.bigint import BigInt3
+
+func test_ec_op_point_not_on_curve{
+    ec_op_ptr: EcOpBuiltin*
+}() {
+    tempvar p = EcPoint(
+        0x654fd7e67a123dd13868093b3b7777f1ffef596c2e324f25ceaf9146698482c,
+        0x4fad269cbf860980e38768fe9cb6b0b9ab03ee3fe84cfde2eccce597c874fd8,
+        );
+    assert ec_op_ptr[0].p = p;
+    assert ec_op_ptr[0].q = EcPoint(x=p.x, y=p.y + 1);
+    assert ec_op_ptr[0].m = 7;
+    let ec_op_ptr = &ec_op_ptr[1];
+    return ();
+}
+
+func main{
+    ec_op_ptr: EcOpBuiltin*
+}() {
+    test_ec_op_point_not_on_curve();
+    return ();
+}

--- a/cairo_programs/bad_programs/ec_op_same_x.cairo
+++ b/cairo_programs/bad_programs/ec_op_same_x.cairo
@@ -1,6 +1,10 @@
+%builtins ec_op
+
 from starkware.cairo.common.cairo_builtins import EcOpBuiltin, SignatureBuiltin
-from starkware.cairo.common.cairo_secp.ec import (
+from starkware.cairo.common.ec_point import (
     EcPoint,
+)
+from starkware.cairo.common.cairo_secp.ec import (
     ec_negate,
     compute_doubling_slope,
     compute_slope,
@@ -9,20 +13,6 @@ from starkware.cairo.common.cairo_secp.ec import (
     ec_mul_inner,
 )
 from starkware.cairo.common.cairo_secp.bigint import BigInt3
-
-func test_ec_op_point_not_on_curve{
-    ec_op_ptr: EcOpBuiltin*
-}() {
-    tempvar p = EcPoint(
-        0x654fd7e67a123dd13868093b3b7777f1ffef596c2e324f25ceaf9146698482c,
-        0x4fad269cbf860980e38768fe9cb6b0b9ab03ee3fe84cfde2eccce597c874fd8,
-        );
-    assert ec_op_ptr[0].p = p;
-    assert ec_op_ptr[0].q = EcPoint(x=p.x, y=p.y + 1);
-    assert ec_op_ptr[0].m = 7;
-    let ec_op_ptr = &ec_op_ptr[1];
-    return ();
-}
 
 func test_ec_op_invalid_input{
     ec_op_ptr: EcOpBuiltin*
@@ -44,5 +34,12 @@ func test_ec_op_invalid_input{
         );
     assert ec_op_ptr[0].m = 8;
     let ec_op_ptr = &ec_op_ptr[1];
+    return ();
+}
+
+func main{
+    ec_op_ptr: EcOpBuiltin*
+}() {
+    test_ec_op_invalid_input();
     return ();
 }

--- a/cairo_programs/ec_op_deduce_memory_cell_bug.cairo
+++ b/cairo_programs/ec_op_deduce_memory_cell_bug.cairo
@@ -1,0 +1,48 @@
+from starkware.cairo.common.cairo_builtins import EcOpBuiltin, SignatureBuiltin
+from starkware.cairo.common.cairo_secp.ec import (
+    EcPoint,
+    ec_negate,
+    compute_doubling_slope,
+    compute_slope,
+    ec_double,
+    fast_ec_add,
+    ec_mul_inner,
+)
+from starkware.cairo.common.cairo_secp.bigint import BigInt3
+
+func test_ec_op_point_not_on_curve{
+    ec_op_ptr: EcOpBuiltin*
+}() {
+    tempvar p = EcPoint(
+        0x654fd7e67a123dd13868093b3b7777f1ffef596c2e324f25ceaf9146698482c,
+        0x4fad269cbf860980e38768fe9cb6b0b9ab03ee3fe84cfde2eccce597c874fd8,
+        );
+    assert ec_op_ptr[0].p = p;
+    assert ec_op_ptr[0].q = EcPoint(x=p.x, y=p.y + 1);
+    assert ec_op_ptr[0].m = 7;
+    let ec_op_ptr = &ec_op_ptr[1];
+    return ();
+}
+
+func test_ec_op_invalid_input{
+    ec_op_ptr: EcOpBuiltin*
+}() {
+    // Choose p = 4 * q.
+    // Trying to compute p + 8 * q starts with the following pairs of points:
+    //   (p, q),
+    //   (p, 2 * q),
+    //   (p, 4 * q),
+    //   (p, 8 * q),
+    // But since p = 4 * q, the pair (p, 4 * q) is invalid (the x-coordinate is the same).
+    assert ec_op_ptr[0].p = EcPoint(
+        0x6a4beaef5a93425b973179cdba0c9d42f30e01a5f1e2db73da0884b8d6756fc,
+        0x72565ec81bc09ff53fbfad99324a92aa5b39fb58267e395e8abe36290ebf24f,
+        );
+    assert ec_op_ptr[0].q = EcPoint(
+        0x654fd7e67a123dd13868093b3b7777f1ffef596c2e324f25ceaf9146698482c,
+        0x4fad269cbf860980e38768fe9cb6b0b9ab03ee3fe84cfde2eccce597c874fd8,
+        );
+    assert ec_op_ptr[0].m = 8;
+    let ec_op_ptr = &ec_op_ptr[1];
+    return ();
+}

--- a/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
@@ -92,9 +92,9 @@ pub fn compute_doubling_slope(
     );
 
     let value = ec_double_slope(
-        &(
-            pack(x_d0.as_ref(), x_d1.as_ref(), x_d2.as_ref()),
-            pack(y_d0.as_ref(), y_d1.as_ref(), y_d2.as_ref()),
+        (
+            &pack(x_d0.as_ref(), x_d1.as_ref(), x_d2.as_ref()),
+            &pack(y_d0.as_ref(), y_d1.as_ref(), y_d2.as_ref()),
         ),
         &BigInt::zero(),
         &secp_p,
@@ -156,25 +156,25 @@ pub fn compute_slope(
     );
 
     let value = line_slope(
-        &(
-            pack(
+        (
+            &pack(
                 point0_x_d0.as_ref(),
                 point0_x_d1.as_ref(),
                 point0_x_d2.as_ref(),
             ),
-            pack(
+            &pack(
                 point0_y_d0.as_ref(),
                 point0_y_d1.as_ref(),
                 point0_y_d2.as_ref(),
             ),
         ),
-        &(
-            pack(
+        (
+            &pack(
                 point1_x_d0.as_ref(),
                 point1_x_d1.as_ref(),
                 point1_x_d2.as_ref(),
             ),
-            pack(
+            &pack(
                 point1_y_d0.as_ref(),
                 point1_y_d1.as_ref(),
                 point1_y_d2.as_ref(),

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -305,6 +305,7 @@ mod tests {
     };
     use felt::felt_str;
     use proptest::prelude::*;
+    use std::path::Path;
     use EcOpBuiltinRunner;
 
     proptest! {
@@ -1096,5 +1097,41 @@ mod tests {
     fn initial_stack_not_included_test() {
         let ec_op_builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), false);
         assert_eq!(ec_op_builtin.initial_stack(), Vec::new())
+    }
+
+    #[test]
+    fn catch_point_not_in_curve() {
+        let program = Program::from_file(
+            Path::new("cairo_programs/bad_programs/ec_op_not_in_curve.json"),
+            Some("main"),
+        )
+        .expect("Call to `Program::from_file()` failed.");
+
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
+        let mut cairo_runner = cairo_runner!(program, "all", false);
+        let mut vm = vm!();
+
+        let end = cairo_runner.initialize(&mut vm).unwrap();
+        assert!(cairo_runner
+            .run_until_pc(end, &mut vm, &mut hint_processor)
+            .is_err());
+    }
+
+    #[test]
+    fn catch_point_same_x() {
+        let program = Program::from_file(
+            Path::new("cairo_programs/bad_programs/ec_op_same_x.json"),
+            Some("main"),
+        )
+        .expect("Call to `Program::from_file()` failed.");
+
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
+        let mut cairo_runner = cairo_runner!(program, "all", false);
+        let mut vm = vm!();
+
+        let end = cairo_runner.initialize(&mut vm).unwrap();
+        assert!(cairo_runner
+            .run_until_pc(end, &mut vm, &mut hint_processor)
+            .is_err());
     }
 }


### PR DESCRIPTION
- Adds property tests for `point_on_curve`
- Converts to the correct prime for elliptic curves
- Convert a few bits to references

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [x] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
