### PR TITLE
Convert `Felt` to struct and avoid counterintuitive imports

### DIFF
--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -817,21 +817,6 @@ impl fmt::Display for ParseFeltError {
     }
 }
 
-#[macro_export]
-macro_rules! felt_str {
-    ($val: expr) => {
-        <felt::Felt as felt::FeltOps<{ felt::FIELD_HIGH }, { felt::FIELD_LOW }>>::new(
-            num_bigint::BigInt::parse_bytes($val.as_bytes(), 10_u32).expect("Couldn't parse bytes"),
-        )
-    };
-    ($val: expr, $opt: expr) => {
-        <felt::Felt as felt::FeltOps<{ felt::FIELD_HIGH }, { felt::FIELD_LOW }>>::new(
-            num_bigint::BigInt::parse_bytes($val.as_bytes(), $opt as u32)
-                .expect("Couldn't parse bytes"),
-        )
-    };
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -521,19 +521,15 @@ impl<'a, const PH: u128, const PL: u128> Div<FeltBigInt<PH, PL>> for &'a FeltBig
 
 impl<const PH: u128, const PL: u128> Rem for FeltBigInt<PH, PL> {
     type Output = Self;
-    fn rem(self, rhs: Self) -> Self {
-        FeltBigInt {
-            val: self.val % rhs.val,
-        }
+    fn rem(self, _rhs: Self) -> Self {
+        FeltBigInt::zero()
     }
 }
 
 impl<'a, const PH: u128, const PL: u128> Rem<&'a FeltBigInt<PH, PL>> for FeltBigInt<PH, PL> {
     type Output = Self;
-    fn rem(self, rhs: &'a FeltBigInt<PH, PL>) -> Self::Output {
-        FeltBigInt {
-            val: self.val % &rhs.val,
-        }
+    fn rem(self, _rhs: &'a FeltBigInt<PH, PL>) -> Self::Output {
+        FeltBigInt::zero()
     }
 }
 

--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -25,8 +25,7 @@ lazy_static! {
 }
 
 #[derive(Eq, Hash, PartialEq, PartialOrd, Ord, Clone, Deserialize, Default, Serialize)]
-//pub struct FeltBigInt(BigUint);
-pub struct FeltBigInt<const PH: u128, const PL: u128> {
+pub(crate) struct FeltBigInt<const PH: u128, const PL: u128> {
     val: BigUint,
 }
 

--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -31,7 +31,7 @@ pub(crate) struct FeltBigInt<const PH: u128, const PL: u128> {
 
 macro_rules! from_integer {
     ($type:ty) => {
-        impl<const PH: u128, const PL: u128> From<$type> for FeltBigInt<PH, PL> {
+        impl From<$type> for FeltBigInt<FIELD_HIGH, FIELD_LOW> {
             fn from(value: $type) -> Self {
                 Self {
                     val: value
@@ -45,7 +45,7 @@ macro_rules! from_integer {
 
 macro_rules! from_unsigned {
     ($type:ty) => {
-        impl<const PH: u128, const PL: u128> From<$type> for FeltBigInt<PH, PL> {
+        impl From<$type> for FeltBigInt<FIELD_HIGH, FIELD_LOW> {
             fn from(value: $type) -> Self {
                 Self { val: value.into() }
             }

--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -390,16 +390,16 @@ impl<'a, const PH: u128, const PL: u128> SubAssign<&'a FeltBigInt<PH, PL>> for F
     }
 }
 
-impl<const PH: u128, const PL: u128> Sub<FeltBigInt<PH, PL>> for usize {
-    type Output = FeltBigInt<PH, PL>;
-    fn sub(self, rhs: FeltBigInt<PH, PL>) -> Self::Output {
+impl Sub<FeltBigInt<FIELD_HIGH, FIELD_LOW>> for usize {
+    type Output = FeltBigInt<FIELD_HIGH, FIELD_LOW>;
+    fn sub(self, rhs: FeltBigInt<FIELD_HIGH, FIELD_LOW>) -> Self::Output {
         self - &rhs
     }
 }
 
-impl<const PH: u128, const PL: u128> Sub<&FeltBigInt<PH, PL>> for usize {
-    type Output = FeltBigInt<PH, PL>;
-    fn sub(self, rhs: &FeltBigInt<PH, PL>) -> Self::Output {
+impl Sub<&FeltBigInt<FIELD_HIGH, FIELD_LOW>> for usize {
+    type Output = FeltBigInt<FIELD_HIGH, FIELD_LOW>;
+    fn sub(self, rhs: &FeltBigInt<FIELD_HIGH, FIELD_LOW>) -> Self::Output {
         match (rhs.val).to_usize() {
             Some(num) => {
                 if num > self {

--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -13,7 +13,7 @@ use std::{
     },
 };
 
-use crate::{FeltOps, NewFelt, ParseFeltError, FIELD_HIGH, FIELD_LOW};
+use crate::{FeltOps, ParseFeltError, FIELD_HIGH, FIELD_LOW};
 
 lazy_static! {
     pub static ref CAIRO_PRIME: BigUint =
@@ -125,13 +125,11 @@ impl<const PH: u128, const PL: u128> From<&BigInt> for FeltBigInt<PH, PL> {
     }
 }
 
-impl<const PH: u128, const PL: u128> NewFelt<PH, PL> for FeltBigInt<PH, PL> {
+impl<const PH: u128, const PL: u128> FeltOps<PH, PL> for FeltBigInt<PH, PL> {
     fn new<T: Into<Self>>(value: T) -> Self {
         value.into()
     }
-}
 
-impl<const PH: u128, const PL: u128> FeltOps<PH, PL> for FeltBigInt<PH, PL> {
     fn modpow(&self, exponent: &FeltBigInt<PH, PL>, modulus: &FeltBigInt<PH, PL>) -> Self {
         FeltBigInt {
             val: self.val.modpow(&exponent.val, &modulus.val),
@@ -825,12 +823,12 @@ impl fmt::Display for ParseFeltError {
 #[macro_export]
 macro_rules! felt_str {
     ($val: expr) => {
-        <felt::Felt as felt::NewFelt<{ felt::FIELD_HIGH }, { felt::FIELD_LOW }>>::new(
+        <felt::Felt as felt::FeltOps<{ felt::FIELD_HIGH }, { felt::FIELD_LOW }>>::new(
             num_bigint::BigInt::parse_bytes($val.as_bytes(), 10_u32).expect("Couldn't parse bytes"),
         )
     };
     ($val: expr, $opt: expr) => {
-        <felt::Felt as felt::NewFelt<{ felt::FIELD_HIGH }, { felt::FIELD_LOW }>>::new(
+        <felt::Felt as felt::FeltOps<{ felt::FIELD_HIGH }, { felt::FIELD_LOW }>>::new(
             num_bigint::BigInt::parse_bytes($val.as_bytes(), $opt as u32)
                 .expect("Couldn't parse bytes"),
         )

--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -2,7 +2,7 @@ use lazy_static::lazy_static;
 use num_bigint::{BigInt, BigUint, ToBigInt, U64Digits};
 use num_integer::Integer;
 use num_traits::{Bounded, FromPrimitive, Num, One, Pow, Signed, ToPrimitive, Zero};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::{
     convert::Into,
     fmt,
@@ -24,7 +24,7 @@ lazy_static! {
         .expect("Conversion BigUint -> BigInt can't fail");
 }
 
-#[derive(Eq, Hash, PartialEq, PartialOrd, Ord, Clone, Deserialize, Default)]
+#[derive(Eq, Hash, PartialEq, PartialOrd, Ord, Clone, Deserialize, Default, Serialize)]
 pub struct FeltBigInt(BigUint);
 
 macro_rules! from_integer {

--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -69,32 +69,24 @@ from_unsigned!(usize);
 
 impl<const PH: u128, const PL: u128> From<BigUint> for FeltBigInt<PH, PL> {
     fn from(value: BigUint) -> Self {
-        if value > *CAIRO_PRIME {
-            Self {
-                val: value.mod_floor(&CAIRO_PRIME),
-            }
-        } else if value == *CAIRO_PRIME {
-            Self {
-                val: BigUint::zero(),
-            }
-        } else {
-            Self { val: value }
+        Self {
+            val: match value {
+                _ if value > *CAIRO_PRIME => value.mod_floor(&CAIRO_PRIME),
+                _ if value == *CAIRO_PRIME => BigUint::zero(),
+                _ => value,
+            },
         }
     }
 }
 
 impl<const PH: u128, const PL: u128> From<&BigUint> for FeltBigInt<PH, PL> {
     fn from(value: &BigUint) -> Self {
-        if value > &*CAIRO_PRIME {
-            Self {
-                val: value.mod_floor(&CAIRO_PRIME),
-            }
-        } else if value == &*CAIRO_PRIME {
-            Self {
-                val: BigUint::zero(),
-            }
-        } else {
-            Self { val: value.clone() }
+        Self {
+            val: match value {
+                _ if value > &*CAIRO_PRIME => value.mod_floor(&CAIRO_PRIME),
+                _ if value == &*CAIRO_PRIME => BigUint::zero(),
+                _ => value.clone(),
+            },
         }
     }
 }

--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -588,7 +588,7 @@ impl Num for FeltBigInt<FIELD_HIGH, FIELD_LOW> {
 impl Integer for FeltBigInt<FIELD_HIGH, FIELD_LOW> {
     fn div_floor(&self, other: &Self) -> Self {
         FeltBigInt {
-            val: self.val.div_floor(&other.val),
+            val: &self.val / &other.val,
         }
     }
 
@@ -611,8 +611,8 @@ impl Integer for FeltBigInt<FIELD_HIGH, FIELD_LOW> {
         self.val.is_even()
     }
 
-    fn is_multiple_of(&self, other: &Self) -> bool {
-        self.val.is_multiple_of(&other.val)
+    fn is_multiple_of(&self, _other: &Self) -> bool {
+        true
     }
 
     fn is_odd(&self) -> bool {
@@ -620,7 +620,7 @@ impl Integer for FeltBigInt<FIELD_HIGH, FIELD_LOW> {
     }
 
     fn lcm(&self, other: &Self) -> Self {
-        Self::new(self.val.lcm(&other.val))
+        Self::new(std::cmp::max(&self.val, &other.val))
     }
 
     fn mod_floor(&self, other: &Self) -> Self {

--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -25,11 +25,14 @@ lazy_static! {
 }
 
 #[derive(Eq, Hash, PartialEq, PartialOrd, Ord, Clone, Deserialize, Default, Serialize)]
-pub struct FeltBigInt(BigUint);
+//pub struct FeltBigInt(BigUint);
+pub struct FeltBigInt<const P: (u128, u128)> {
+    val: BigUint,
+}
 
 macro_rules! from_integer {
     ($type:ty) => {
-        impl From<$type> for FeltBigInt {
+        impl From<$type> for FeltBigInt<FIELD> {
             fn from(value: $type) -> Self {
                 Self(
                     value
@@ -43,7 +46,7 @@ macro_rules! from_integer {
 
 macro_rules! from_unsigned {
     ($type:ty) => {
-        impl From<$type> for FeltBigInt {
+        impl From<$type> for FeltBigInt<FIELD> {
             fn from(value: $type) -> Self {
                 Self(value.into())
             }

--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -68,7 +68,7 @@ from_unsigned!(u64);
 from_unsigned!(u128);
 from_unsigned!(usize);
 
-impl From<BigUint> for FeltBigInt {
+impl From<BigUint> for FeltBigInt<FIELD> {
     fn from(value: BigUint) -> Self {
         if value > *CAIRO_PRIME {
             Self(value.mod_floor(&CAIRO_PRIME))
@@ -78,7 +78,7 @@ impl From<BigUint> for FeltBigInt {
     }
 }
 
-impl From<&BigUint> for FeltBigInt {
+impl From<&BigUint> for FeltBigInt<FIELD> {
     fn from(value: &BigUint) -> Self {
         if value > &*CAIRO_PRIME {
             Self(value.mod_floor(&CAIRO_PRIME))
@@ -104,13 +104,13 @@ impl From<&BigUint> for FeltBigInt {
    }
 */
 
-impl From<BigInt> for FeltBigInt {
+impl From<BigInt> for FeltBigInt<FIELD> {
     fn from(value: BigInt) -> Self {
         (&value).into()
     }
 }
 
-impl From<&BigInt> for FeltBigInt {
+impl From<&BigInt> for FeltBigInt<FIELD> {
     fn from(value: &BigInt) -> Self {
         Self(
             value
@@ -121,15 +121,17 @@ impl From<&BigInt> for FeltBigInt {
     }
 }
 
-impl NewFelt for FeltBigInt {
+impl NewFelt for FeltBigInt<FIELD> {
     fn new<T: Into<Self>>(value: T) -> Self {
         value.into()
     }
 }
 
-impl FeltOps for FeltBigInt {
-    fn modpow(&self, exponent: &FeltBigInt, modulus: &FeltBigInt) -> Self {
-        FeltBigInt(self.0.modpow(&exponent.0, &modulus.0))
+impl FeltOps for FeltBigInt<FIELD> {
+    fn modpow(&self, exponent: &FeltBigInt<FIELD>, modulus: &FeltBigInt<FIELD>) -> Self {
+        FeltBigInt {
+            val: self.val.modpow(&exponent.val, &modulus.val),
+        }
     }
 
     fn iter_u64_digits(&self) -> U64Digits {
@@ -181,7 +183,7 @@ impl FeltOps for FeltBigInt {
     }
 }
 
-impl Add for FeltBigInt {
+impl Add for FeltBigInt<FIELD> {
     type Output = Self;
     fn add(mut self, rhs: Self) -> Self {
         self.0 += rhs.0;
@@ -192,7 +194,7 @@ impl Add for FeltBigInt {
     }
 }
 
-impl<'a> Add for &'a FeltBigInt {
+impl<'a> Add for &'a FeltBigInt<FIELD> {
     type Output = FeltBigInt;
 
     fn add(self, rhs: Self) -> Self::Output {
@@ -204,7 +206,7 @@ impl<'a> Add for &'a FeltBigInt {
     }
 }
 
-impl<'a> Add<&'a FeltBigInt> for FeltBigInt {
+impl<'a> Add<&'a FeltBigInt> for FeltBigInt<FIELD> {
     type Output = FeltBigInt;
 
     fn add(mut self, rhs: &'a FeltBigInt) -> Self::Output {
@@ -216,7 +218,7 @@ impl<'a> Add<&'a FeltBigInt> for FeltBigInt {
     }
 }
 
-impl Add<u32> for FeltBigInt {
+impl Add<u32> for FeltBigInt<FIELD> {
     type Output = Self;
     fn add(mut self, rhs: u32) -> Self {
         self.0 += rhs;
@@ -227,7 +229,7 @@ impl Add<u32> for FeltBigInt {
     }
 }
 
-impl Add<usize> for FeltBigInt {
+impl Add<usize> for FeltBigInt<FIELD> {
     type Output = Self;
     fn add(mut self, rhs: usize) -> Self {
         self.0 += rhs;
@@ -238,7 +240,7 @@ impl Add<usize> for FeltBigInt {
     }
 }
 
-impl<'a> Add<usize> for &'a FeltBigInt {
+impl<'a> Add<usize> for &'a FeltBigInt<FIELD> {
     type Output = FeltBigInt;
     fn add(self, rhs: usize) -> Self::Output {
         let mut sum = &self.0 + rhs;
@@ -249,19 +251,19 @@ impl<'a> Add<usize> for &'a FeltBigInt {
     }
 }
 
-impl AddAssign for FeltBigInt {
+impl AddAssign for FeltBigInt<FIELD> {
     fn add_assign(&mut self, rhs: Self) {
         *self = &*self + &rhs;
     }
 }
 
-impl<'a> AddAssign<&'a FeltBigInt> for FeltBigInt {
+impl<'a> AddAssign<&'a FeltBigInt> for FeltBigInt<FIELD> {
     fn add_assign(&mut self, rhs: &'a FeltBigInt) {
         *self = &*self + rhs;
     }
 }
 
-impl Sum for FeltBigInt {
+impl Sum for FeltBigInt<FIELD> {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(FeltBigInt::zero(), |mut acc, x| {
             acc += x;
@@ -270,7 +272,7 @@ impl Sum for FeltBigInt {
     }
 }
 
-impl Neg for FeltBigInt {
+impl Neg for FeltBigInt<FIELD> {
     type Output = FeltBigInt;
     fn neg(self) -> Self::Output {
         if self.is_zero() {
@@ -281,7 +283,7 @@ impl Neg for FeltBigInt {
     }
 }
 
-impl<'a> Neg for &'a FeltBigInt {
+impl<'a> Neg for &'a FeltBigInt<FIELD> {
     type Output = FeltBigInt;
     fn neg(self) -> Self::Output {
         if self.is_zero() {
@@ -292,7 +294,7 @@ impl<'a> Neg for &'a FeltBigInt {
     }
 }
 
-impl Sub for FeltBigInt {
+impl Sub for FeltBigInt<FIELD> {
     type Output = Self;
     fn sub(mut self, rhs: Self) -> Self::Output {
         if self.0 < rhs.0 {
@@ -303,7 +305,7 @@ impl Sub for FeltBigInt {
     }
 }
 
-impl<'a> Sub<&'a FeltBigInt> for FeltBigInt {
+impl<'a> Sub<&'a FeltBigInt> for FeltBigInt<FIELD> {
     type Output = FeltBigInt;
     fn sub(mut self, rhs: &'a FeltBigInt) -> Self::Output {
         if self.0 < rhs.0 {
@@ -314,7 +316,7 @@ impl<'a> Sub<&'a FeltBigInt> for FeltBigInt {
     }
 }
 
-impl<'a> Sub for &'a FeltBigInt {
+impl<'a> Sub for &'a FeltBigInt<FIELD> {
     type Output = FeltBigInt;
     fn sub(self, rhs: Self) -> Self::Output {
         FeltBigInt(if self.0 < rhs.0 {
@@ -325,7 +327,7 @@ impl<'a> Sub for &'a FeltBigInt {
     }
 }
 
-impl Sub<u32> for FeltBigInt {
+impl Sub<u32> for FeltBigInt<FIELD> {
     type Output = FeltBigInt;
     fn sub(self, rhs: u32) -> Self {
         match (self.0).to_u32() {
@@ -335,7 +337,7 @@ impl Sub<u32> for FeltBigInt {
     }
 }
 
-impl<'a> Sub<u32> for &'a FeltBigInt {
+impl<'a> Sub<u32> for &'a FeltBigInt<FIELD> {
     type Output = FeltBigInt;
     fn sub(self, rhs: u32) -> Self::Output {
         match (self.0).to_u32() {
@@ -345,7 +347,7 @@ impl<'a> Sub<u32> for &'a FeltBigInt {
     }
 }
 
-impl Sub<usize> for FeltBigInt {
+impl Sub<usize> for FeltBigInt<FIELD> {
     type Output = FeltBigInt;
     fn sub(self, rhs: usize) -> Self {
         match (self.0).to_usize() {
@@ -355,13 +357,13 @@ impl Sub<usize> for FeltBigInt {
     }
 }
 
-impl SubAssign for FeltBigInt {
+impl SubAssign for FeltBigInt<FIELD> {
     fn sub_assign(&mut self, rhs: Self) {
         *self = &*self - &rhs;
     }
 }
 
-impl<'a> SubAssign<&'a FeltBigInt> for FeltBigInt {
+impl<'a> SubAssign<&'a FeltBigInt> for FeltBigInt<FIELD> {
     fn sub_assign(&mut self, rhs: &'a FeltBigInt) {
         *self = &*self - rhs;
     }
@@ -390,41 +392,41 @@ impl Sub<&FeltBigInt> for usize {
     }
 }
 
-impl Mul for FeltBigInt {
+impl Mul for FeltBigInt<FIELD> {
     type Output = Self;
     fn mul(self, rhs: Self) -> Self::Output {
         FeltBigInt((self.0 * rhs.0).mod_floor(&CAIRO_PRIME))
     }
 }
 
-impl<'a> Mul for &'a FeltBigInt {
+impl<'a> Mul for &'a FeltBigInt<FIELD> {
     type Output = FeltBigInt;
     fn mul(self, rhs: Self) -> Self::Output {
         FeltBigInt((&self.0 * &rhs.0).mod_floor(&CAIRO_PRIME))
     }
 }
 
-impl<'a> Mul<&'a FeltBigInt> for FeltBigInt {
+impl<'a> Mul<&'a FeltBigInt> for FeltBigInt<FIELD> {
     type Output = FeltBigInt;
     fn mul(self, rhs: &'a FeltBigInt) -> Self::Output {
         FeltBigInt((&self.0 * &rhs.0).mod_floor(&CAIRO_PRIME))
     }
 }
 
-impl<'a> MulAssign<&'a FeltBigInt> for FeltBigInt {
+impl<'a> MulAssign<&'a FeltBigInt> for FeltBigInt<FIELD> {
     fn mul_assign(&mut self, rhs: &'a FeltBigInt) {
         *self = &*self * rhs;
     }
 }
 
-impl Pow<u32> for FeltBigInt {
+impl Pow<u32> for FeltBigInt<FIELD> {
     type Output = Self;
     fn pow(self, rhs: u32) -> Self {
         FeltBigInt(self.0.pow(rhs).mod_floor(&CAIRO_PRIME))
     }
 }
 
-impl<'a> Pow<u32> for &'a FeltBigInt {
+impl<'a> Pow<u32> for &'a FeltBigInt<FIELD> {
     type Output = FeltBigInt;
     #[allow(clippy::needless_borrow)] // the borrow of self.0 is necessary becase it's of the type BigUInt, which doesn't implement the Copy trait
     fn pow(self, rhs: u32) -> Self::Output {
@@ -432,7 +434,7 @@ impl<'a> Pow<u32> for &'a FeltBigInt {
     }
 }
 
-impl Div for FeltBigInt {
+impl Div for FeltBigInt<FIELD> {
     type Output = Self;
     // In Felts `x / y` needs to be expressed as `x * y^-1`
     #[allow(clippy::suspicious_arithmetic_impl)]
@@ -447,7 +449,7 @@ impl Div for FeltBigInt {
     }
 }
 
-impl<'a> Div for &'a FeltBigInt {
+impl<'a> Div for &'a FeltBigInt<FIELD> {
     type Output = FeltBigInt;
     // In Felts `x / y` needs to be expressed as `x * y^-1`
     #[allow(clippy::suspicious_arithmetic_impl)]
@@ -462,7 +464,7 @@ impl<'a> Div for &'a FeltBigInt {
     }
 }
 
-impl<'a> Div<FeltBigInt> for &'a FeltBigInt {
+impl<'a> Div<FeltBigInt> for &'a FeltBigInt<FIELD> {
     type Output = FeltBigInt;
     // In Felts `x / y` needs to be expressed as `x * y^-1`
     #[allow(clippy::suspicious_arithmetic_impl)]
@@ -477,21 +479,21 @@ impl<'a> Div<FeltBigInt> for &'a FeltBigInt {
     }
 }
 
-impl Rem for FeltBigInt {
+impl Rem for FeltBigInt<FIELD> {
     type Output = Self;
     fn rem(self, rhs: Self) -> Self {
         FeltBigInt(self.0 % rhs.0)
     }
 }
 
-impl<'a> Rem<&'a FeltBigInt> for FeltBigInt {
+impl<'a> Rem<&'a FeltBigInt<FIELD>> for FeltBigInt<FIELD> {
     type Output = Self;
     fn rem(self, rhs: &'a FeltBigInt) -> Self::Output {
         FeltBigInt(self.0 % &rhs.0)
     }
 }
 
-impl Zero for FeltBigInt {
+impl Zero for FeltBigInt<FIELD> {
     fn zero() -> Self {
         Self(BigUint::zero())
     }
@@ -501,7 +503,7 @@ impl Zero for FeltBigInt {
     }
 }
 
-impl One for FeltBigInt {
+impl One for FeltBigInt<FIELD> {
     fn one() -> Self {
         Self(BigUint::one())
     }
@@ -514,7 +516,7 @@ impl One for FeltBigInt {
     }
 }
 
-impl Bounded for FeltBigInt {
+impl Bounded for FeltBigInt<FIELD> {
     fn min_value() -> Self {
         Self::zero()
     }
@@ -523,7 +525,7 @@ impl Bounded for FeltBigInt {
     }
 }
 
-impl Num for FeltBigInt {
+impl Num for FeltBigInt<FIELD> {
     type FromStrRadixErr = ParseFeltError;
     fn from_str_radix(string: &str, radix: u32) -> Result<Self, Self::FromStrRadixErr> {
         match BigUint::from_str_radix(string, radix) {
@@ -533,7 +535,7 @@ impl Num for FeltBigInt {
     }
 }
 
-impl Integer for FeltBigInt {
+impl Integer for FeltBigInt<FIELD> {
     fn div_floor(&self, other: &Self) -> Self {
         FeltBigInt(self.0.div_floor(&other.0))
     }
@@ -571,7 +573,7 @@ impl Integer for FeltBigInt {
     }
 }
 
-impl Signed for FeltBigInt {
+impl Signed for FeltBigInt<FIELD> {
     fn abs(&self) -> Self {
         if self.is_negative() {
             self.neg()
@@ -607,95 +609,98 @@ impl Signed for FeltBigInt {
     }
 }
 
-impl Shl<u32> for FeltBigInt {
+impl Shl<u32> for FeltBigInt<FIELD> {
     type Output = Self;
     fn shl(self, other: u32) -> Self::Output {
         FeltBigInt((self.0).shl(other).mod_floor(&CAIRO_PRIME))
     }
 }
 
-impl<'a> Shl<u32> for &'a FeltBigInt {
-    type Output = FeltBigInt;
+impl<'a> Shl<u32> for &'a FeltBigInt<FIELD> {
+    type Output = FeltBigInt<FIELD>;
     fn shl(self, other: u32) -> Self::Output {
         FeltBigInt((&self.0).shl(other).mod_floor(&CAIRO_PRIME))
     }
 }
 
-impl Shl<usize> for FeltBigInt {
+impl Shl<usize> for FeltBigInt<FIELD> {
     type Output = Self;
     fn shl(self, other: usize) -> Self::Output {
         FeltBigInt((self.0).shl(other).mod_floor(&CAIRO_PRIME))
     }
 }
 
-impl<'a> Shl<usize> for &'a FeltBigInt {
-    type Output = FeltBigInt;
+impl<'a> Shl<usize> for &'a FeltBigInt<FIELD> {
+    type Output = FeltBigInt<FIELD>;
     fn shl(self, other: usize) -> Self::Output {
         FeltBigInt((&self.0).shl(other).mod_floor(&CAIRO_PRIME))
     }
 }
 
-impl Shr<u32> for FeltBigInt {
+impl Shr<u32> for FeltBigInt<FIELD> {
     type Output = Self;
     fn shr(self, other: u32) -> Self::Output {
         FeltBigInt(self.0.shr(other).mod_floor(&CAIRO_PRIME))
     }
 }
 
-impl<'a> Shr<u32> for &'a FeltBigInt {
-    type Output = FeltBigInt;
+impl<'a> Shr<u32> for &'a FeltBigInt<FIELD> {
+    type Output = FeltBigInt<FIELD>;
     fn shr(self, other: u32) -> Self::Output {
         FeltBigInt((&self.0).shr(other).mod_floor(&CAIRO_PRIME))
     }
 }
 
-impl ShrAssign<usize> for FeltBigInt {
+impl ShrAssign<usize> for FeltBigInt<FIELD> {
     fn shr_assign(&mut self, other: usize) {
         self.0 = (&self.0).shr(other).mod_floor(&CAIRO_PRIME);
     }
 }
 
-impl<'a> BitAnd for &'a FeltBigInt {
-    type Output = FeltBigInt;
+impl<'a> BitAnd for &'a FeltBigInt<FIELD> {
+    type Output = FeltBigInt<FIELD>;
     fn bitand(self, rhs: Self) -> Self::Output {
         FeltBigInt(&self.0 & &rhs.0)
     }
 }
 
-impl<'a> BitAnd<&'a FeltBigInt> for FeltBigInt {
+impl<'a> BitAnd<&'a FeltBigInt> for FeltBigInt<FIELD> {
     type Output = Self;
     fn bitand(self, rhs: &'a FeltBigInt) -> Self::Output {
         FeltBigInt(self.0 & &rhs.0)
     }
 }
 
-impl<'a> BitAnd<FeltBigInt> for &'a FeltBigInt {
-    type Output = FeltBigInt;
+impl<'a> BitAnd<FeltBigInt> for &'a FeltBigInt<FIELD> {
+    type Output = FeltBigInt<FIELD>;
     fn bitand(self, rhs: Self::Output) -> Self::Output {
         FeltBigInt(&self.0 & rhs.0)
     }
 }
 
-impl<'a> BitOr for &'a FeltBigInt {
-    type Output = FeltBigInt;
+impl<'a> BitOr for &'a FeltBigInt<FIELD> {
+    type Output = FeltBigInt<FIELD>;
     fn bitor(self, rhs: Self) -> Self::Output {
         FeltBigInt(&self.0 | &rhs.0)
     }
 }
 
-impl<'a> BitXor for &'a FeltBigInt {
-    type Output = FeltBigInt;
+impl<'a> BitXor for &'a FeltBigInt<FIELD> {
+    type Output = FeltBigInt<FIELD>;
     fn bitxor(self, rhs: Self) -> Self::Output {
         FeltBigInt(&self.0 ^ &rhs.0)
     }
 }
 
-pub fn div_rem(x: &FeltBigInt, y: &FeltBigInt) -> (FeltBigInt, FeltBigInt) {
+pub fn div_rem(
+    x: &FeltBigInt<FIELD>,
+    y: &FeltBigInt<FIELD>,
+) -> (FeltBigInt<FIELD>, FeltBigInt<FIELD>) {
     let (d, m) = x.0.div_mod_floor(&y.0);
     (FeltBigInt(d), FeltBigInt(m))
 }
 
-impl ToPrimitive for FeltBigInt {
+impl ToPrimitive for FeltBigInt<FIELD> {
     fn to_u64(&self) -> Option<u64> {
         self.0.to_u64()
     }
@@ -709,7 +714,7 @@ impl ToPrimitive for FeltBigInt {
     }
 }
 
-impl FromPrimitive for FeltBigInt {
+impl FromPrimitive for FeltBigInt<FIELD> {
     fn from_u64(n: u64) -> Option<Self> {
         BigUint::from_u64(n).map(Self)
     }
@@ -723,13 +728,13 @@ impl FromPrimitive for FeltBigInt {
     }
 }
 
-impl fmt::Display for FeltBigInt {
+impl fmt::Display for FeltBigInt<FIELD> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
-impl fmt::Debug for FeltBigInt {
+impl fmt::Debug for FeltBigInt<FIELD> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }

--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -73,6 +73,10 @@ impl<const PH: u128, const PL: u128> From<BigUint> for FeltBigInt<PH, PL> {
             Self {
                 val: value.mod_floor(&CAIRO_PRIME),
             }
+        } else if value == *CAIRO_PRIME {
+            Self {
+                val: BigUint::zero(),
+            }
         } else {
             Self { val: value }
         }
@@ -84,6 +88,10 @@ impl<const PH: u128, const PL: u128> From<&BigUint> for FeltBigInt<PH, PL> {
         if value > &*CAIRO_PRIME {
             Self {
                 val: value.mod_floor(&CAIRO_PRIME),
+            }
+        } else if value == &*CAIRO_PRIME {
+            Self {
+                val: BigUint::zero(),
             }
         } else {
             Self { val: value.clone() }

--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -124,12 +124,18 @@ impl<const PH: u128, const PL: u128> From<&BigInt> for FeltBigInt<PH, PL> {
     }
 }
 
-impl<const PH: u128, const PL: u128> FeltOps<PH, PL> for FeltBigInt<PH, PL> {
-    fn new<T: Into<Self>>(value: T) -> Self {
+impl FeltOps for FeltBigInt<FIELD_HIGH, FIELD_LOW> {
+    fn new<T: Into<FeltBigInt<FIELD_HIGH, FIELD_LOW>>>(
+        value: T,
+    ) -> FeltBigInt<FIELD_HIGH, FIELD_LOW> {
         value.into()
     }
 
-    fn modpow(&self, exponent: &FeltBigInt<PH, PL>, modulus: &FeltBigInt<PH, PL>) -> Self {
+    fn modpow(
+        &self,
+        exponent: &FeltBigInt<FIELD_HIGH, FIELD_LOW>,
+        modulus: &FeltBigInt<FIELD_HIGH, FIELD_LOW>,
+    ) -> Self {
         FeltBigInt {
             val: self.val.modpow(&exponent.val, &modulus.val),
         }
@@ -148,7 +154,6 @@ impl<const PH: u128, const PL: u128> FeltOps<PH, PL> for FeltBigInt<PH, PL> {
     }
 
     fn parse_bytes(buf: &[u8], radix: u32) -> Option<Self> {
-        //BigUint::parse_bytes(buf, radix).map(FeltBigInt::new)
         match BigUint::parse_bytes(buf, radix) {
             Some(parsed) => Some(FeltBigInt::new(parsed)),
             None => BigInt::parse_bytes(buf, radix).map(FeltBigInt::new),

--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -598,7 +598,7 @@ impl Integer for FeltBigInt<FIELD_HIGH, FIELD_LOW> {
     }
 
     fn divides(&self, other: &Self) -> bool {
-        self.val.divides(&other.val)
+        self.val.is_multiple_of(&other.val)
     }
 
     fn gcd(&self, other: &Self) -> Self {

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -136,10 +136,29 @@ impl Add for Felt {
     }
 }
 
-macro_rules! assert_felt_impl {
+impl<'a> Add for &'a Felt {
+    type Output = Felt;
+    fn add(self, other: Self) -> Self::Output {
+        Self::Output {
+            value: self.value + other.value,
+        }
+    }
+}
+
+macro_rules! assert_felt_methods {
     ($type:ty) => {
         const _: () = {
             fn assert_felt_ops<T: FeltOps<FIELD_HIGH, FIELD_LOW>>() {}
+            {
+                assert_felt_ops::<$type>();
+            }
+        };
+    };
+}
+
+macro_rules! assert_felt_impl {
+    ($type:ty) => {
+        const _: () = {
             fn assert_add<T: Add>() {}
             fn assert_add_ref<'a, T: Add<&'a $type>>() {}
             fn assert_add_u32<T: Add<u32>>() {}
@@ -183,10 +202,8 @@ macro_rules! assert_felt_impl {
             fn assert_display<T: Display>() {}
             fn assert_debug<T: Debug>() {}
 
-            // RFC 2056
             #[allow(dead_code)]
             fn assert_all() {
-                assert_felt_ops::<$type>();
                 assert_add::<$type>();
                 assert_add::<&$type>();
                 assert_add_ref::<$type>();
@@ -244,7 +261,9 @@ macro_rules! assert_felt_impl {
     };
 }
 
+assert_felt_methods!(FeltBigInt<FIELD_HIGH, FIELD_LOW>);
 assert_felt_impl!(FeltBigInt<FIELD_HIGH, FIELD_LOW>);
+assert_felt_impl!(Felt);
 
 #[cfg(test)]
 mod test {

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -14,10 +14,10 @@ use std::{
     },
 };
 
-pub type Felt = FeltBigInt;
-
 pub const PRIME_STR: &str = "0x800000000000011000000000000000000000000000000000000000000000001";
 pub const FIELD: (u128, u128) = ((1 << 123) + (17 << 64), 1);
+
+pub type Felt = FeltBigInt<FIELD>;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ParseFeltError;

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -886,10 +886,9 @@ mod test {
         fn shift_right_assign_in_range(ref value in "(0|[1-9][0-9]*)", ref shift_amount in "[0-9]{1,3}"){
             let mut value = Felt::parse_bytes(value.as_bytes(), 10).unwrap();
             let shift_amount:usize = shift_amount.parse::<usize>().unwrap();
-            let p = Felt::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
+            let p = BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
             value >>= shift_amount;
-            value.to_biguint();
-            prop_assert!(value < p);
+            prop_assert!(value.to_biguint() < p);
         }
 
         #[test]
@@ -897,10 +896,10 @@ mod test {
         fn bitand_in_range(ref x in "(0|[1-9][0-9]*)", ref y in "(0|[1-9][0-9]*)"){
             let x = Felt::parse_bytes(x.as_bytes(), 10).unwrap();
             let y = Felt::parse_bytes(y.as_bytes(), 10).unwrap();
-            let p = Felt::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
+            let p = BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
             let result = &x & &y;
             result.to_biguint();
-            prop_assert!(result < p);
+            prop_assert!(result.to_biguint() < p);
         }
 
         #[test]
@@ -908,11 +907,9 @@ mod test {
         fn bitor_in_range(ref x in "(0|[1-9][0-9]*)", ref y in "(0|[1-9][0-9]*)"){
             let x = Felt::parse_bytes(x.as_bytes(), 10).unwrap();
             let y = Felt::parse_bytes(y.as_bytes(), 10).unwrap();
-            let p = Felt::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
+            let p = BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
             let result = &x | &y;
-            println!("x: {}, y: {}, result: {}", x, y, result);
-            result.to_biguint();
-            prop_assert!(result < p);
+            prop_assert!(result.to_biguint() < p);
         }
 
         #[test]
@@ -920,11 +917,9 @@ mod test {
         fn bitxor_in_range(ref x in "(0|[1-9][0-9]*)", ref y in "(0|[1-9][0-9]*)"){
             let x = Felt::parse_bytes(x.as_bytes(), 10).unwrap();
             let y = Felt::parse_bytes(y.as_bytes(), 10).unwrap();
-            let p = Felt::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
+            let p = BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
             let result = &x ^ &y;
-            println!("x: {}, y: {}, result: {}", x, y, result);
-            result.to_biguint();
-            prop_assert!(result < p);
+            prop_assert!(result.to_biguint() < p);
         }
 
         #[test]

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -20,9 +20,7 @@ pub const FIELD_HIGH: u128 = (1 << 123) + (17 << 64);
 pub const FIELD_LOW: u128 = 1;
 
 pub(crate) trait FeltOps {
-    fn new<T: Into<FeltBigInt<FIELD_HIGH, FIELD_LOW>>>(
-        value: T,
-    ) -> FeltBigInt<FIELD_HIGH, FIELD_LOW>;
+    fn new<T: Into<FeltBigInt<FIELD_HIGH, FIELD_LOW>>>(value: T) -> Self;
     fn modpow(
         &self,
         exponent: &FeltBigInt<FIELD_HIGH, FIELD_LOW>,

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -933,5 +933,24 @@ mod test {
             let as_uint = &result.to_biguint();
             prop_assert!(as_uint < p, "{}", as_uint);
         }
+
+        #[test]
+        // Property test to check that lcm(x, y) works. Since we're operating in a prime field, lcm
+        // will just be the smaller number.
+        fn lcm_doesnt_panic(ref x in "(0|[1-9][0-9]*)", ref y in "(0|[1-9][0-9]*)") {
+            let x = Felt::parse_bytes(x.as_bytes(), 10).unwrap();
+            let y = Felt::parse_bytes(y.as_bytes(), 10).unwrap();
+            let lcm = x.lcm(&y);
+            prop_assert!(lcm == std::cmp::max(x, y))
+        }
+
+        #[test]
+        // Property test to check that is_multiple_of(x, y) works. Since we're operating in a prime field, is_multiple_of
+        // will always be true
+        fn is_multiple_of_doesnt_panic(ref x in "(0|[1-9][0-9]*)", ref y in "(0|[1-9][0-9]*)") {
+            let x = Felt::parse_bytes(x.as_bytes(), 10).unwrap();
+            let y = Felt::parse_bytes(y.as_bytes(), 10).unwrap();
+            assert!(x.is_multiple_of(&y));
+        }
     }
 }

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -19,13 +19,19 @@ pub const PRIME_STR: &str = "0x8000000000000110000000000000000000000000000000000
 pub const FIELD_HIGH: u128 = (1 << 123) + (17 << 64);
 pub const FIELD_LOW: u128 = 1;
 
-pub(crate) trait FeltOps<const PH: u128, const PL: u128> {
-    fn new<T: Into<FeltBigInt<PH, PL>>>(value: T) -> Self;
-    fn modpow(&self, exponent: &FeltBigInt<PH, PL>, modulus: &FeltBigInt<PH, PL>) -> Self;
+pub(crate) trait FeltOps {
+    fn new<T: Into<FeltBigInt<FIELD_HIGH, FIELD_LOW>>>(
+        value: T,
+    ) -> FeltBigInt<FIELD_HIGH, FIELD_LOW>;
+    fn modpow(
+        &self,
+        exponent: &FeltBigInt<FIELD_HIGH, FIELD_LOW>,
+        modulus: &FeltBigInt<FIELD_HIGH, FIELD_LOW>,
+    ) -> Self;
     fn iter_u64_digits(&self) -> U64Digits;
     fn to_signed_bytes_le(&self) -> Vec<u8>;
     fn to_bytes_be(&self) -> Vec<u8>;
-    fn parse_bytes(buf: &[u8], radix: u32) -> Option<FeltBigInt<PH, PL>>;
+    fn parse_bytes(buf: &[u8], radix: u32) -> Option<FeltBigInt<FIELD_HIGH, FIELD_LOW>>;
     fn from_bytes_be(bytes: &[u8]) -> Self;
     fn to_str_radix(&self, radix: u32) -> String;
     fn to_bigint(&self) -> BigInt;
@@ -644,7 +650,7 @@ impl fmt::Debug for Felt {
 macro_rules! assert_felt_methods {
     ($type:ty) => {
         const _: () = {
-            fn assert_felt_ops<T: FeltOps<FIELD_HIGH, FIELD_LOW>>() {}
+            fn assert_felt_ops<T: FeltOps>() {}
             {
                 assert_felt_ops::<$type>();
             }

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -129,18 +129,120 @@ impl Felt {
 
 impl Add for Felt {
     type Output = Self;
-    fn add(self, other: Self) -> Self {
+    fn add(self, rhs: Self) -> Self {
         Self {
-            value: self.value + other.value,
+            value: self.value + rhs.value,
         }
     }
 }
 
 impl<'a> Add for &'a Felt {
     type Output = Felt;
-    fn add(self, other: Self) -> Self::Output {
+    fn add(self, rhs: Self) -> Self::Output {
         Self::Output {
-            value: self.value + other.value,
+            value: self.value + rhs.value,
+        }
+    }
+}
+
+impl<'a> Add<&'a Felt> for Felt {
+    type Output = Self;
+    fn add(self, rhs: &Self) -> Self::Output {
+        Self::Output {
+            value: self.value + rhs.value,
+        }
+    }
+}
+
+impl Add<u32> for Felt {
+    type Output = Self;
+    fn add(self, rhs: u32) -> Self {
+        Self {
+            value: self.value + rhs,
+        }
+    }
+}
+
+impl Add<usize> for Felt {
+    type Output = Self;
+    fn add(self, rhs: usize) -> Self {
+        Self {
+            value: self.value + rhs,
+        }
+    }
+}
+
+impl<'a> Add<usize> for &'a Felt {
+    type Output = Felt;
+    fn add(self, rhs: usize) -> Self::Output {
+        Self::Output {
+            value: self.value + rhs,
+        }
+    }
+}
+
+impl AddAssign for Felt {
+    fn add_assign(&mut self, rhs: Self) {
+        self.value += rhs.value;
+    }
+}
+
+impl<'a> AddAssign<&Felt> for Felt {
+    fn add_assign(&mut self, rhs: &Self) {
+        self.value += rhs.value;
+    }
+}
+
+impl Sum for Felt {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.fold(Felt::zero(), |mut acc, x| {
+            acc += x;
+            acc
+        })
+    }
+}
+
+impl Neg for Felt {
+    type Output = Self;
+    fn neg(self) -> Self {
+        Self {
+            value: self.value.neg(),
+        }
+    }
+}
+
+impl<'a> Neg for &Felt {
+    type Output = Felt;
+    fn neg(self) -> Self::Output {
+        Felt {
+            value: self.value.neg(),
+        }
+    }
+}
+
+impl Sub for Felt {
+    type Output = Self;
+    fn sub(self, rhs: Self) -> Self {
+        Self {
+            value: self.value - rhs.value,
+        }
+    }
+}
+
+impl<'a> Sub for &Felt {
+    type Output = Self;
+    fn sub(self, rhs: Self) -> Self {
+        &Felt {
+            value: self.value - rhs.value,
+        }
+    }
+}
+
+impl<'a> Sub<&Felt> for Felt {
+    type Output = Self;
+    fn sub(self, rhs: &Self) -> Self {
+        Self {
+            value: self.value - rhs.value,
         }
     }
 }
@@ -163,7 +265,6 @@ macro_rules! assert_felt_impl {
             fn assert_add_ref<'a, T: Add<&'a $type>>() {}
             fn assert_add_u32<T: Add<u32>>() {}
             fn assert_add_usize<T: Add<usize>>() {}
-            fn assert_add_ref_usize<T: Add<usize>>() {}
             fn assert_add_assign<T: AddAssign>() {}
             fn assert_add_assign_ref<'a, T: AddAssign<&'a $type>>() {}
             fn assert_sum<T: Sum<$type>>() {}
@@ -209,7 +310,7 @@ macro_rules! assert_felt_impl {
                 assert_add_ref::<$type>();
                 assert_add_u32::<$type>();
                 assert_add_usize::<$type>();
-                assert_add_ref_usize::<&$type>();
+                assert_add_usize::<&$type>();
                 assert_add_assign::<$type>();
                 assert_add_assign_ref::<$type>();
                 assert_sum::<$type>();

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -23,11 +23,8 @@ pub type Felt = FeltBigInt<FIELD_HIGH, FIELD_LOW>;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ParseFeltError;
 
-pub trait NewFelt<const PH: u128, const PL: u128> {
-    fn new<T: Into<FeltBigInt<PH, PL>>>(value: T) -> Self;
-}
-
 pub trait FeltOps<const PH: u128, const PL: u128> {
+    fn new<T: Into<FeltBigInt<PH, PL>>>(value: T) -> Self;
     fn modpow(&self, exponent: &FeltBigInt<PH, PL>, modulus: &FeltBigInt<PH, PL>) -> Self;
     fn iter_u64_digits(&self) -> U64Digits;
     fn to_signed_bytes_le(&self) -> Vec<u8>;
@@ -44,7 +41,6 @@ pub trait FeltOps<const PH: u128, const PL: u128> {
 macro_rules! assert_felt_impl {
     ($type:ty) => {
         const _: () = {
-            fn assert_new_felt<T: NewFelt<FIELD_HIGH, FIELD_LOW>>() {}
             fn assert_felt_ops<T: FeltOps<FIELD_HIGH, FIELD_LOW>>() {}
             fn assert_add<T: Add>() {}
             fn assert_add_ref<'a, T: Add<&'a $type>>() {}
@@ -92,7 +88,6 @@ macro_rules! assert_felt_impl {
             // RFC 2056
             #[allow(dead_code)]
             fn assert_all() {
-                assert_new_felt::<$type>();
                 assert_felt_ops::<$type>();
                 assert_add::<$type>();
                 assert_add::<&$type>();

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -15,23 +15,24 @@ use std::{
 };
 
 pub const PRIME_STR: &str = "0x800000000000011000000000000000000000000000000000000000000000001";
-pub const FIELD: (u128, u128) = ((1 << 123) + (17 << 64), 1);
+pub const FIELD_HIGH: u128 = (1 << 123) + (17 << 64);
+pub const FIELD_LOW: u128 = 1;
 
-pub type Felt = FeltBigInt<FIELD>;
+pub type Felt = FeltBigInt<FIELD_HIGH, FIELD_LOW>;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ParseFeltError;
 
-pub trait NewFelt {
-    fn new<T: Into<Felt>>(value: T) -> Self;
+pub trait NewFelt<const PH: u128, const PL: u128> {
+    fn new<T: Into<FeltBigInt<PH, PL>>>(value: T) -> Self;
 }
 
-pub trait FeltOps {
-    fn modpow(&self, exponent: &Felt, modulus: &Felt) -> Self;
+pub trait FeltOps<const PH: u128, const PL: u128> {
+    fn modpow(&self, exponent: &FeltBigInt<PH, PL>, modulus: &FeltBigInt<PH, PL>) -> Self;
     fn iter_u64_digits(&self) -> U64Digits;
     fn to_signed_bytes_le(&self) -> Vec<u8>;
     fn to_bytes_be(&self) -> Vec<u8>;
-    fn parse_bytes(buf: &[u8], radix: u32) -> Option<Felt>;
+    fn parse_bytes(buf: &[u8], radix: u32) -> Option<FeltBigInt<PH, PL>>;
     fn from_bytes_be(bytes: &[u8]) -> Self;
     fn to_str_radix(&self, radix: u32) -> String;
     fn to_bigint(&self) -> BigInt;
@@ -43,8 +44,8 @@ pub trait FeltOps {
 macro_rules! assert_felt_impl {
     ($type:ty) => {
         const _: () = {
-            fn assert_new_felt<T: NewFelt>() {}
-            fn assert_felt_ops<T: FeltOps>() {}
+            fn assert_new_felt<T: NewFelt<FIELD_HIGH, FIELD_LOW>>() {}
+            fn assert_felt_ops<T: FeltOps<FIELD_HIGH, FIELD_LOW>>() {}
             fn assert_add<T: Add>() {}
             fn assert_add_ref<'a, T: Add<&'a $type>>() {}
             fn assert_add_u32<T: Add<u32>>() {}

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -651,7 +651,7 @@ macro_rules! assert_felt_methods {
     ($type:ty) => {
         const _: () = {
             fn assert_felt_ops<T: FeltOps>() {}
-            {
+            fn assertion() {
                 assert_felt_ops::<$type>();
             }
         };

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -7,7 +7,7 @@ use num_traits::{Bounded, FromPrimitive, Num, One, Pow, Signed, ToPrimitive, Zer
 use serde::{Deserialize, Serialize};
 use std::{
     convert::Into,
-    fmt::{Debug, Display},
+    fmt,
     iter::Sum,
     ops::{
         Add, AddAssign, BitAnd, BitOr, BitXor, Div, Mul, MulAssign, Neg, Rem, Shl, Shr, ShrAssign,
@@ -140,7 +140,7 @@ impl<'a> Add for &'a Felt {
     type Output = Felt;
     fn add(self, rhs: Self) -> Self::Output {
         Self::Output {
-            value: self.value + rhs.value,
+            value: &self.value + &rhs.value,
         }
     }
 }
@@ -149,7 +149,7 @@ impl<'a> Add<&'a Felt> for Felt {
     type Output = Self;
     fn add(self, rhs: &Self) -> Self::Output {
         Self::Output {
-            value: self.value + rhs.value,
+            value: self.value + &rhs.value,
         }
     }
 }
@@ -176,7 +176,7 @@ impl<'a> Add<usize> for &'a Felt {
     type Output = Felt;
     fn add(self, rhs: usize) -> Self::Output {
         Self::Output {
-            value: self.value + rhs,
+            value: &self.value + rhs,
         }
     }
 }
@@ -187,9 +187,9 @@ impl AddAssign for Felt {
     }
 }
 
-impl<'a> AddAssign<&Felt> for Felt {
+impl<'a> AddAssign<&'a Felt> for Felt {
     fn add_assign(&mut self, rhs: &Self) {
-        self.value += rhs.value;
+        self.value += &rhs.value;
     }
 }
 
@@ -211,11 +211,11 @@ impl Neg for Felt {
     }
 }
 
-impl<'a> Neg for &Felt {
+impl<'a> Neg for &'a Felt {
     type Output = Felt;
     fn neg(self) -> Self::Output {
-        Felt {
-            value: self.value.neg(),
+        Self::Output {
+            value: (&self.value).neg(),
         }
     }
 }
@@ -229,21 +229,415 @@ impl Sub for Felt {
     }
 }
 
-impl<'a> Sub for &Felt {
-    type Output = Self;
-    fn sub(self, rhs: Self) -> Self {
-        &Felt {
-            value: self.value - rhs.value,
+impl<'a> Sub for &'a Felt {
+    type Output = Felt;
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self::Output {
+            value: &self.value - &rhs.value,
         }
     }
 }
 
-impl<'a> Sub<&Felt> for Felt {
+impl<'a> Sub<&'a Felt> for Felt {
     type Output = Self;
     fn sub(self, rhs: &Self) -> Self {
         Self {
-            value: self.value - rhs.value,
+            value: self.value - &rhs.value,
         }
+    }
+}
+
+impl SubAssign for Felt {
+    fn sub_assign(&mut self, rhs: Self) {
+        self.value -= rhs.value
+    }
+}
+
+impl<'a> SubAssign<&'a Felt> for Felt {
+    fn sub_assign(&mut self, rhs: &Self) {
+        self.value -= &rhs.value;
+    }
+}
+
+impl Sub<u32> for Felt {
+    type Output = Self;
+    fn sub(self, rhs: u32) -> Self {
+        Self {
+            value: self.value - rhs,
+        }
+    }
+}
+
+impl<'a> Sub<u32> for &'a Felt {
+    type Output = Felt;
+    fn sub(self, rhs: u32) -> Self::Output {
+        Self::Output {
+            value: &self.value - rhs,
+        }
+    }
+}
+
+impl Sub<usize> for Felt {
+    type Output = Self;
+    fn sub(self, rhs: usize) -> Self {
+        Self {
+            value: self.value - rhs,
+        }
+    }
+}
+
+impl Mul for Felt {
+    type Output = Self;
+    fn mul(self, rhs: Self) -> Self {
+        Self {
+            value: self.value * rhs.value,
+        }
+    }
+}
+
+impl<'a> Mul for &'a Felt {
+    type Output = Felt;
+    fn mul(self, rhs: Self) -> Self::Output {
+        Self::Output {
+            value: &self.value * &rhs.value,
+        }
+    }
+}
+
+impl<'a> Mul<&'a Felt> for Felt {
+    type Output = Self;
+    fn mul(self, rhs: &Self) -> Self {
+        Self {
+            value: self.value * &rhs.value,
+        }
+    }
+}
+
+impl<'a> MulAssign<&'a Felt> for Felt {
+    fn mul_assign(&mut self, rhs: &Self) {
+        self.value *= &rhs.value;
+    }
+}
+
+impl Pow<u32> for Felt {
+    type Output = Self;
+    fn pow(self, rhs: u32) -> Self {
+        Self {
+            value: self.value.pow(rhs),
+        }
+    }
+}
+
+impl<'a> Pow<u32> for &'a Felt {
+    type Output = Felt;
+    fn pow(self, rhs: u32) -> Self::Output {
+        Self::Output {
+            value: (&self.value).pow(rhs),
+        }
+    }
+}
+
+impl Div for Felt {
+    type Output = Self;
+    fn div(self, rhs: Self) -> Self {
+        Self {
+            value: self.value / rhs.value,
+        }
+    }
+}
+
+impl<'a> Div for &'a Felt {
+    type Output = Felt;
+    fn div(self, rhs: Self) -> Self::Output {
+        Self::Output {
+            value: &self.value / &rhs.value,
+        }
+    }
+}
+
+impl<'a> Div<Felt> for &'a Felt {
+    type Output = Felt;
+    fn div(self, rhs: Self::Output) -> Self::Output {
+        Self::Output {
+            value: &self.value / rhs.value,
+        }
+    }
+}
+
+impl Rem for Felt {
+    type Output = Self;
+    fn rem(self, rhs: Self) -> Self {
+        Self {
+            value: self.value % rhs.value,
+        }
+    }
+}
+
+impl<'a> Rem<&'a Felt> for Felt {
+    type Output = Self;
+    fn rem(self, rhs: &Self) -> Self {
+        Self {
+            value: self.value % &rhs.value,
+        }
+    }
+}
+
+impl Zero for Felt {
+    fn zero() -> Self {
+        Self {
+            value: FeltBigInt::zero(),
+        }
+    }
+
+    fn is_zero(&self) -> bool {
+        self.value.is_zero()
+    }
+}
+
+impl One for Felt {
+    fn one() -> Self {
+        Self {
+            value: FeltBigInt::one(),
+        }
+    }
+
+    fn is_one(&self) -> bool {
+        self.value.is_one()
+    }
+}
+
+impl Bounded for Felt {
+    fn min_value() -> Self {
+        Self {
+            value: FeltBigInt::min_value(),
+        }
+    }
+
+    fn max_value() -> Self {
+        Self {
+            value: FeltBigInt::max_value(),
+        }
+    }
+}
+
+impl Num for Felt {
+    type FromStrRadixErr = ParseFeltError;
+    fn from_str_radix(string: &str, radix: u32) -> Result<Self, Self::FromStrRadixErr> {
+        Ok(Self {
+            value: FeltBigInt::from_str_radix(string, radix)?,
+        })
+    }
+}
+
+impl Integer for Felt {
+    fn div_floor(&self, rhs: &Self) -> Self {
+        Self {
+            value: self.value.div_floor(&rhs.value),
+        }
+    }
+
+    fn div_rem(&self, other: &Self) -> (Self, Self) {
+        let (div, rem) = self.value.div_rem(&other.value);
+        (Self { value: div }, Self { value: rem })
+    }
+
+    fn divides(&self, other: &Self) -> bool {
+        self.value.divides(&other.value)
+    }
+
+    fn gcd(&self, other: &Self) -> Self {
+        Self {
+            value: self.value.gcd(&other.value),
+        }
+    }
+
+    fn is_even(&self) -> bool {
+        self.value.is_even()
+    }
+
+    fn is_multiple_of(&self, other: &Self) -> bool {
+        self.value.is_multiple_of(&other.value)
+    }
+
+    fn is_odd(&self) -> bool {
+        self.value.is_odd()
+    }
+
+    fn lcm(&self, other: &Self) -> Self {
+        Self {
+            value: self.value.lcm(&other.value),
+        }
+    }
+
+    fn mod_floor(&self, rhs: &Self) -> Self {
+        Self {
+            value: self.value.mod_floor(&rhs.value),
+        }
+    }
+}
+
+impl Signed for Felt {
+    fn abs(&self) -> Self {
+        Self {
+            value: self.value.abs(),
+        }
+    }
+
+    fn abs_sub(&self, other: &Self) -> Self {
+        Self {
+            value: self.value.abs_sub(&other.value),
+        }
+    }
+
+    fn signum(&self) -> Self {
+        Self {
+            value: self.value.signum(),
+        }
+    }
+
+    fn is_positive(&self) -> bool {
+        self.value.is_positive()
+    }
+
+    fn is_negative(&self) -> bool {
+        self.value.is_negative()
+    }
+}
+
+impl Shl<u32> for Felt {
+    type Output = Self;
+    fn shl(self, rhs: u32) -> Self {
+        Self {
+            value: self.value << rhs,
+        }
+    }
+}
+
+impl<'a> Shl<u32> for &'a Felt {
+    type Output = Felt;
+    fn shl(self, rhs: u32) -> Self::Output {
+        Self::Output {
+            value: &self.value << rhs,
+        }
+    }
+}
+
+impl Shl<usize> for Felt {
+    type Output = Self;
+    fn shl(self, rhs: usize) -> Self {
+        Self {
+            value: self.value << rhs,
+        }
+    }
+}
+
+impl<'a> Shl<usize> for &'a Felt {
+    type Output = Felt;
+    fn shl(self, rhs: usize) -> Self::Output {
+        Self::Output {
+            value: &self.value << rhs,
+        }
+    }
+}
+
+impl Shr<u32> for Felt {
+    type Output = Self;
+    fn shr(self, rhs: u32) -> Self {
+        Self {
+            value: self.value >> rhs,
+        }
+    }
+}
+
+impl<'a> Shr<u32> for &'a Felt {
+    type Output = Felt;
+    fn shr(self, rhs: u32) -> Self::Output {
+        Self::Output {
+            value: &self.value >> rhs,
+        }
+    }
+}
+
+impl ShrAssign<usize> for Felt {
+    fn shr_assign(&mut self, rhs: usize) {
+        self.value >>= rhs
+    }
+}
+
+impl<'a> BitAnd for &'a Felt {
+    type Output = Felt;
+    fn bitand(self, rhs: Self) -> Self::Output {
+        Self::Output {
+            value: &self.value & &rhs.value,
+        }
+    }
+}
+
+impl<'a> BitAnd<&'a Felt> for Felt {
+    type Output = Self;
+    fn bitand(self, rhs: &Self) -> Self {
+        Self {
+            value: self.value & &rhs.value,
+        }
+    }
+}
+
+impl<'a> BitAnd<Felt> for &'a Felt {
+    type Output = Felt;
+    fn bitand(self, rhs: Self::Output) -> Self::Output {
+        Self::Output {
+            value: &self.value & rhs.value,
+        }
+    }
+}
+
+impl<'a> BitOr for &'a Felt {
+    type Output = Felt;
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self::Output {
+            value: &self.value | &rhs.value,
+        }
+    }
+}
+
+impl<'a> BitXor for &'a Felt {
+    type Output = Felt;
+    fn bitxor(self, rhs: Self) -> Self::Output {
+        Self::Output {
+            value: &self.value ^ &rhs.value,
+        }
+    }
+}
+
+impl ToPrimitive for Felt {
+    fn to_u64(&self) -> Option<u64> {
+        self.value.to_u64()
+    }
+
+    fn to_i64(&self) -> Option<i64> {
+        self.value.to_i64()
+    }
+}
+
+impl FromPrimitive for Felt {
+    fn from_u64(n: u64) -> Option<Self> {
+        FeltBigInt::from_u64(n).map(|n| Self { value: n })
+    }
+
+    fn from_i64(n: i64) -> Option<Self> {
+        FeltBigInt::from_i64(n).map(|n| Self { value: n })
+    }
+}
+
+impl fmt::Display for Felt {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.value)
+    }
+}
+
+impl fmt::Debug for Felt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.value)
     }
 }
 
@@ -293,15 +687,15 @@ macro_rules! assert_felt_impl {
             fn assert_shl_usize<T: Shl<usize>>() {}
             fn assert_shr_u32<T: Shr<u32>>() {}
             fn assert_shr_assign_usize<T: ShrAssign<usize>>() {}
-            fn assert_bitand_ref<T: BitAnd>() {}
-            fn assert_bitand<'a, T: BitAnd<&'a $type>>() {}
+            fn assert_bitand<T: BitAnd>() {}
+            fn assert_bitand_ref<'a, T: BitAnd<&'a $type>>() {}
             fn assert_ref_bitand<T: BitAnd<$type>>() {}
             fn assert_bitor<T: BitOr>() {}
             fn assert_bitxor<T: BitXor>() {}
             fn assert_from_primitive<T: FromPrimitive>() {}
             fn assert_to_primitive<T: ToPrimitive>() {}
-            fn assert_display<T: Display>() {}
-            fn assert_debug<T: Debug>() {}
+            fn assert_display<T: fmt::Display>() {}
+            fn assert_debug<T: fmt::Debug>() {}
 
             #[allow(dead_code)]
             fn assert_all() {
@@ -348,8 +742,8 @@ macro_rules! assert_felt_impl {
                 assert_shr_u32::<$type>();
                 assert_shr_u32::<&$type>();
                 assert_shr_assign_usize::<$type>();
-                assert_bitand_ref::<&$type>();
-                assert_bitand::<$type>();
+                assert_bitand::<&$type>();
+                assert_bitand_ref::<$type>();
                 assert_ref_bitand::<&$type>();
                 assert_bitor::<&$type>();
                 assert_bitxor::<&$type>();
@@ -467,7 +861,7 @@ mod test {
         // "With assignment" means that the result of the operation is autommatically assigned to the variable value, replacing its previous content.
         fn shift_right_assign_in_range(ref value in "(0|[1-9][0-9]*)", ref shift_amount in "[0-9]{1,3}"){
             let mut value = Felt::parse_bytes(value.as_bytes(), 10).unwrap();
-            let p = FeltBigInt::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
+            let p = Felt::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
             let shift_amount:usize = shift_amount.parse::<usize>().unwrap();
             value >>= shift_amount;
             value.to_biguint();
@@ -479,7 +873,7 @@ mod test {
         fn bitand_in_range(ref x in "(0|[1-9][0-9]*)", ref y in "(0|[1-9][0-9]*)"){
             let x = Felt::parse_bytes(x.as_bytes(), 10).unwrap();
             let y = Felt::parse_bytes(y.as_bytes(), 10).unwrap();
-            let p = FeltBigInt::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
+            let p = Felt::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
             let result = &x & &y;
             result.to_biguint();
             prop_assert!(result < p);
@@ -490,7 +884,7 @@ mod test {
         fn bitor_in_range(ref x in "(0|[1-9][0-9]*)", ref y in "(0|[1-9][0-9]*)"){
             let x = Felt::parse_bytes(x.as_bytes(), 10).unwrap();
             let y = Felt::parse_bytes(y.as_bytes(), 10).unwrap();
-            let p = FeltBigInt::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
+            let p = Felt::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
             let result = &x | &y;
             println!("x: {}, y: {}, result: {}", x, y, result);
             result.to_biguint();
@@ -502,7 +896,7 @@ mod test {
         fn bitxor_in_range(ref x in "(0|[1-9][0-9]*)", ref y in "(0|[1-9][0-9]*)"){
             let x = Felt::parse_bytes(x.as_bytes(), 10).unwrap();
             let y = Felt::parse_bytes(y.as_bytes(), 10).unwrap();
-            let p = FeltBigInt::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
+            let p = Felt::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
             let result = &x ^ &y;
             println!("x: {}, y: {}, result: {}", x, y, result);
             result.to_biguint();

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -18,7 +18,18 @@ pub const PRIME_STR: &str = "0x8000000000000110000000000000000000000000000000000
 pub const FIELD_HIGH: u128 = (1 << 123) + (17 << 64);
 pub const FIELD_LOW: u128 = 1;
 
-pub type Felt = FeltBigInt<FIELD_HIGH, FIELD_LOW>;
+pub struct Felt {
+    felt_bigint: FeltBigInt<FIELD_HIGH, FIELD_LOW>,
+}
+
+impl Felt {
+    pub fn new<T: Into<Felt>>(value: T) -> Self {
+        Felt { felt_bigint: FeltBigInt::new(value) }
+    }
+    pub fn bits(&self) -> u64 {
+        self.felt_bigint.bits()
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ParseFeltError;

--- a/src/cairo_run.rs
+++ b/src/cairo_run.rs
@@ -10,7 +10,7 @@ use crate::{
         vm_core::VirtualMachine,
     },
 };
-use felt::{Felt, FeltOps};
+use felt::Felt;
 use std::{
     fs::File,
     io::{self, BufWriter, Error, ErrorKind, Write},

--- a/src/cairo_run.rs
+++ b/src/cairo_run.rs
@@ -141,7 +141,6 @@ mod tests {
         },
         utils::test_utils::*,
     };
-    use felt::FeltOps;
     use std::io::Read;
 
     fn run_test_program(

--- a/src/cairo_run.rs
+++ b/src/cairo_run.rs
@@ -141,7 +141,7 @@ mod tests {
         },
         utils::test_utils::*,
     };
-    use felt::NewFelt;
+    use felt::FeltOps;
     use std::io::Read;
 
     fn run_test_program(

--- a/src/hint_processor/builtin_hint_processor/blake2s_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/blake2s_utils.rs
@@ -14,7 +14,7 @@ use crate::{
         vm_core::VirtualMachine,
     },
 };
-use felt::{Felt, FeltOps};
+use felt::Felt;
 use num_traits::ToPrimitive;
 use std::{borrow::Cow, collections::HashMap};
 

--- a/src/hint_processor/builtin_hint_processor/blake2s_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/blake2s_utils.rs
@@ -14,7 +14,7 @@ use crate::{
         vm_core::VirtualMachine,
     },
 };
-use felt::{Felt, NewFelt};
+use felt::{Felt, FeltOps};
 use num_traits::ToPrimitive;
 use std::{borrow::Cow, collections::HashMap};
 

--- a/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -461,7 +461,6 @@ mod tests {
             vm_memory::memory::Memory,
         },
     };
-    use felt::FeltOps;
     use num_traits::{One, Zero};
     use std::any::Any;
 

--- a/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -461,7 +461,7 @@ mod tests {
             vm_memory::memory::Memory,
         },
     };
-    use felt::NewFelt;
+    use felt::FeltOps;
     use num_traits::{One, Zero};
     use std::any::Any;
 

--- a/src/hint_processor/builtin_hint_processor/cairo_keccak/keccak_hints.rs
+++ b/src/hint_processor/builtin_hint_processor/cairo_keccak/keccak_hints.rs
@@ -12,7 +12,7 @@ use crate::{
         vm_core::VirtualMachine,
     },
 };
-use felt::{Felt, NewFelt};
+use felt::{Felt, FeltOps};
 use num_traits::{ToPrimitive, Zero};
 use std::{borrow::Cow, collections::HashMap, ops::Add};
 

--- a/src/hint_processor/builtin_hint_processor/cairo_keccak/keccak_hints.rs
+++ b/src/hint_processor/builtin_hint_processor/cairo_keccak/keccak_hints.rs
@@ -12,7 +12,7 @@ use crate::{
         vm_core::VirtualMachine,
     },
 };
-use felt::{Felt, FeltOps};
+use felt::Felt;
 use num_traits::{ToPrimitive, Zero};
 use std::{borrow::Cow, collections::HashMap, ops::Add};
 

--- a/src/hint_processor/builtin_hint_processor/find_element_hint.rs
+++ b/src/hint_processor/builtin_hint_processor/find_element_hint.rs
@@ -14,7 +14,7 @@ use crate::{
         vm_core::VirtualMachine,
     },
 };
-use felt::{Felt, NewFelt};
+use felt::{Felt, FeltOps};
 use num_traits::{Signed, ToPrimitive};
 use std::collections::HashMap;
 

--- a/src/hint_processor/builtin_hint_processor/find_element_hint.rs
+++ b/src/hint_processor/builtin_hint_processor/find_element_hint.rs
@@ -14,7 +14,7 @@ use crate::{
         vm_core::VirtualMachine,
     },
 };
-use felt::{Felt, FeltOps};
+use felt::Felt;
 use num_traits::{Signed, ToPrimitive};
 use std::collections::HashMap;
 

--- a/src/hint_processor/builtin_hint_processor/hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/hint_utils.rs
@@ -116,7 +116,7 @@ pub fn get_reference_from_var_name<'a>(
 
 #[cfg(test)]
 mod tests {
-    use felt::NewFelt;
+    use felt::FeltOps;
 
     use super::*;
     use crate::{

--- a/src/hint_processor/builtin_hint_processor/hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/hint_utils.rs
@@ -116,7 +116,6 @@ pub fn get_reference_from_var_name<'a>(
 
 #[cfg(test)]
 mod tests {
-    use felt::FeltOps;
 
     use super::*;
     use crate::{

--- a/src/hint_processor/builtin_hint_processor/keccak_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/keccak_utils.rs
@@ -15,7 +15,7 @@ use crate::{
         vm_core::VirtualMachine,
     },
 };
-use felt::{Felt, FeltOps};
+use felt::Felt;
 use num_traits::{One, Signed, ToPrimitive};
 use sha3::{Digest, Keccak256};
 use std::{cmp, collections::HashMap, ops::Shl};

--- a/src/hint_processor/builtin_hint_processor/math_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/math_utils.rs
@@ -15,7 +15,7 @@ use crate::{
         vm_core::VirtualMachine,
     },
 };
-use felt::{Felt, FeltOps, PRIME_STR};
+use felt::{Felt, PRIME_STR};
 use num_bigint::BigUint;
 use num_integer::Integer;
 use num_traits::One;

--- a/src/hint_processor/builtin_hint_processor/math_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/math_utils.rs
@@ -15,7 +15,7 @@ use crate::{
         vm_core::VirtualMachine,
     },
 };
-use felt::{Felt, FeltOps, NewFelt, PRIME_STR};
+use felt::{Felt, FeltOps, PRIME_STR};
 use num_bigint::BigUint;
 use num_integer::Integer;
 use num_traits::One;

--- a/src/hint_processor/builtin_hint_processor/memcpy_hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/memcpy_hint_utils.rs
@@ -82,7 +82,6 @@ mod tests {
             vm_memory::memory::Memory,
         },
     };
-    use felt::FeltOps;
 
     #[test]
     fn get_integer_from_var_name_valid() {

--- a/src/hint_processor/builtin_hint_processor/memcpy_hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/memcpy_hint_utils.rs
@@ -82,7 +82,7 @@ mod tests {
             vm_memory::memory::Memory,
         },
     };
-    use felt::NewFelt;
+    use felt::FeltOps;
 
     #[test]
     fn get_integer_from_var_name_valid() {

--- a/src/hint_processor/builtin_hint_processor/memset_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/memset_utils.rs
@@ -9,7 +9,7 @@ use crate::{
     types::exec_scope::ExecutionScopes,
     vm::{errors::hint_errors::HintError, vm_core::VirtualMachine},
 };
-use felt::{Felt, FeltOps};
+use felt::Felt;
 use num_traits::Signed;
 use std::{any::Any, collections::HashMap};
 

--- a/src/hint_processor/builtin_hint_processor/memset_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/memset_utils.rs
@@ -9,7 +9,7 @@ use crate::{
     types::exec_scope::ExecutionScopes,
     vm::{errors::hint_errors::HintError, vm_core::VirtualMachine},
 };
-use felt::{Felt, NewFelt};
+use felt::{Felt, FeltOps};
 use num_traits::Signed;
 use std::{any::Any, collections::HashMap};
 

--- a/src/hint_processor/builtin_hint_processor/pow_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/pow_utils.rs
@@ -8,7 +8,7 @@ use crate::{
     serde::deserialize_program::ApTracking,
     vm::{errors::hint_errors::HintError, vm_core::VirtualMachine},
 };
-use felt::{Felt, FeltOps};
+use felt::Felt;
 use num_integer::Integer;
 use std::collections::HashMap;
 

--- a/src/hint_processor/builtin_hint_processor/pow_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/pow_utils.rs
@@ -8,7 +8,7 @@ use crate::{
     serde::deserialize_program::ApTracking,
     vm::{errors::hint_errors::HintError, vm_core::VirtualMachine},
 };
-use felt::{Felt, NewFelt};
+use felt::{Felt, FeltOps};
 use num_integer::Integer;
 use std::collections::HashMap;
 

--- a/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
@@ -13,7 +13,7 @@ use crate::{
         vm_core::VirtualMachine,
     },
 };
-use felt::{Felt, NewFelt};
+use felt::{Felt, FeltOps};
 use std::collections::HashMap;
 /*
 Implements hint:

--- a/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
@@ -13,7 +13,7 @@ use crate::{
         vm_core::VirtualMachine,
     },
 };
-use felt::{Felt, FeltOps};
+use felt::Felt;
 use std::collections::HashMap;
 /*
 Implements hint:

--- a/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
@@ -13,7 +13,7 @@ use crate::{
     types::exec_scope::ExecutionScopes,
     vm::{errors::hint_errors::HintError, vm_core::VirtualMachine},
 };
-use felt::{Felt, FeltOps};
+use felt::Felt;
 use num_bigint::BigInt;
 use num_integer::Integer;
 use num_traits::{One, Zero};

--- a/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
@@ -175,7 +175,6 @@ mod tests {
             vm_memory::memory::Memory,
         },
     };
-    use felt::FeltOps;
     use std::any::Any;
 
     #[test]

--- a/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
@@ -12,7 +12,7 @@ use crate::{
     types::exec_scope::ExecutionScopes,
     vm::{errors::hint_errors::HintError, vm_core::VirtualMachine},
 };
-use felt::{Felt, FeltOps, NewFelt};
+use felt::{Felt, FeltOps};
 use num_bigint::BigInt;
 use num_integer::Integer;
 use num_traits::{One, Zero};
@@ -175,7 +175,7 @@ mod tests {
             vm_memory::memory::Memory,
         },
     };
-    use felt::NewFelt;
+    use felt::FeltOps;
     use std::any::Any;
 
     #[test]

--- a/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
@@ -12,7 +12,7 @@ use crate::{
     types::exec_scope::ExecutionScopes,
     vm::{errors::hint_errors::HintError, vm_core::VirtualMachine},
 };
-use felt::{Felt, FeltOps};
+use felt::Felt;
 use num_bigint::BigInt;
 use num_integer::Integer;
 use num_traits::{One, Zero};

--- a/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
@@ -7,7 +7,7 @@ use crate::{
     types::relocatable::Relocatable,
     vm::{errors::hint_errors::HintError, vm_core::VirtualMachine},
 };
-use felt::{Felt, FeltOps};
+use felt::Felt;
 use num_bigint::BigInt;
 use num_traits::Zero;
 use std::collections::HashMap;
@@ -93,7 +93,7 @@ pub fn pack_from_relocatable(rel: Relocatable, vm: &VirtualMachine) -> Result<Bi
 mod tests {
     use super::*;
     use crate::utils::test_utils::*;
-    use felt::{felt_str, FeltOps};
+    use felt::Felt;
     use num_bigint::BigUint;
     use num_traits::One;
 

--- a/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
@@ -93,7 +93,7 @@ pub fn pack_from_relocatable(rel: Relocatable, vm: &VirtualMachine) -> Result<Bi
 mod tests {
     use super::*;
     use crate::utils::test_utils::*;
-    use felt::Felt;
+    use felt::felt_str;
     use num_bigint::BigUint;
     use num_traits::One;
 

--- a/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
@@ -93,7 +93,7 @@ pub fn pack_from_relocatable(rel: Relocatable, vm: &VirtualMachine) -> Result<Bi
 mod tests {
     use super::*;
     use crate::utils::test_utils::*;
-    use felt::{felt_str, NewFelt};
+    use felt::{felt_str, FeltOps};
     use num_bigint::BigUint;
     use num_traits::One;
 

--- a/src/hint_processor/builtin_hint_processor/secp/signature.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/signature.rs
@@ -156,7 +156,7 @@ mod tests {
             vm_memory::memory::Memory,
         },
     };
-    use felt::NewFelt;
+    use felt::FeltOps;
     use num_traits::Zero;
     use std::{any::Any, ops::Shl};
 

--- a/src/hint_processor/builtin_hint_processor/secp/signature.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/signature.rs
@@ -12,7 +12,7 @@ use crate::{
     vm::errors::hint_errors::HintError,
     vm::vm_core::VirtualMachine,
 };
-use felt::{Felt, FeltOps};
+use felt::Felt;
 use num_bigint::BigInt;
 use num_integer::Integer;
 use num_traits::One;

--- a/src/hint_processor/builtin_hint_processor/secp/signature.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/signature.rs
@@ -156,7 +156,6 @@ mod tests {
             vm_memory::memory::Memory,
         },
     };
-    use felt::FeltOps;
     use num_traits::Zero;
     use std::{any::Any, ops::Shl};
 

--- a/src/hint_processor/builtin_hint_processor/set.rs
+++ b/src/hint_processor/builtin_hint_processor/set.rs
@@ -12,7 +12,7 @@ use crate::{
         vm_core::VirtualMachine,
     },
 };
-use felt::{Felt, NewFelt};
+use felt::{Felt, FeltOps};
 use num_traits::{One, ToPrimitive, Zero};
 use std::collections::HashMap;
 

--- a/src/hint_processor/builtin_hint_processor/set.rs
+++ b/src/hint_processor/builtin_hint_processor/set.rs
@@ -12,7 +12,7 @@ use crate::{
         vm_core::VirtualMachine,
     },
 };
-use felt::{Felt, FeltOps};
+use felt::Felt;
 use num_traits::{One, ToPrimitive, Zero};
 use std::collections::HashMap;
 

--- a/src/hint_processor/builtin_hint_processor/sha256_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/sha256_utils.rs
@@ -10,7 +10,7 @@ use crate::{
     vm::errors::{hint_errors::HintError, vm_errors::VirtualMachineError},
     vm::vm_core::VirtualMachine,
 };
-use felt::{Felt, FeltOps};
+use felt::Felt;
 use generic_array::GenericArray;
 use num_traits::{One, Zero};
 use sha2::compress256;

--- a/src/hint_processor/builtin_hint_processor/sha256_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/sha256_utils.rs
@@ -10,7 +10,7 @@ use crate::{
     vm::errors::{hint_errors::HintError, vm_errors::VirtualMachineError},
     vm::vm_core::VirtualMachine,
 };
-use felt::{Felt, NewFelt};
+use felt::{Felt, FeltOps};
 use generic_array::GenericArray;
 use num_traits::{One, Zero};
 use sha2::compress256;

--- a/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
@@ -16,7 +16,7 @@ use crate::{
         vm_core::VirtualMachine,
     },
 };
-use felt::{Felt, NewFelt};
+use felt::{Felt, FeltOps};
 use num_integer::Integer;
 use num_traits::{One, ToPrimitive, Zero};
 use std::collections::HashMap;

--- a/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
@@ -16,7 +16,7 @@ use crate::{
         vm_core::VirtualMachine,
     },
 };
-use felt::{Felt, FeltOps};
+use felt::Felt;
 use num_integer::Integer;
 use num_traits::{One, ToPrimitive, Zero};
 use std::collections::HashMap;

--- a/src/hint_processor/builtin_hint_processor/uint256_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/uint256_utils.rs
@@ -8,7 +8,7 @@ use crate::{
     serde::deserialize_program::ApTracking,
     vm::{errors::hint_errors::HintError, vm_core::VirtualMachine},
 };
-use felt::{Felt, FeltOps, NewFelt};
+use felt::{Felt, FeltOps};
 use num_integer::div_rem;
 use num_traits::{One, Signed, Zero};
 use std::{

--- a/src/hint_processor/builtin_hint_processor/uint256_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/uint256_utils.rs
@@ -8,7 +8,7 @@ use crate::{
     serde::deserialize_program::ApTracking,
     vm::{errors::hint_errors::HintError, vm_core::VirtualMachine},
 };
-use felt::{Felt, FeltOps};
+use felt::Felt;
 use num_integer::div_rem;
 use num_traits::{One, Signed, Zero};
 use std::{

--- a/src/hint_processor/builtin_hint_processor/usort.rs
+++ b/src/hint_processor/builtin_hint_processor/usort.rs
@@ -9,7 +9,7 @@ use crate::{
     types::exec_scope::ExecutionScopes,
     vm::{errors::hint_errors::HintError, vm_core::VirtualMachine},
 };
-use felt::{Felt, NewFelt};
+use felt::{Felt, FeltOps};
 use num_traits::{ToPrimitive, Zero};
 use std::{any::Any, collections::HashMap};
 

--- a/src/hint_processor/builtin_hint_processor/usort.rs
+++ b/src/hint_processor/builtin_hint_processor/usort.rs
@@ -9,7 +9,7 @@ use crate::{
     types::exec_scope::ExecutionScopes,
     vm::{errors::hint_errors::HintError, vm_core::VirtualMachine},
 };
-use felt::{Felt, FeltOps};
+use felt::Felt;
 use num_traits::{ToPrimitive, Zero};
 use std::{any::Any, collections::HashMap};
 

--- a/src/hint_processor/hint_processor_utils.rs
+++ b/src/hint_processor/hint_processor_utils.rs
@@ -201,7 +201,7 @@ mod tests {
             errors::memory_errors::MemoryError, vm_core::VirtualMachine, vm_memory::memory::Memory,
         },
     };
-    use felt::NewFelt;
+    use felt::FeltOps;
 
     #[test]
     fn get_integer_from_reference_with_immediate_value() {

--- a/src/hint_processor/hint_processor_utils.rs
+++ b/src/hint_processor/hint_processor_utils.rs
@@ -201,7 +201,6 @@ mod tests {
             errors::memory_errors::MemoryError, vm_core::VirtualMachine, vm_memory::memory::Memory,
         },
     };
-    use felt::FeltOps;
 
     #[test]
     fn get_integer_from_reference_with_immediate_value() {

--- a/src/math_utils.rs
+++ b/src/math_utils.rs
@@ -179,7 +179,6 @@ pub fn ec_double_slope(point: &(BigInt, BigInt), alpha: &BigInt, prime: &BigInt)
 mod tests {
     use super::*;
     use crate::utils::test_utils::*;
-    use felt::FeltOps;
     use num_traits::Num;
 
     #[test]

--- a/src/math_utils.rs
+++ b/src/math_utils.rs
@@ -179,7 +179,7 @@ pub fn ec_double_slope(point: &(BigInt, BigInt), alpha: &BigInt, prime: &BigInt)
 mod tests {
     use super::*;
     use crate::utils::test_utils::*;
-    use felt::NewFelt;
+    use felt::FeltOps;
     use num_traits::Num;
 
     #[test]

--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -370,7 +370,7 @@ pub fn deserialize_program(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use felt::{felt_str, NewFelt};
+    use felt::{felt_str, FeltOps};
     use num_traits::Zero;
     use std::{fs::File, io::BufReader};
 

--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -5,7 +5,7 @@ use crate::{
         relocatable::MaybeRelocatable,
     },
 };
-use felt::{Felt, FeltOps, PRIME_STR};
+use felt::{Felt, PRIME_STR};
 use num_traits::Num;
 use serde::{de, de::MapAccess, de::SeqAccess, Deserialize, Deserializer};
 use serde_json::Number;
@@ -370,7 +370,7 @@ pub fn deserialize_program(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use felt::{felt_str, FeltOps};
+    use felt::Felt;
     use num_traits::Zero;
     use std::{fs::File, io::BufReader};
 

--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -370,7 +370,7 @@ pub fn deserialize_program(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use felt::Felt;
+    use felt::felt_str;
     use num_traits::Zero;
     use std::{fs::File, io::BufReader};
 

--- a/src/serde/deserialize_utils.rs
+++ b/src/serde/deserialize_utils.rs
@@ -2,7 +2,7 @@ use crate::{
     serde::deserialize_program::{OffsetValue, ValueAddress},
     types::instruction::Register,
 };
-use felt::{Felt, NewFelt, ParseFeltError};
+use felt::{Felt, FeltOps, ParseFeltError};
 use nom::{
     branch::alt,
     bytes::{

--- a/src/serde/deserialize_utils.rs
+++ b/src/serde/deserialize_utils.rs
@@ -2,7 +2,7 @@ use crate::{
     serde::deserialize_program::{OffsetValue, ValueAddress},
     types::instruction::Register,
 };
-use felt::{Felt, FeltOps, ParseFeltError};
+use felt::{Felt, ParseFeltError};
 use nom::{
     branch::alt,
     bytes::{

--- a/src/types/exec_scope.rs
+++ b/src/types/exec_scope.rs
@@ -186,7 +186,7 @@ impl Default for ExecutionScopes {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use felt::{Felt, FeltOps};
+    use felt::Felt;
     use num_traits::One;
 
     #[test]

--- a/src/types/exec_scope.rs
+++ b/src/types/exec_scope.rs
@@ -186,7 +186,7 @@ impl Default for ExecutionScopes {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use felt::{Felt, NewFelt};
+    use felt::{Felt, FeltOps};
     use num_traits::One;
 
     #[test]

--- a/src/types/instruction.rs
+++ b/src/types/instruction.rs
@@ -102,7 +102,6 @@ pub(crate) fn is_call_instruction(encoded_instruction: &Felt, imm: Option<&Felt>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use felt::FeltOps;
 
     #[test]
     fn is_call_instruction_true() {

--- a/src/types/instruction.rs
+++ b/src/types/instruction.rs
@@ -102,7 +102,7 @@ pub(crate) fn is_call_instruction(encoded_instruction: &Felt, imm: Option<&Felt>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use felt::NewFelt;
+    use felt::FeltOps;
 
     #[test]
     fn is_call_instruction_true() {

--- a/src/types/program.rs
+++ b/src/types/program.rs
@@ -111,7 +111,7 @@ mod tests {
     use super::*;
     use crate::serde::deserialize_program::{ApTracking, FlowTrackingData};
     use crate::utils::test_utils::mayberelocatable;
-    use felt::Felt;
+    use felt::felt_str;
     use num_traits::Zero;
 
     #[test]

--- a/src/types/program.rs
+++ b/src/types/program.rs
@@ -111,7 +111,7 @@ mod tests {
     use super::*;
     use crate::serde::deserialize_program::{ApTracking, FlowTrackingData};
     use crate::utils::test_utils::mayberelocatable;
-    use felt::{felt_str, FeltOps};
+    use felt::Felt;
     use num_traits::Zero;
 
     #[test]

--- a/src/types/program.rs
+++ b/src/types/program.rs
@@ -111,7 +111,7 @@ mod tests {
     use super::*;
     use crate::serde::deserialize_program::{ApTracking, FlowTrackingData};
     use crate::utils::test_utils::mayberelocatable;
-    use felt::{felt_str, NewFelt};
+    use felt::{felt_str, FeltOps};
     use num_traits::Zero;
 
     #[test]

--- a/src/types/relocatable.rs
+++ b/src/types/relocatable.rs
@@ -2,7 +2,7 @@ use crate::{
     relocatable,
     vm::errors::{memory_errors::MemoryError, vm_errors::VirtualMachineError},
 };
-use felt::{Felt, FeltOps};
+use felt::Felt;
 use num_traits::{FromPrimitive, ToPrimitive, Zero};
 use std::{
     fmt::{self, Display},

--- a/src/types/relocatable.rs
+++ b/src/types/relocatable.rs
@@ -2,7 +2,7 @@ use crate::{
     relocatable,
     vm::errors::{memory_errors::MemoryError, vm_errors::VirtualMachineError},
 };
-use felt::{Felt, NewFelt};
+use felt::{Felt, FeltOps};
 use num_traits::{FromPrimitive, ToPrimitive, Zero};
 use std::{
     fmt::{self, Display},

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -183,10 +183,7 @@ pub mod test_utils {
             MaybeRelocatable::from(($val1, $val2))
         };
         ($val1 : expr) => {
-            MaybeRelocatable::from(<felt::Felt as felt::FeltOps<
-                { felt::FIELD_HIGH },
-                { felt::FIELD_LOW },
-            >>::new($val1 as i128))
+            MaybeRelocatable::from(felt::Felt::new($val1 as i128))
         };
     }
     pub(crate) use mayberelocatable;
@@ -531,7 +528,7 @@ mod test {
             vm_core::VirtualMachine, vm_memory::memory::Memory,
         },
     };
-    use felt::{Felt, FeltOps};
+    use felt::Felt;
     use num_traits::One;
     use std::{any::Any, cell::RefCell, collections::HashMap, rc::Rc};
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -183,7 +183,7 @@ pub mod test_utils {
             MaybeRelocatable::from(($val1, $val2))
         };
         ($val1 : expr) => {
-            MaybeRelocatable::from(<felt::Felt as felt::NewFelt<
+            MaybeRelocatable::from(<felt::Felt as felt::FeltOps<
                 { felt::FIELD_HIGH },
                 { felt::FIELD_LOW },
             >>::new($val1 as i128))
@@ -531,7 +531,7 @@ mod test {
             vm_core::VirtualMachine, vm_memory::memory::Memory,
         },
     };
-    use felt::{Felt, NewFelt};
+    use felt::{Felt, FeltOps};
     use num_traits::One;
     use std::{any::Any, cell::RefCell, collections::HashMap, rc::Rc};
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -183,7 +183,10 @@ pub mod test_utils {
             MaybeRelocatable::from(($val1, $val2))
         };
         ($val1 : expr) => {
-            MaybeRelocatable::from(<felt::Felt as felt::NewFelt>::new($val1 as i128))
+            MaybeRelocatable::from(<felt::Felt as felt::NewFelt<
+                { felt::FIELD_HIGH },
+                { felt::FIELD_LOW },
+            >>::new($val1 as i128))
         };
     }
     pub(crate) use mayberelocatable;

--- a/src/vm/context/run_context.rs
+++ b/src/vm/context/run_context.rs
@@ -110,7 +110,7 @@ mod tests {
     use crate::types::instruction::{ApUpdate, FpUpdate, Opcode, PcUpdate, Res};
     use crate::utils::test_utils::mayberelocatable;
     use crate::vm::errors::memory_errors::MemoryError;
-    use felt::{Felt, FeltOps};
+    use felt::Felt;
 
     #[test]
     fn compute_dst_addr_for_ap_register() {

--- a/src/vm/context/run_context.rs
+++ b/src/vm/context/run_context.rs
@@ -110,7 +110,7 @@ mod tests {
     use crate::types::instruction::{ApUpdate, FpUpdate, Opcode, PcUpdate, Res};
     use crate::utils::test_utils::mayberelocatable;
     use crate::vm::errors::memory_errors::MemoryError;
-    use felt::{Felt, NewFelt};
+    use felt::{Felt, FeltOps};
 
     #[test]
     fn compute_dst_addr_for_ap_register() {

--- a/src/vm/decoding/decoder.rs
+++ b/src/vm/decoding/decoder.rs
@@ -146,7 +146,6 @@ fn decode_offset(offset: i64) -> isize {
 #[cfg(test)]
 mod decoder_test {
     use super::*;
-    use felt::FeltOps;
 
     #[test]
     fn invalid_op1_reg() {

--- a/src/vm/decoding/decoder.rs
+++ b/src/vm/decoding/decoder.rs
@@ -146,7 +146,7 @@ fn decode_offset(offset: i64) -> isize {
 #[cfg(test)]
 mod decoder_test {
     use super::*;
-    use felt::NewFelt;
+    use felt::FeltOps;
 
     #[test]
     fn invalid_op1_reg() {

--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -222,7 +222,7 @@ mod tests {
         hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor,
         types::program::Program, utils::test_utils::*, vm::runners::cairo_runner::CairoRunner,
     };
-    use felt::{Felt, NewFelt};
+    use felt::{Felt, FeltOps};
 
     #[test]
     fn get_used_instances() {

--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -12,7 +12,6 @@ use crate::{
         vm_memory::{memory::Memory, memory_segments::MemorySegmentManager},
     },
 };
-use felt::FeltOps;
 use num_integer::div_ceil;
 
 #[derive(Debug, Clone)]
@@ -222,7 +221,7 @@ mod tests {
         hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor,
         types::program::Program, utils::test_utils::*, vm::runners::cairo_runner::CairoRunner,
     };
-    use felt::{Felt, FeltOps};
+    use felt::Felt;
 
     #[test]
     fn get_used_instances() {

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -8,7 +8,7 @@ use crate::vm::errors::runner_errors::RunnerError;
 use crate::vm::vm_core::VirtualMachine;
 use crate::vm::vm_memory::memory::Memory;
 use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
-use felt::{Felt, FeltOps, NewFelt};
+use felt::{Felt, FeltOps};
 use num_bigint::BigInt;
 use num_integer::{div_ceil, Integer};
 use num_traits::{Num, One, Pow, Zero};

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -8,7 +8,7 @@ use crate::vm::errors::runner_errors::RunnerError;
 use crate::vm::vm_core::VirtualMachine;
 use crate::vm::vm_memory::memory::Memory;
 use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
-use felt::{Felt, FeltOps};
+use felt::Felt;
 use num_bigint::BigInt;
 use num_integer::{div_ceil, Integer};
 use num_traits::{Num, One, Pow, Zero};

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -10,7 +10,7 @@ use crate::vm::errors::runner_errors::RunnerError;
 use crate::vm::vm_core::VirtualMachine;
 use crate::vm::vm_memory::memory::Memory;
 use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
-use felt::{Felt, FeltOps};
+use felt::Felt;
 use num_integer::{div_ceil, Integer};
 use starknet_crypto::{pedersen_hash, FieldElement};
 

--- a/src/vm/runners/builtin_runner/keccak.rs
+++ b/src/vm/runners/builtin_runner/keccak.rs
@@ -265,7 +265,7 @@ mod tests {
         runners::builtin_runner::BuiltinRunner,
         vm_core::VirtualMachine,
     };
-    use felt::NewFelt;
+    use felt::FeltOps;
     use std::path::Path;
 
     #[test]

--- a/src/vm/runners/builtin_runner/keccak.rs
+++ b/src/vm/runners/builtin_runner/keccak.rs
@@ -265,7 +265,6 @@ mod tests {
         runners::builtin_runner::BuiltinRunner,
         vm_core::VirtualMachine,
     };
-    use felt::FeltOps;
     use std::path::Path;
 
     #[test]

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -13,7 +13,7 @@ use crate::{
         },
     },
 };
-use felt::{Felt, NewFelt};
+use felt::{Felt, FeltOps};
 use num_integer::Integer;
 use num_traits::{One, ToPrimitive, Zero};
 use std::{

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -13,7 +13,7 @@ use crate::{
         },
     },
 };
-use felt::{Felt, FeltOps};
+use felt::Felt;
 use num_integer::Integer;
 use num_traits::{One, ToPrimitive, Zero};
 use std::{

--- a/src/vm/runners/builtin_runner/signature.rs
+++ b/src/vm/runners/builtin_runner/signature.rs
@@ -13,7 +13,7 @@ use crate::{
         },
     },
 };
-use felt::{Felt, FeltOps};
+use felt::Felt;
 use num_integer::{div_ceil, Integer};
 use num_traits::ToPrimitive;
 use starknet_crypto::{verify, FieldElement, Signature};

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -1135,7 +1135,7 @@ mod tests {
         utils::test_utils::*,
         vm::{trace::trace_entry::TraceEntry, vm_memory::memory::Memory},
     };
-    use felt::{felt_str, NewFelt};
+    use felt::{felt_str, FeltOps};
     use num_traits::One;
     use std::{
         collections::{HashMap, HashSet},

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -1135,7 +1135,7 @@ mod tests {
         utils::test_utils::*,
         vm::{trace::trace_entry::TraceEntry, vm_memory::memory::Memory},
     };
-    use felt::Felt;
+    use felt::felt_str;
     use num_traits::One;
     use std::{
         collections::{HashMap, HashSet},

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -1117,7 +1117,7 @@ pub struct SegmentInfo {
     pub size: usize,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Default)]
 pub struct ExecutionResources {
     pub n_steps: usize,
     pub n_memory_holes: usize,

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -33,7 +33,7 @@ use crate::{
         },
     },
 };
-use felt::{Felt, FeltOps};
+use felt::Felt;
 use num_integer::div_rem;
 use num_traits::Zero;
 use std::{
@@ -1135,7 +1135,7 @@ mod tests {
         utils::test_utils::*,
         vm::{trace::trace_entry::TraceEntry, vm_memory::memory::Memory},
     };
-    use felt::{felt_str, FeltOps};
+    use felt::Felt;
     use num_traits::One;
     use std::{
         collections::{HashMap, HashSet},

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -1008,7 +1008,7 @@ mod tests {
         },
     };
 
-    use felt::{felt_str, NewFelt};
+    use felt::{felt_str, FeltOps};
     use std::{collections::HashSet, path::Path};
 
     #[test]

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -1008,7 +1008,7 @@ mod tests {
         },
     };
 
-    use felt::{felt_str, FeltOps};
+    use felt::Felt;
     use std::{collections::HashSet, path::Path};
 
     #[test]

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -3745,10 +3745,10 @@ mod tests {
     #[test]
     fn gen_arg_bigint_prime() {
         let mut vm = vm!();
-        let prime = felt_str!(&felt::PRIME_STR[2..], 16);
+        let prime = felt_str!(felt::PRIME_STR[2..], 16);
         let prime_maybe = MaybeRelocatable::from(prime);
 
-        assert_eq!(vm.gen_arg(&prime_maybe), Ok(mayberelocatable!(0)),);
+        assert_eq!(vm.gen_arg(&prime_maybe), Ok(mayberelocatable!(0)));
     }
 
     /// Test that the call to .gen_arg() with a Vec<MaybeRelocatable> writes its

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -1008,7 +1008,7 @@ mod tests {
         },
     };
 
-    use felt::Felt;
+    use felt::felt_str;
     use std::{collections::HashSet, path::Path};
 
     #[test]

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -375,7 +375,7 @@ mod memory_tests {
             vm_memory::memory_segments::MemorySegmentManager,
         },
     };
-    use felt::Felt;
+    use felt::{felt_str, Felt};
 
     use crate::vm::errors::memory_errors::MemoryError;
 

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -375,7 +375,7 @@ mod memory_tests {
             vm_memory::memory_segments::MemorySegmentManager,
         },
     };
-    use felt::{felt_str, NewFelt};
+    use felt::{felt_str, FeltOps};
 
     use crate::vm::errors::memory_errors::MemoryError;
 

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -375,7 +375,7 @@ mod memory_tests {
             vm_memory::memory_segments::MemorySegmentManager,
         },
     };
-    use felt::{felt_str, FeltOps};
+    use felt::Felt;
 
     use crate::vm::errors::memory_errors::MemoryError;
 

--- a/src/vm/vm_memory/memory_segments.rs
+++ b/src/vm/vm_memory/memory_segments.rs
@@ -257,7 +257,7 @@ mod tests {
     use super::*;
     use crate::vm::vm_core::VirtualMachine;
     use crate::{relocatable, utils::test_utils::*};
-    use felt::{Felt, FeltOps};
+    use felt::Felt;
     use num_traits::Num;
 
     #[test]

--- a/src/vm/vm_memory/memory_segments.rs
+++ b/src/vm/vm_memory/memory_segments.rs
@@ -257,7 +257,7 @@ mod tests {
     use super::*;
     use crate::vm::vm_core::VirtualMachine;
     use crate::{relocatable, utils::test_utils::*};
-    use felt::{Felt, NewFelt};
+    use felt::{Felt, FeltOps};
     use num_traits::Num;
 
     #[test]


### PR DESCRIPTION
# TITLE

## Description

This PR finishes up the work started in #732 and #734 (must be merged after these two). Now the internal felt implementation, `FeltBigInt` in this case, is completely hidden from the user and its no longer necessary to import the traits `NewFelt` and `FeltOps` to use `Felt`'s methods
Resolves: #719
## Checklist
- [x] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
