### PR TITLE
feat: add missing 'cairo_type' for Identifier

### DIFF
--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -1279,147 +1279,31 @@ mod tests {
 
     #[test]
     fn deserialize_program_with_type_definition() {
-        let valid_json = r#"{
-            "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
-            "attributes": [],
-            "debug_info": {
-                "instruction_locations": {}
-            },  
-            "builtins": [],
-            "data": [
-            ],
-            "identifiers": {
-                "__main__.a": {
-                    "decorators": [],
-                    "pc": 0,
-                    "type": "function"
-                },
-                "__main__.a.Args": {
-                    "full_name": "__main__.a.Args",
-                    "members": {},
-                    "size": 0,
-                    "type": "struct"
-                },
-                "__main__.a.ImplicitArgs": {
-                    "full_name": "__main__.a.ImplicitArgs",
-                    "members": {},
-                    "size": 0,
-                    "type": "struct"
-                },
-                "__main__.a.Return": {
-                    "cairo_type": "(b: felt)",
-                    "type": "type_definition"
-                },
-                "__main__.a.SIZEOF_LOCALS": {
-                    "type": "const",
-                    "value": 0
-                },
-                "__main__.main": {
-                    "decorators": [],
-                    "pc": 13,
-                    "type": "function"
-                },
-                "__main__.main.Args": {
-                    "full_name": "__main__.main.Args",
-                    "members": {},
-                    "size": 0,
-                    "type": "struct"
-                },
-                "__main__.main.ImplicitArgs": {
-                    "full_name": "__main__.main.ImplicitArgs",
-                    "members": {},
-                    "size": 0,
-                    "type": "struct"
-                },
-                "__main__.main.Return": {
-                    "cairo_type": "()",
-                    "type": "type_definition"
-                },
-                "__main__.main.SIZEOF_LOCALS": {
-                    "type": "const",
-                    "value": 0
-                },
-                "__main__.multi": {
-                    "decorators": [],
-                    "pc": 3,
-                    "type": "function"
-                },
-                "__main__.multi.Args": {
-                    "full_name": "__main__.multi.Args",
-                    "members": {},
-                    "size": 0,
-                    "type": "struct"
-                },
-                "__main__.multi.ImplicitArgs": {
-                    "full_name": "__main__.multi.ImplicitArgs",
-                    "members": {},
-                    "size": 0,
-                    "type": "struct"
-                },
-                "__main__.multi.Return": {
-                    "cairo_type": "(a: felt, b: felt)",
-                    "type": "type_definition"
-                },
-                "__main__.multi.SIZEOF_LOCALS": {
-                    "type": "const",
-                    "value": 0
-                },
-                "__main__.multi_noname": {
-                    "decorators": [],
-                    "pc": 8,
-                    "type": "function"
-                },
-                "__main__.multi_noname.Args": {
-                    "full_name": "__main__.multi_noname.Args",
-                    "members": {},
-                    "size": 0,
-                    "type": "struct"
-                },
-                "__main__.multi_noname.ImplicitArgs": {
-                    "full_name": "__main__.multi_noname.ImplicitArgs",
-                    "members": {},
-                    "size": 0,
-                    "type": "struct"
-                },
-                "__main__.multi_noname.Return": {
-                    "cairo_type": "(felt, felt)",
-                    "type": "type_definition"
-                },
-                "__main__.multi_noname.SIZEOF_LOCALS": {
-                    "type": "const",
-                    "value": 0
-                }
-            },
-            "hints": {
-            },
-            "reference_manager": {
-                "references": []
-            }
-        }
-        "#;
+        let file = File::open("cairo_programs/uint256_integration_tests.json").unwrap();
+        let reader = BufReader::new(file);
 
-        let program_json: ProgramJson = serde_json::from_str(valid_json).unwrap();
+        let program_json: ProgramJson = serde_json::from_reader(reader).unwrap();
 
         assert_eq!(
-            program_json.identifiers["__main__.a.Return"]
+            program_json.identifiers["starkware.cairo.common.alloc.alloc.Return"]
                 .cairo_type
                 .as_ref()
                 .expect("key not found"),
-            "(b: felt)"
+            "(ptr: felt*)"
         );
         assert_eq!(
-            program_json.identifiers["__main__.multi.Return"]
+            program_json.identifiers["starkware.cairo.common.uint256.uint256_add.Return"]
                 .cairo_type
                 .as_ref()
                 .expect("key not found"),
-            "(a: felt, b: felt)"
+            "(res: starkware.cairo.common.uint256.Uint256, carry: felt)"
         );
         assert_eq!(
-            program_json.identifiers["__main__.multi_noname.Return"]
+            program_json.identifiers["__main__.test_unsigned_div_rem.Return"]
                 .cairo_type
                 .as_ref()
                 .expect("key not found"),
-            "(felt, felt)"
+            "()"
         );
     }
 }

--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -70,6 +70,7 @@ pub struct Identifier {
 
     pub full_name: Option<String>,
     pub members: Option<HashMap<String, Member>>,
+    pub cairo_type: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -852,6 +853,7 @@ mod tests {
                 value: None,
                 full_name: None,
                 members: None,
+                cairo_type: None,
             },
         );
         identifiers.insert(
@@ -864,6 +866,7 @@ mod tests {
                 )),
                 full_name: None,
                 members: None,
+                cairo_type: None,
             },
         );
         identifiers.insert(
@@ -874,6 +877,7 @@ mod tests {
                 value: None,
                 full_name: None,
                 members: None,
+                cairo_type: None,
             },
         );
         identifiers.insert(
@@ -886,6 +890,7 @@ mod tests {
                 )),
                 full_name: None,
                 members: None,
+                cairo_type: None,
             },
         );
         identifiers.insert(
@@ -896,6 +901,7 @@ mod tests {
                 value: Some(Felt::new(3)),
                 full_name: None,
                 members: None,
+                cairo_type: None,
             },
         );
         identifiers.insert(
@@ -906,6 +912,7 @@ mod tests {
                 value: Some(Felt::zero()),
                 full_name: None,
                 members: None,
+                cairo_type: None,
             },
         );
         identifiers.insert(
@@ -916,6 +923,7 @@ mod tests {
                 value: Some(felt_str!("340282366920938463463374607431768211456")),
                 full_name: None,
                 members: None,
+                cairo_type: None,
             },
         );
 
@@ -1267,5 +1275,151 @@ mod tests {
         ) };
 
         assert_eq!(program_json.debug_info, Some(debug_info));
+    }
+
+    #[test]
+    fn deserialize_program_with_type_definition() {
+        let valid_json = r#"{
+            "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
+            "attributes": [],
+            "debug_info": {
+                "instruction_locations": {}
+            },  
+            "builtins": [],
+            "data": [
+            ],
+            "identifiers": {
+                "__main__.a": {
+                    "decorators": [],
+                    "pc": 0,
+                    "type": "function"
+                },
+                "__main__.a.Args": {
+                    "full_name": "__main__.a.Args",
+                    "members": {},
+                    "size": 0,
+                    "type": "struct"
+                },
+                "__main__.a.ImplicitArgs": {
+                    "full_name": "__main__.a.ImplicitArgs",
+                    "members": {},
+                    "size": 0,
+                    "type": "struct"
+                },
+                "__main__.a.Return": {
+                    "cairo_type": "(b: felt)",
+                    "type": "type_definition"
+                },
+                "__main__.a.SIZEOF_LOCALS": {
+                    "type": "const",
+                    "value": 0
+                },
+                "__main__.main": {
+                    "decorators": [],
+                    "pc": 13,
+                    "type": "function"
+                },
+                "__main__.main.Args": {
+                    "full_name": "__main__.main.Args",
+                    "members": {},
+                    "size": 0,
+                    "type": "struct"
+                },
+                "__main__.main.ImplicitArgs": {
+                    "full_name": "__main__.main.ImplicitArgs",
+                    "members": {},
+                    "size": 0,
+                    "type": "struct"
+                },
+                "__main__.main.Return": {
+                    "cairo_type": "()",
+                    "type": "type_definition"
+                },
+                "__main__.main.SIZEOF_LOCALS": {
+                    "type": "const",
+                    "value": 0
+                },
+                "__main__.multi": {
+                    "decorators": [],
+                    "pc": 3,
+                    "type": "function"
+                },
+                "__main__.multi.Args": {
+                    "full_name": "__main__.multi.Args",
+                    "members": {},
+                    "size": 0,
+                    "type": "struct"
+                },
+                "__main__.multi.ImplicitArgs": {
+                    "full_name": "__main__.multi.ImplicitArgs",
+                    "members": {},
+                    "size": 0,
+                    "type": "struct"
+                },
+                "__main__.multi.Return": {
+                    "cairo_type": "(a: felt, b: felt)",
+                    "type": "type_definition"
+                },
+                "__main__.multi.SIZEOF_LOCALS": {
+                    "type": "const",
+                    "value": 0
+                },
+                "__main__.multi_noname": {
+                    "decorators": [],
+                    "pc": 8,
+                    "type": "function"
+                },
+                "__main__.multi_noname.Args": {
+                    "full_name": "__main__.multi_noname.Args",
+                    "members": {},
+                    "size": 0,
+                    "type": "struct"
+                },
+                "__main__.multi_noname.ImplicitArgs": {
+                    "full_name": "__main__.multi_noname.ImplicitArgs",
+                    "members": {},
+                    "size": 0,
+                    "type": "struct"
+                },
+                "__main__.multi_noname.Return": {
+                    "cairo_type": "(felt, felt)",
+                    "type": "type_definition"
+                },
+                "__main__.multi_noname.SIZEOF_LOCALS": {
+                    "type": "const",
+                    "value": 0
+                }
+            },
+            "hints": {
+            },
+            "reference_manager": {
+                "references": []
+            }
+        }
+        "#;
+
+        let program_json: ProgramJson = serde_json::from_str(valid_json).unwrap();
+
+        assert_eq!(
+            program_json.identifiers["__main__.a.Return"]
+                .cairo_type
+                .as_ref()
+                .expect("key not found"),
+            "(b: felt)"
+        );
+        assert_eq!(
+            program_json.identifiers["__main__.multi.Return"]
+                .cairo_type
+                .as_ref()
+                .expect("key not found"),
+            "(a: felt, b: felt)"
+        );
+        assert_eq!(
+            program_json.identifiers["__main__.multi_noname.Return"]
+                .cairo_type
+                .as_ref()
+                .expect("key not found"),
+            "(felt, felt)"
+        );
     }
 }

--- a/src/types/program.rs
+++ b/src/types/program.rs
@@ -178,6 +178,7 @@ mod tests {
                 value: None,
                 full_name: None,
                 members: None,
+                cairo_type: None,
             },
         );
 
@@ -189,6 +190,7 @@ mod tests {
                 value: Some(Felt::zero()),
                 full_name: None,
                 members: None,
+                cairo_type: None,
             },
         );
 
@@ -245,6 +247,7 @@ mod tests {
                 value: None,
                 full_name: None,
                 members: None,
+                cairo_type: None,
             },
         );
 
@@ -256,6 +259,7 @@ mod tests {
                 value: None,
                 full_name: None,
                 members: None,
+                cairo_type: None,
             },
         );
 
@@ -302,6 +306,7 @@ mod tests {
                 value: None,
                 full_name: None,
                 members: None,
+                cairo_type: None,
             },
         );
         identifiers.insert(
@@ -312,6 +317,7 @@ mod tests {
                 value: None,
                 full_name: Some("__main__.main.Args".to_string()),
                 members: Some(HashMap::new()),
+                cairo_type: None,
             },
         );
         identifiers.insert(
@@ -322,6 +328,7 @@ mod tests {
                 value: None,
                 full_name: Some("__main__.main.ImplicitArgs".to_string()),
                 members: Some(HashMap::new()),
+                cairo_type: None,
             },
         );
         identifiers.insert(
@@ -332,6 +339,7 @@ mod tests {
                 value: None,
                 full_name: Some("__main__.main.Return".to_string()),
                 members: Some(HashMap::new()),
+                cairo_type: None,
             },
         );
         identifiers.insert(
@@ -342,6 +350,7 @@ mod tests {
                 value: Some(Felt::zero()),
                 full_name: None,
                 members: None,
+                cairo_type: None,
             },
         );
 
@@ -396,6 +405,7 @@ mod tests {
                 value: None,
                 full_name: None,
                 members: None,
+                cairo_type: None,
             },
         );
         identifiers.insert(
@@ -406,6 +416,7 @@ mod tests {
                 value: None,
                 full_name: Some("__main__.main.Args".to_string()),
                 members: Some(HashMap::new()),
+                cairo_type: None,
             },
         );
         identifiers.insert(
@@ -416,6 +427,7 @@ mod tests {
                 value: None,
                 full_name: Some("__main__.main.ImplicitArgs".to_string()),
                 members: Some(HashMap::new()),
+                cairo_type: None,
             },
         );
         identifiers.insert(
@@ -426,6 +438,7 @@ mod tests {
                 value: None,
                 full_name: Some("__main__.main.Return".to_string()),
                 members: Some(HashMap::new()),
+                cairo_type: None,
             },
         );
         identifiers.insert(
@@ -436,6 +449,7 @@ mod tests {
                 value: Some(Felt::zero()),
                 full_name: None,
                 members: None,
+                cairo_type: None,
             },
         );
 

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -3918,6 +3918,7 @@ mod tests {
                 value: None,
                 full_name: None,
                 members: None,
+                cairo_type: None,
             },
         )]
         .into_iter()
@@ -3944,6 +3945,7 @@ mod tests {
                     value: None,
                     full_name: None,
                     members: None,
+                    cairo_type: None,
                 },
             ),
             (
@@ -3954,6 +3956,7 @@ mod tests {
                     value: None,
                     full_name: None,
                     members: None,
+                    cairo_type: None,
                 },
             ),
         ]
@@ -3981,6 +3984,7 @@ mod tests {
                 value: None,
                 full_name: None,
                 members: None,
+                cairo_type: None,
             },
         )]
         .into_iter()


### PR DESCRIPTION
In cairo compiled program, funtion returned values types is stored in `cairo_type` key.

# Add `cairo_type` for Identifier

## Description

This pull request add missing `cairo_type` field for `serde::deserialize_program::Identifier`

In a cairo compiled program, each function have an identifier with key `{symbol}.Return`  which contains function output parameter signature in `cairo_type` key.

For instance a cairo function such as:
```
func multi{}() -> (a: felt, b: felt) {
    return (42,7,);
}
```
will have the following identifier in cairo compiled program JSON output:
```
        "__main__.multi.Return": {
            "cairo_type": "(a: felt, b: felt)",
            "type": "type_definition"
        },
```

Using this `cairo_type` information, we can compute function returns size and ensure that mocked value have the same size.

[cairo-foundry related issue](https://github.com/open-dust/cairo-foundry/issues/98)


## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
- [ ] Documentation has been added/updated.
