### PR TITLE
Fix misleading definition of `layout` flag in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ To run a compiled .json program through the VM, call the executable giving it th
 ```bash 
 target/release/cairo-rs-run cairo_programs/abs_value_array_compiled.json --layout all
 ```
-The flag `--layout` determines which builtin is going to be used. More info about layouts [here](https://www.cairo-lang.org/docs/how_cairo_works/builtins.html#layouts).
+The flag `--layout` determines which builtins can be used. More info about layouts [here](https://www.cairo-lang.org/docs/how_cairo_works/builtins.html#layouts).
 
 To sum up, the following code will get you from zero to running a Cairo program:
 


### PR DESCRIPTION
The `--layout` flag limits the runner to a specific set of builtins, with no obligation to use any of them. An error will be outputed if the program uses a builtin that is not allowed by the layout chosen