### PR TITLE
Remove unused entrypoint from `run_from_entrypoint` example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,10 @@ There are two ways to use non-standard hints in this VM:
 ### Running a function in a Cairo program with arguments
 When running a Cairo program directly using the Cairo-rs repository you would first need to prepare a couple of things. 
 
-1. Specify the Cairo program and the function you want to run
+1. Specify the Cairo program you want to run
 ```rust
 let program =
-        Program::from_file(Path::new(&file_path), Some(&func_name));
+        Program::from_file(Path::new(&file_path), None);
 ```
 
 2. Instantiate the VM, the cairo_runner, the hint processor, and the entrypoint


### PR DESCRIPTION
The entrypoint set in the program is only used when running a program with `cairo_run`, when using the `run_from_entrypoint` method, this value is not used, and might as well be None