### PR TITLE
Fix EC op

### DIFF
--- a/cairo_programs/bad_programs/ec_op_not_in_curve.cairo
+++ b/cairo_programs/bad_programs/ec_op_not_in_curve.cairo
@@ -1,0 +1,38 @@
+%builtins ec_op
+
+from starkware.cairo.common.cairo_builtins import EcOpBuiltin, SignatureBuiltin
+from starkware.cairo.common.ec_point import (
+    EcPoint,
+)
+from starkware.cairo.common.cairo_secp.ec import (
+    ec_negate,
+    compute_doubling_slope,
+    compute_slope,
+    ec_double,
+    fast_ec_add,
+    ec_mul_inner,
+)
+from starkware.cairo.common.cairo_secp.bigint import BigInt3
+
+func test_ec_op_point_not_on_curve{
+    ec_op_ptr: EcOpBuiltin*
+}() {
+    tempvar p = EcPoint(
+        0x654fd7e67a123dd13868093b3b7777f1ffef596c2e324f25ceaf9146698482c,
+        0x4fad269cbf860980e38768fe9cb6b0b9ab03ee3fe84cfde2eccce597c874fd8,
+        );
+    assert ec_op_ptr[0].p = p;
+    assert ec_op_ptr[0].q = EcPoint(x=p.x, y=p.y + 1);
+    assert ec_op_ptr[0].m = 7;
+    assert ec_op_ptr[0].r.x = ec_op_ptr[0].r.x;
+    assert ec_op_ptr[0].r.y = ec_op_ptr[0].r.y;
+    let ec_op_ptr = &ec_op_ptr[1];
+    return ();
+}
+
+func main{
+    ec_op_ptr: EcOpBuiltin*
+}() {
+    test_ec_op_point_not_on_curve();
+    return ();
+}

--- a/cairo_programs/bad_programs/ec_op_same_x.cairo
+++ b/cairo_programs/bad_programs/ec_op_same_x.cairo
@@ -1,0 +1,47 @@
+%builtins ec_op
+
+from starkware.cairo.common.cairo_builtins import EcOpBuiltin, SignatureBuiltin
+from starkware.cairo.common.ec_point import (
+    EcPoint,
+)
+from starkware.cairo.common.cairo_secp.ec import (
+    ec_negate,
+    compute_doubling_slope,
+    compute_slope,
+    ec_double,
+    fast_ec_add,
+    ec_mul_inner,
+)
+from starkware.cairo.common.cairo_secp.bigint import BigInt3
+
+func test_ec_op_invalid_input{
+    ec_op_ptr: EcOpBuiltin*
+}() {
+    // Choose p = 4 * q.
+    // Trying to compute p + 8 * q starts with the following pairs of points:
+    //   (p, q),
+    //   (p, 2 * q),
+    //   (p, 4 * q),
+    //   (p, 8 * q),
+    // But since p = 4 * q, the pair (p, 4 * q) is invalid (the x-coordinate is the same).
+    assert ec_op_ptr[0].p = EcPoint(
+        0x6a4beaef5a93425b973179cdba0c9d42f30e01a5f1e2db73da0884b8d6756fc,
+        0x72565ec81bc09ff53fbfad99324a92aa5b39fb58267e395e8abe36290ebf24f,
+        );
+    assert ec_op_ptr[0].q = EcPoint(
+        0x654fd7e67a123dd13868093b3b7777f1ffef596c2e324f25ceaf9146698482c,
+        0x4fad269cbf860980e38768fe9cb6b0b9ab03ee3fe84cfde2eccce597c874fd8,
+        );
+    assert ec_op_ptr[0].m = 8;
+    assert ec_op_ptr[0].r.x = ec_op_ptr[0].r.x;
+    assert ec_op_ptr[0].r.y = ec_op_ptr[0].r.y;
+    let ec_op_ptr = &ec_op_ptr[1];
+    return ();
+}
+
+func main{
+    ec_op_ptr: EcOpBuiltin*
+}() {
+    test_ec_op_invalid_input();
+    return ();
+}

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -1003,4 +1003,40 @@ mod tests {
         let ec_op_builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), false);
         assert_eq!(ec_op_builtin.initial_stack(), Vec::new())
     }
+
+    #[test]
+    fn catch_point_not_in_curve() {
+        let program = Program::from_file(
+            Path::new("cairo_programs/bad_programs/ec_op_not_in_curve.json"),
+            Some("main"),
+        )
+        .expect("Call to `Program::from_file()` failed.");
+
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
+        let mut cairo_runner = cairo_runner!(program, "all", false);
+        let mut vm = vm!();
+
+        let end = cairo_runner.initialize(&mut vm).unwrap();
+        assert!(cairo_runner
+            .run_until_pc(end, &mut vm, &mut hint_processor)
+            .is_err());
+    }
+
+    #[test]
+    fn catch_point_same_x() {
+        let program = Program::from_file(
+            Path::new("cairo_programs/bad_programs/ec_op_same_x.json"),
+            Some("main"),
+        )
+        .expect("Call to `Program::from_file()` failed.");
+
+        let mut hint_processor = BuiltinHintProcessor::new_empty();
+        let mut cairo_runner = cairo_runner!(program, "all", false);
+        let mut vm = vm!();
+
+        let end = cairo_runner.initialize(&mut vm).unwrap();
+        assert!(cairo_runner
+            .run_until_pc(end, &mut vm, &mut hint_processor)
+            .is_err());
+    }
 }

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -9,7 +9,7 @@ use crate::vm::vm_core::VirtualMachine;
 use crate::vm::vm_memory::memory::Memory;
 use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
 use felt::{Felt, FeltOps, NewFelt};
-use num_bigint::BigInt;
+use num_bigint::{BigInt, ToBigInt};
 use num_integer::{div_ceil, Integer};
 use num_traits::{Num, One, Pow, Zero};
 use std::borrow::Cow;
@@ -60,9 +60,35 @@ impl EcOpBuiltinRunner {
         prime: &BigInt,
         height: u32,
     ) -> Result<(BigInt, BigInt), RunnerError> {
-        let mut slope = m.clone().to_bigint();
-        let mut partial_sum_b = (partial_sum.0.to_bigint(), partial_sum.1.to_bigint());
-        let mut doubled_point_b = (doubled_point.0.to_bigint(), doubled_point.1.to_bigint());
+        let mut slope = m
+            .clone()
+            .to_biguint()
+            .to_bigint()
+            .ok_or(RunnerError::FoundNonInt)?;
+        let mut partial_sum_b = (
+            partial_sum
+                .0
+                .to_biguint()
+                .to_bigint()
+                .ok_or(RunnerError::FoundNonInt)?,
+            partial_sum
+                .1
+                .to_biguint()
+                .to_bigint()
+                .ok_or(RunnerError::FoundNonInt)?,
+        );
+        let mut doubled_point_b = (
+            doubled_point
+                .0
+                .to_biguint()
+                .to_bigint()
+                .ok_or(RunnerError::FoundNonInt)?,
+            doubled_point
+                .1
+                .to_biguint()
+                .to_bigint()
+                .ok_or(RunnerError::FoundNonInt)?,
+        );
         for _ in 0..height {
             if (doubled_point_b.0.clone() - partial_sum_b.0.clone()).is_zero() {
                 return Err(RunnerError::EcOpSameXCoordinate(Self::format_ec_op_error(
@@ -294,6 +320,7 @@ mod tests {
         vm_core::VirtualMachine,
     };
     use felt::felt_str;
+    use std::path::Path;
     use EcOpBuiltinRunner;
 
     #[test]


### PR DESCRIPTION
The EC op implementation was mistakenly converting felts into signed felts instead of extracting the unsigned value contained in it.

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [x] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
