### PR TITLE
Fix Felt::from_bytes_be + add proptest

### DIFF
--- a/felt/proptest-regressions/lib.txt
+++ b/felt/proptest-regressions/lib.txt
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc 1bf12114a6bfc70e8f949318158595883c33bc6fb35862852bc5144547ac3557 # shrinks to ref x = "0"
+cc 3a938be1bdfbb188c7c1f0dc097d8089fe8b26a98b76c013014651353d2926d0 # shrinks to ref x = "10000000000000000000000000000000"

--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -150,7 +150,11 @@ impl FeltOps for FeltBigInt {
     }
 
     fn from_bytes_be(bytes: &[u8]) -> Self {
-        Self::new(BigUint::from_bytes_be(bytes))
+        let mut value = BigUint::from_bytes_be(bytes);
+        if value > *CAIRO_PRIME {
+            value = value.mod_floor(&CAIRO_PRIME);
+        }
+        Self(value)
     }
 
     fn to_str_radix(&self, radix: u32) -> String {

--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -161,7 +161,7 @@ impl<const PH: u128, const PL: u128> FeltOps<PH, PL> for FeltBigInt<PH, PL> {
         if value > *CAIRO_PRIME {
             value = value.mod_floor(&CAIRO_PRIME);
         }
-        Self(value)
+        Self::from(value)
     }
 
     fn to_str_radix(&self, radix: u32) -> String {

--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -162,7 +162,7 @@ impl FeltOps for FeltBigInt<FIELD_HIGH, FIELD_LOW> {
 
     fn from_bytes_be(bytes: &[u8]) -> FeltBigInt<FIELD_HIGH, FIELD_LOW> {
         let mut value = BigUint::from_bytes_be(bytes);
-        if value > *CAIRO_PRIME {
+        if value >= *CAIRO_PRIME {
             value = value.mod_floor(&CAIRO_PRIME);
         }
         Self::from(value)

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -166,6 +166,16 @@ mod test {
             let p = &BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
             prop_assert!(&x.to_biguint() < p);
         }
+
+        #[test]
+        // Property-based test that ensures, for 100 felt values that are randomly generated each time tests are run, that a felt created using Felt::from_bytes_be doesn't fall outside the range [0, p].
+        // In this and some of the following tests, The value of {x} can be either [0] or a very large number, in order to try to overflow the value of {p} and thus ensure the modular arithmetic is working correctly.
+        fn from_bytes_be_in_range(ref x in "(0|[1-9][0-9]*)") {
+            let x = &Felt::from_bytes_be(x.as_bytes());
+            let p = &Felt::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
+            prop_assert!(x < p);
+        }
+
         #[test]
         // Property-based test that ensures, for 100 felt values that are randomly generated each time tests are run, that the negative of a felt doesn't fall outside the range [0, p].
         fn neg_in_range(ref x in "(0|[1-9][0-9]*)") {

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -794,8 +794,8 @@ mod test {
         // In this and some of the following tests, The value of {x} can be either [0] or a very large number, in order to try to overflow the value of {p} and thus ensure the modular arithmetic is working correctly.
         fn from_bytes_be_in_range(ref x in "(0|[1-9][0-9]*)") {
             let x = &Felt::from_bytes_be(x.as_bytes());
-            let p = &Felt::from(&(BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap() - 1_u32));
-            prop_assert!(x <= p);
+            let max_felt = &Felt::max_value();
+            prop_assert!(x <= max_felt);
         }
 
         #[test]


### PR DESCRIPTION
`Felt::from_bytes_be` wasnt performing modulo prime when the number went out of range
