### PR TITLE
Fix clippy error in cairo-rs-py

### DIFF
--- a/src/vm/errors/vm_exception.rs
+++ b/src/vm/errors/vm_exception.rs
@@ -64,7 +64,11 @@ pub fn get_error_attr_value(
             ));
         }
     }
-    (!errors.is_empty()).then_some(errors)
+    if errors.is_empty() {
+        None
+    } else {
+        Some(errors)
+    }
 }
 
 pub fn get_location(


### PR DESCRIPTION
When updating the cairo-rs commit used by cairo-rs-py, running clippy outputs the following error:
```
Checking cairo-vm v0.1.1 (https://github.com/lambdaclass/cairo-rs.git?rev=9321055390512cd2e668a82fa34619c20baee9d7#93210553)
[202](https://github.com/lambdaclass/cairo-rs-py/actions/runs/3951144729/jobs/6764619128#step:7:203)
error[E0658]: use of unstable library feature 'bool_to_option'
[203](https://github.com/lambdaclass/cairo-rs-py/actions/runs/3951144729/jobs/6764619128#step:7:204)
  --> /home/runner/.cargo/git/checkouts/cairo-rs-550f844fbb3def24/9321055/src/vm/errors/vm_exception.rs:67:26
[204](https://github.com/lambdaclass/cairo-rs-py/actions/runs/3951144729/jobs/6764619128#step:7:205)
   |
[205](https://github.com/lambdaclass/cairo-rs-py/actions/runs/3951144729/jobs/6764619128#step:7:206)
67 |     (!errors.is_empty()).then_some(errors)
[206](https://github.com/lambdaclass/cairo-rs-py/actions/runs/3951144729/jobs/6764619128#step:7:207)
   |                          ^^^^^^^^^
[207](https://github.com/lambdaclass/cairo-rs-py/actions/runs/3951144729/jobs/6764619128#step:7:208)
   |
[208](https://github.com/lambdaclass/cairo-rs-py/actions/runs/3951144729/jobs/6764619128#step:7:209)
   = note: see issue #80967 <https://github.com/rust-lang/rust/issues/80967> for more information
[209](https://github.com/lambdaclass/cairo-rs-py/actions/runs/3951144729/jobs/6764619128#step:7:210)

[210](https://github.com/lambdaclass/cairo-rs-py/actions/runs/3951144729/jobs/6764619128#step:7:211)
For more information about this error, try `rustc --explain E0658`.
[211](https://github.com/lambdaclass/cairo-rs-py/actions/runs/3951144729/jobs/6764619128#step:7:212)
error: could not compile `cairo-vm` due to previous error
[212](https://github.com/lambdaclass/cairo-rs-py/actions/runs/3951144729/jobs/6764619128#step:7:213)
make: *** [Makefile:86: clippy] Error 101
```
PR for reference: https://github.com/lambdaclass/cairo-rs-py/actions/runs/3951144729/jobs/6764619128
