### PR TITLE
Refactor method `BuiltinRunner::run_security_checks`

### DIFF
--- a/src/vm/errors/vm_errors.rs
+++ b/src/vm/errors/vm_errors.rs
@@ -135,4 +135,6 @@ pub enum VirtualMachineError {
     Hint(usize, Box<HintError>),
     #[error("Unexpected Failure")]
     Unexpected,
+    #[error("Negative builtin base")]
+    NegBuiltinBase,
 }

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -1090,6 +1090,64 @@ mod tests {
     }
 
     #[test]
+    fn run_security_ec_op_check_memory_empty() {
+        let mut ec_op_builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
+
+        ec_op_builtin.cells_per_instance = 5;
+        ec_op_builtin.n_input_cells = 7;
+
+        let builtin: BuiltinRunner = ec_op_builtin.into();
+
+        let mut vm = vm!();
+        // The values stored in memory are not relevant for this test
+        vm.memory.data = vec![vec![]];
+
+        assert_eq!(builtin.run_security_checks(&mut vm), Ok(()),);
+    }
+
+    #[test]
+    fn run_security_ec_op_check_memory_1_element() {
+        let mut ec_op_builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
+
+        ec_op_builtin.cells_per_instance = 5;
+        ec_op_builtin.n_input_cells = 7;
+
+        let builtin: BuiltinRunner = ec_op_builtin.into();
+
+        let mut vm = vm!();
+        // The values stored in memory are not relevant for this test
+        vm.memory.data = vec![vec![mayberelocatable!(0).into()]];
+
+        assert_eq!(
+            builtin.run_security_checks(&mut vm),
+            Err(MemoryError::MissingMemoryCellsWithOffsets("ec_op", vec![1, 2, 3, 4]).into()),
+        );
+    }
+
+    #[test]
+    fn run_security_ec_op_check_memory_3_elements() {
+        let mut ec_op_builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
+
+        ec_op_builtin.cells_per_instance = 5;
+        ec_op_builtin.n_input_cells = 7;
+
+        let builtin: BuiltinRunner = ec_op_builtin.into();
+
+        let mut vm = vm!();
+        // The values stored in memory are not relevant for this test
+        vm.memory.data = vec![vec![
+            mayberelocatable!(0).into(),
+            mayberelocatable!(0).into(),
+            mayberelocatable!(0).into(),
+        ]];
+
+        assert_eq!(
+            builtin.run_security_checks(&mut vm),
+            Err(MemoryError::MissingMemoryCellsWithOffsets("ec_op", vec![3, 4]).into()),
+        );
+    }
+
+    #[test]
     fn run_security_ec_op_missing_memory_cells_with_offsets() {
         let builtin: BuiltinRunner =
             EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true).into();
@@ -1112,7 +1170,7 @@ mod tests {
     }
 
     #[test]
-    fn run_security_ec_op_check_missing_memory_cells() {
+    fn run_security_ec_op_check_memory_gap() {
         let mut ec_op_builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
 
         ec_op_builtin.cells_per_instance = 5;
@@ -1121,23 +1179,23 @@ mod tests {
         let builtin: BuiltinRunner = ec_op_builtin.into();
 
         let mut vm = vm!();
-
+        // The values stored in memory are not relevant for this test
         vm.memory.data = vec![vec![
-            mayberelocatable!(0, 0).into(),
-            mayberelocatable!(0, 1).into(),
-            mayberelocatable!(0, 2).into(),
-            mayberelocatable!(0, 3).into(),
-            mayberelocatable!(0, 4).into(),
-            mayberelocatable!(0, 5).into(),
-            mayberelocatable!(0, 6).into(),
-            mayberelocatable!(0, 8).into(),
-            mayberelocatable!(0, 9).into(),
-            mayberelocatable!(0, 10).into(),
+            mayberelocatable!(0).into(),
+            mayberelocatable!(1).into(),
+            mayberelocatable!(2).into(),
+            mayberelocatable!(3).into(),
+            mayberelocatable!(4).into(),
+            mayberelocatable!(5).into(),
+            mayberelocatable!(6).into(),
+            None,
+            mayberelocatable!(8).into(),
+            mayberelocatable!(9).into(),
         ]];
 
         assert_eq!(
             builtin.run_security_checks(&mut vm),
-            Err(MemoryError::MissingMemoryCells("ec_op").into()),
+            Err(MemoryError::MissingMemoryCellsWithOffsets("ec_op", vec![7]).into()),
         );
     }
 

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -1094,10 +1094,7 @@ mod tests {
 
     #[test]
     fn run_security_ec_op_check_memory_empty() {
-        let mut ec_op_builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
-
-        ec_op_builtin.cells_per_instance = 5;
-        ec_op_builtin.n_input_cells = 7;
+        let ec_op_builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
 
         let builtin: BuiltinRunner = ec_op_builtin.into();
 
@@ -1110,10 +1107,7 @@ mod tests {
 
     #[test]
     fn run_security_ec_op_check_memory_1_element() {
-        let mut ec_op_builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
-
-        ec_op_builtin.cells_per_instance = 5;
-        ec_op_builtin.n_input_cells = 7;
+        let ec_op_builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
 
         let builtin: BuiltinRunner = ec_op_builtin.into();
 
@@ -1129,10 +1123,7 @@ mod tests {
 
     #[test]
     fn run_security_ec_op_check_memory_3_elements() {
-        let mut ec_op_builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
-
-        ec_op_builtin.cells_per_instance = 5;
-        ec_op_builtin.n_input_cells = 7;
+        let ec_op_builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
 
         let builtin: BuiltinRunner = ec_op_builtin.into();
 

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -1008,9 +1008,9 @@ mod tests {
     #[test]
     fn run_security_checks_for_output() {
         let builtin = BuiltinRunner::Output(OutputBuiltinRunner::new(true));
-        let mut vm = vm!();
+        let vm = vm!();
 
-        assert_eq!(builtin.run_security_checks(&mut vm), Ok(()));
+        assert_eq!(builtin.run_security_checks(&vm), Ok(()));
     }
 
     #[test]
@@ -1019,9 +1019,9 @@ mod tests {
             &BitwiseInstanceDef::default(),
             true,
         ));
-        let mut vm = vm!();
+        let vm = vm!();
         // Unsed builtin shouldnt fail security checks
-        assert_eq!(builtin.run_security_checks(&mut vm), Ok(()),);
+        assert_eq!(builtin.run_security_checks(&vm), Ok(()),);
     }
 
     #[test]
@@ -1031,10 +1031,10 @@ mod tests {
             builtin.base = -1;
             builtin
         });
-        let mut vm = vm!();
+        let vm = vm!();
 
         assert_eq!(
-            builtin.run_security_checks(&mut vm),
+            builtin.run_security_checks(&vm),
             Err(VirtualMachineError::NegBuiltinBase),
         );
     }
@@ -1049,7 +1049,7 @@ mod tests {
 
         vm.memory.data = vec![vec![]];
 
-        assert_eq!(builtin.run_security_checks(&mut vm), Ok(()));
+        assert_eq!(builtin.run_security_checks(&vm), Ok(()));
     }
 
     #[test]
@@ -1069,7 +1069,7 @@ mod tests {
         ]];
 
         assert_eq!(
-            builtin.run_security_checks(&mut vm),
+            builtin.run_security_checks(&vm),
             Err(MemoryError::MissingMemoryCellsWithOffsets("bitwise", vec![0],).into()),
         );
     }
@@ -1095,7 +1095,7 @@ mod tests {
         ]];
 
         assert_eq!(
-            builtin.run_security_checks(&mut vm),
+            builtin.run_security_checks(&vm),
             Err(MemoryError::MissingMemoryCells("bitwise").into()),
         );
     }
@@ -1115,7 +1115,7 @@ mod tests {
         ]];
 
         assert_eq!(
-            builtin.run_security_checks(&mut vm),
+            builtin.run_security_checks(&vm),
             Err(MemoryError::MissingMemoryCellsWithOffsets("hash", vec![0],).into()),
         );
     }
@@ -1131,7 +1131,7 @@ mod tests {
         vm.memory.data = vec![vec![mayberelocatable!(0, 0).into()]];
 
         assert_eq!(
-            builtin.run_security_checks(&mut vm),
+            builtin.run_security_checks(&vm),
             Err(MemoryError::MissingMemoryCells("hash").into()),
         );
     }
@@ -1154,7 +1154,7 @@ mod tests {
         ]];
 
         assert_eq!(
-            builtin.run_security_checks(&mut vm),
+            builtin.run_security_checks(&vm),
             Err(MemoryError::MissingMemoryCells("range_check").into()),
         );
     }
@@ -1168,7 +1168,7 @@ mod tests {
         vm.memory.data = vec![vec![None, mayberelocatable!(0).into()]];
 
         assert_eq!(
-            builtin.run_security_checks(&mut vm),
+            builtin.run_security_checks(&vm),
             Err(MemoryError::MissingMemoryCells("range_check").into()),
         );
     }
@@ -1183,7 +1183,7 @@ mod tests {
 
         vm.memory.data = vec![vec![None, None, None]];
 
-        assert_eq!(builtin.run_security_checks(&mut vm), Ok(()),);
+        assert_eq!(builtin.run_security_checks(&vm), Ok(()),);
     }
 
     #[test]
@@ -1204,7 +1204,7 @@ mod tests {
             mayberelocatable!(0, 4).into(),
         ]];
 
-        assert_eq!(builtin.run_security_checks(&mut vm), Ok(()));
+        assert_eq!(builtin.run_security_checks(&vm), Ok(()));
     }
 
     #[test]
@@ -1217,7 +1217,7 @@ mod tests {
         // The values stored in memory are not relevant for this test
         vm.memory.data = vec![vec![]];
 
-        assert_eq!(builtin.run_security_checks(&mut vm), Ok(()),);
+        assert_eq!(builtin.run_security_checks(&vm), Ok(()),);
     }
 
     #[test]
@@ -1231,7 +1231,7 @@ mod tests {
         vm.memory.data = vec![vec![mayberelocatable!(0).into()]];
 
         assert_eq!(
-            builtin.run_security_checks(&mut vm),
+            builtin.run_security_checks(&vm),
             Err(MemoryError::MissingMemoryCells("ec_op").into()),
         );
     }
@@ -1251,7 +1251,7 @@ mod tests {
         ]];
 
         assert_eq!(
-            builtin.run_security_checks(&mut vm),
+            builtin.run_security_checks(&vm),
             Err(MemoryError::MissingMemoryCells("ec_op").into()),
         );
     }
@@ -1273,7 +1273,7 @@ mod tests {
         ]];
 
         assert_eq!(
-            builtin.run_security_checks(&mut vm),
+            builtin.run_security_checks(&vm),
             Err(MemoryError::MissingMemoryCellsWithOffsets("ec_op", vec![0],).into()),
         );
     }
@@ -1302,7 +1302,7 @@ mod tests {
         ]];
 
         assert_eq!(
-            builtin.run_security_checks(&mut vm),
+            builtin.run_security_checks(&vm),
             Err(MemoryError::MissingMemoryCellsWithOffsets("ec_op", vec![7]).into()),
         );
     }

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -309,11 +309,8 @@ impl BuiltinRunner {
             Some(segment) => segment,
             None => return Ok(()),
         };
-        // The builtin segment's size is the maximum offset within the segment's addresses
-        let n = div_floor(builtin_segment.len(), cells_per_instance) + 1;
-        if n <= div_floor(builtin_segment.len(), n_input_cells) {
-            return Err(MemoryError::MissingMemoryCells(self.name()).into());
-        }
+        // The builtin segment's size - 1 is the maximum offset within the segment's addresses
+        let n = div_floor(builtin_segment.len() - 1, cells_per_instance) + 1;
         // Check that the two inputs (x and y) of each instance are set.
         let mut missing_offsets = Vec::with_capacity(n);
         // Check for missing expected offsets (either their address is no present, or their value is None)

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -310,7 +310,10 @@ impl BuiltinRunner {
             None => return Ok(()),
         };
         // The builtin segment's size - 1 is the maximum offset within the segment's addresses
-        let n = div_floor(builtin_segment.len() - 1, cells_per_instance) + 1;
+        let n = match builtin_segment.len() {
+            0 => 0,
+            size => div_floor(size - 1, cells_per_instance) + 1,
+        };
         // Check that the two inputs (x and y) of each instance are set.
         let mut missing_offsets = Vec::with_capacity(n);
         // Check for missing expected offsets (either their address is no present, or their value is None)

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -294,7 +294,7 @@ impl BuiltinRunner {
         }
     }
 
-    pub fn run_security_checks(&self, vm: &mut VirtualMachine) -> Result<(), VirtualMachineError> {
+    pub fn run_security_checks(&self, vm: &VirtualMachine) -> Result<(), VirtualMachineError> {
         if let BuiltinRunner::Output(_) = self {
             return Ok(());
         }

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -524,8 +524,8 @@ mod tests {
 
     #[test]
     fn get_n_input_cells_output() {
-        let signature = SignatureBuiltinRunner::new(&EcdsaInstanceDef::new(10), true);
-        let builtin: BuiltinRunner = signature.into();
+        let output = OutputBuiltinRunner::new(true);
+        let builtin: BuiltinRunner = output.into();
         assert_eq!(0, builtin.n_input_cells())
     }
 
@@ -566,9 +566,51 @@ mod tests {
 
     #[test]
     fn get_cells_per_instance_output() {
+        let output = OutputBuiltinRunner::new(true);
+        let builtin: BuiltinRunner = output.into();
+        assert_eq!(0, builtin.cells_per_instance())
+    }
+
+    #[test]
+    fn get_name_bitwise() {
+        let bitwise = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(10), true);
+        let builtin: BuiltinRunner = bitwise.into();
+        assert_eq!("bitwise", builtin.name())
+    }
+
+    #[test]
+    fn get_name_hash() {
+        let hash = HashBuiltinRunner::new(10, true);
+        let builtin: BuiltinRunner = hash.into();
+        assert_eq!("hash", builtin.name())
+    }
+
+    #[test]
+    fn get_name_range_check() {
+        let range_check = RangeCheckBuiltinRunner::new(10, 10, true);
+        let builtin: BuiltinRunner = range_check.into();
+        assert_eq!("range_check", builtin.name())
+    }
+
+    #[test]
+    fn get_name_ec_op() {
+        let ec_op = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
+        let builtin: BuiltinRunner = ec_op.into();
+        assert_eq!("ec_op", builtin.name())
+    }
+
+    #[test]
+    fn get_name_ecdsa() {
         let signature = SignatureBuiltinRunner::new(&EcdsaInstanceDef::new(10), true);
         let builtin: BuiltinRunner = signature.into();
-        assert_eq!(0, builtin.cells_per_instance())
+        assert_eq!("ecdsa", builtin.name())
+    }
+
+    #[test]
+    fn get_name_output() {
+        let output = OutputBuiltinRunner::new(true);
+        let builtin: BuiltinRunner = output.into();
+        assert_eq!("output", builtin.name())
     }
 
     #[test]

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -1171,10 +1171,7 @@ mod tests {
 
     #[test]
     fn run_security_ec_op_check_memory_gap() {
-        let mut ec_op_builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
-
-        ec_op_builtin.cells_per_instance = 5;
-        ec_op_builtin.n_input_cells = 7;
+        let ec_op_builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
 
         let builtin: BuiltinRunner = ec_op_builtin.into();
 
@@ -1191,6 +1188,8 @@ mod tests {
             None,
             mayberelocatable!(8).into(),
             mayberelocatable!(9).into(),
+            mayberelocatable!(10).into(),
+            mayberelocatable!(11).into(),
         ]];
 
         assert_eq!(

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -298,25 +298,19 @@ impl BuiltinRunner {
         if let BuiltinRunner::Output(_) = self {
             return Ok(());
         }
-
-        let (cells_per_instance, n_input_cells) = (
-            self.cells_per_instance() as usize,
-            self.n_input_cells() as usize,
-        );
-
+        let cells_per_instance = self.cells_per_instance() as usize;
+        let n_input_cells = self.n_input_cells() as usize;
         let builtin_segment_index = self
             .base()
             .to_usize()
             .ok_or(VirtualMachineError::NegBuiltinBase)?;
         // If the builtin's segment is empty, there are no security checks to run
-        let builtin_segment = if let Some(segment) = vm.memory.data.get(builtin_segment_index) {
-            segment
-        } else {
-            return Ok(());
+        let builtin_segment = match vm.memory.data.get(builtin_segment_index) {
+            Some(segment) => segment,
+            None => return Ok(()),
         };
-        // The builtin segment size is the maximum offset within the segment's addresses
-        let builtin_segment_size = builtin_segment.len();
-        let n = div_floor(builtin_segment_size, cells_per_instance + 1);
+        // The builtin segment's size is the maximum offset within the segment's addresses
+        let n = div_floor(builtin_segment.len(), cells_per_instance + 1);
         // Check that the two inputs (x and y) of each instance are set.
         let mut missing_offsets = Vec::with_capacity(n);
         // Check for missing expected offsets (either their address is no present, or their value is None)

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -310,7 +310,10 @@ impl BuiltinRunner {
             None => return Ok(()),
         };
         // The builtin segment's size is the maximum offset within the segment's addresses
-        let n = div_floor(builtin_segment.len(), cells_per_instance + 1);
+        let n = div_floor(builtin_segment.len(), cells_per_instance) + 1;
+        if n <= div_floor(builtin_segment.len(), n_input_cells) {
+            return Err(MemoryError::MissingMemoryCells(self.name()).into());
+        }
         // Check that the two inputs (x and y) of each instance are set.
         let mut missing_offsets = Vec::with_capacity(n);
         // Check for missing expected offsets (either their address is no present, or their value is None)

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -341,7 +341,7 @@ impl BuiltinRunner {
                 if let None | Some(None) = builtin_segment.get(offset) {
                     vm.verify_auto_deductions_for_addr(
                         &Relocatable::from((builtin_segment_index as isize, offset)),
-                        &self,
+                        self,
                     )?;
                 }
             }

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -306,8 +306,8 @@ impl BuiltinRunner {
             .ok_or(VirtualMachineError::NegBuiltinBase)?;
         // If the builtin's segment is empty, there are no security checks to run
         let builtin_segment = match vm.memory.data.get(builtin_segment_index) {
-            Some(segment) => segment,
-            None => return Ok(()),
+            Some(segment) if !segment.is_empty() => segment,
+            _ => return Ok(()),
         };
         // The builtin segment's size - 1 is the maximum offset within the segment's addresses
         // Assumption: The last element is not a None value

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -488,6 +488,90 @@ mod tests {
     }
 
     #[test]
+    fn get_n_input_cells_bitwise() {
+        let bitwise = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(10), true);
+        let builtin: BuiltinRunner = bitwise.clone().into();
+        assert_eq!(bitwise.n_input_cells, builtin.n_input_cells())
+    }
+
+    #[test]
+    fn get_n_input_cells_hash() {
+        let hash = HashBuiltinRunner::new(10, true);
+        let builtin: BuiltinRunner = hash.clone().into();
+        assert_eq!(hash.n_input_cells, builtin.n_input_cells())
+    }
+
+    #[test]
+    fn get_n_input_cells_range_check() {
+        let range_check = RangeCheckBuiltinRunner::new(10, 10, true);
+        let builtin: BuiltinRunner = range_check.clone().into();
+        assert_eq!(range_check.n_input_cells, builtin.n_input_cells())
+    }
+
+    #[test]
+    fn get_n_input_cells_ec_op() {
+        let ec_op = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
+        let builtin: BuiltinRunner = ec_op.clone().into();
+        assert_eq!(ec_op.n_input_cells, builtin.n_input_cells())
+    }
+
+    #[test]
+    fn get_n_input_cells_ecdsa() {
+        let signature = SignatureBuiltinRunner::new(&EcdsaInstanceDef::new(10), true);
+        let builtin: BuiltinRunner = signature.clone().into();
+        assert_eq!(signature.n_input_cells, builtin.n_input_cells())
+    }
+
+    #[test]
+    fn get_n_input_cells_output() {
+        let signature = SignatureBuiltinRunner::new(&EcdsaInstanceDef::new(10), true);
+        let builtin: BuiltinRunner = signature.into();
+        assert_eq!(0, builtin.n_input_cells())
+    }
+
+    #[test]
+    fn get_cells_per_instance_bitwise() {
+        let bitwise = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(10), true);
+        let builtin: BuiltinRunner = bitwise.clone().into();
+        assert_eq!(bitwise.cells_per_instance, builtin.cells_per_instance())
+    }
+
+    #[test]
+    fn get_cells_per_instance_hash() {
+        let hash = HashBuiltinRunner::new(10, true);
+        let builtin: BuiltinRunner = hash.clone().into();
+        assert_eq!(hash.cells_per_instance, builtin.cells_per_instance())
+    }
+
+    #[test]
+    fn get_cells_per_instance_range_check() {
+        let range_check = RangeCheckBuiltinRunner::new(10, 10, true);
+        let builtin: BuiltinRunner = range_check.clone().into();
+        assert_eq!(range_check.cells_per_instance, builtin.cells_per_instance())
+    }
+
+    #[test]
+    fn get_cells_per_instance_ec_op() {
+        let ec_op = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
+        let builtin: BuiltinRunner = ec_op.clone().into();
+        assert_eq!(ec_op.cells_per_instance, builtin.cells_per_instance())
+    }
+
+    #[test]
+    fn get_cells_per_instance_ecdsa() {
+        let signature = SignatureBuiltinRunner::new(&EcdsaInstanceDef::new(10), true);
+        let builtin: BuiltinRunner = signature.clone().into();
+        assert_eq!(signature.cells_per_instance, builtin.cells_per_instance())
+    }
+
+    #[test]
+    fn get_cells_per_instance_output() {
+        let signature = SignatureBuiltinRunner::new(&EcdsaInstanceDef::new(10), true);
+        let builtin: BuiltinRunner = signature.into();
+        assert_eq!(0, builtin.cells_per_instance())
+    }
+
+    #[test]
     fn get_allocated_memory_units_bitwise_with_items() {
         let builtin = BuiltinRunner::Bitwise(BitwiseBuiltinRunner::new(
             &BitwiseInstanceDef::new(10),

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -322,7 +322,7 @@ impl BuiltinRunner {
         // Check for missing expected offsets (either their address is no present, or their value is None)
         for i in 0..n {
             for j in 0..n_input_cells {
-                let offset = cells_per_instance * n + j;
+                let offset = cells_per_instance * i + j;
                 if let None | Some(None) = builtin_segment.get(offset) {
                     missing_offsets.push(offset)
                 }
@@ -337,7 +337,7 @@ impl BuiltinRunner {
         // Assigned output cells are checked as part of the call to verify_auto_deductions().
         for i in 0..n {
             for j in n_input_cells..cells_per_instance {
-                let offset = cells_per_instance * n + j;
+                let offset = cells_per_instance * i + j;
                 if let None | Some(None) = builtin_segment.get(offset) {
                     vm.verify_auto_deductions_for_addr(
                         &Relocatable::from((builtin_segment_index as isize, offset)),

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -4124,7 +4124,7 @@ mod tests {
         assert_eq!(
             cairo_runner.run_from_entrypoint(
                 main_entrypoint,
-                &vec![
+                &[
                     &mayberelocatable!(2).into(),
                     &MaybeRelocatable::from((2, 0)).into()
                 ], //range_check_ptr
@@ -4153,7 +4153,7 @@ mod tests {
         assert_eq!(
             new_cairo_runner.run_from_entrypoint(
                 fib_entrypoint,
-                &vec![
+                &[
                     &mayberelocatable!(2).into(),
                     &MaybeRelocatable::from((2, 0)).into()
                 ],

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -3340,6 +3340,35 @@ mod tests {
 
     #[test]
     /* Program used:
+    %builtins bitwise
+    from starkware.cairo.common.bitwise import bitwise_and
+    from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
+
+
+    func main{bitwise_ptr: BitwiseBuiltin*}():
+        let (result) = bitwise_and(12, 10)  # Binary (1100, 1010).
+        assert result = 8  # Binary 1000.
+        return()
+    end
+    */
+    fn verify_auto_deductions_for_addr_bitwise() {
+        let mut builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default(), true);
+        builtin.base = 2;
+        let builtin: BuiltinRunner = builtin.into();
+        let mut vm = vm!();
+        vm.memory = memory![((2, 0), 12), ((2, 1), 10)];
+        assert_eq!(
+            vm.verify_auto_deductions_for_addr(&relocatable!(2, 0), &builtin),
+            Ok(())
+        );
+        assert_eq!(
+            vm.verify_auto_deductions_for_addr(&relocatable!(2, 1), &builtin),
+            Ok(())
+        );
+    }
+
+    #[test]
+    /* Program used:
     %builtins output pedersen
     from starkware.cairo.common.cairo_builtins import HashBuiltin
     from starkware.cairo.common.hash import hash2


### PR DESCRIPTION
- Refactor method `BuiltinRunner::run_security_checks` to be clearer and reduce inconsistencies with source code
- Add convenience methods `BuiltinRunner::input_cells`, `BuiltinRunner::cells_per_instance`,  `BuiltinRunner::name` & `VirtualMachine::verify_auto_deductions_for_addr`
- Add tests for new methods and adapt existing tests for the modified method

Notes:
After the refactor of `BuiltinRunner::run_security_checks`, some tests had to be changed as the functionality changed. In order to check that each change was valid, I compared the test to a modified version of the [source implementation](https://github.com/starkware-libs/cairo-lang/blob/de741b92657f245a50caab99cfaef093152fd8be/src/starkware/cairo/lang/vm/builtin_runner.py#L257) using the test's hardcoded values.
An assumption was made in order to simplify the code: builtin's memory segments don't contain trailing None values.
The reason for this assumption is that trailing none values don't occur naturally in the Vm .None values are a product of  inserting elements(in which case None values are always before an existing element), and there is no public interface that would allow inserting a None value separately.
If the memory was  tampered with, and there were trailing None values, the security checks would fail.
This is an internal refactor without changes to the public interface
