### PR TITLE
CI: add flags '--tests --examples --all-features' to clippy runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ test: $(COMPILED_PROOF_TESTS) $(COMPILED_TESTS) $(COMPILED_BAD_TESTS)
 	cargo test --workspace --features test_utils
 
 clippy:
-	cargo clippy  -- -D warnings
+	cargo clippy --tests --examples --all-features -- -D warnings
 
 coverage:
 	docker run --security-opt seccomp=unconfined -v "${PWD}:/volume" xd009642/tarpaulin

--- a/src/types/relocatable.rs
+++ b/src/types/relocatable.rs
@@ -664,8 +664,8 @@ mod tests {
     fn relocatable_add_i32() {
         let reloc = relocatable!(1, 5);
 
-        assert_eq!(&reloc + 3, relocatable!(1, 8));
-        assert_eq!(&reloc + (-3), relocatable!(1, 2));
+        assert_eq!(reloc + 3, relocatable!(1, 8));
+        assert_eq!(reloc + (-3), relocatable!(1, 2));
     }
 
     #[test]
@@ -673,7 +673,7 @@ mod tests {
     fn relocatable_add_i32_with_overflow() {
         let reloc = relocatable!(1, 1);
 
-        let _panic = &reloc + (-3);
+        let _panic = reloc + (-3);
     }
 
     #[test]

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -4124,7 +4124,7 @@ mod tests {
         assert_eq!(
             cairo_runner.run_from_entrypoint(
                 main_entrypoint,
-                &vec![
+                &[
                     &mayberelocatable!(2).into(),
                     &MaybeRelocatable::from((2, 0)).into()
                 ], //range_check_ptr
@@ -4153,7 +4153,7 @@ mod tests {
         assert_eq!(
             new_cairo_runner.run_from_entrypoint(
                 fib_entrypoint,
-                &vec![
+                &[
                     &mayberelocatable!(2).into(),
                     &MaybeRelocatable::from((2, 0)).into()
                 ],


### PR DESCRIPTION
# Expand the amount of code checked by `clippy`

## Description

Add clippy coverage for tests, examples and not-std features.
