### PR TITLE
get_used_diluted_check_units units test, more negative test coverage

### DIFF
--- a/src/vm/runners/builtin_runner/keccak.rs
+++ b/src/vm/runners/builtin_runner/keccak.rs
@@ -265,7 +265,6 @@ mod tests {
         runners::builtin_runner::BuiltinRunner,
         vm_core::VirtualMachine,
     };
-    use felt::NewFelt;
     use std::path::Path;
 
     #[test]


### PR DESCRIPTION
Issue https://github.com/lambdaclass/cairo-rs/issues/749

Adds 5 more unit tests to the keccak builtin file. One tests `get_used_diluted_check_units`. The other does more negative testing on `deduce_memory_cell` which had some line not covered by a test.

No integration tests added.
No changes to documentation needed.
