### PR TITLE
Make `ProgramError` & `CairoRunError` implement `PartialEq`

### DIFF
--- a/src/types/errors/program_errors.rs
+++ b/src/types/errors/program_errors.rs
@@ -1,19 +1,41 @@
+use std::{fmt::Debug, io};
+
 use felt::PRIME_STR;
-use std::io;
 use thiserror::Error;
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 pub enum ProgramError {
-    #[error(transparent)]
-    IO(#[from] io::Error),
-    #[error(transparent)]
-    Parse(#[from] serde_json::Error),
+    #[error("{0}")]
+    Io(String),
+    #[error("{0}")]
+    Syntax(String),
+    #[error("{0}")]
+    Data(String),
+    #[error("{0}")]
+    Eof(String),
     #[error("Entrypoint {0} not found")]
     EntrypointNotFound(String),
     #[error("Constant {0} has no value")]
     ConstWithoutValue(String),
     #[error("Expected prime {PRIME_STR}, got {0}")]
     PrimeDiffers(String),
+}
+
+impl From<serde_json::Error> for ProgramError {
+    fn from(error: serde_json::Error) -> ProgramError {
+        match error.classify() {
+            serde_json::error::Category::Io => ProgramError::Io(error.to_string()),
+            serde_json::error::Category::Syntax => ProgramError::Syntax(error.to_string()),
+            serde_json::error::Category::Data => ProgramError::Data(error.to_string()),
+            serde_json::error::Category::Eof => ProgramError::Eof(error.to_string()),
+        }
+    }
+}
+
+impl From<io::Error> for ProgramError {
+    fn from(error: io::Error) -> ProgramError {
+        ProgramError::Io(error.to_string())
+    }
 }
 
 #[cfg(test)]

--- a/src/vm/errors/cairo_run_errors.rs
+++ b/src/vm/errors/cairo_run_errors.rs
@@ -6,7 +6,7 @@ use crate::vm::errors::{
 };
 use thiserror::Error;
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 pub enum CairoRunError {
     #[error(transparent)]
     Program(#[from] ProgramError),


### PR DESCRIPTION
This PR aims to make the CairoRunError more user-friendly by making sure it implements PartialEq