### PR TITLE
Cache all Cairo programs in Rust workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,7 +60,7 @@ jobs:
           cairo_programs/*/*.memory
           cairo_programs/*/*.trace
           !cairo_programs/*/*.rs.*
-        key: cairo-cache-${{ hashFiles( cairo_programs/*.cairo cairo_programs/*/*.cairo ) }}
+        key: cairo-cache-${{ hashFiles( 'cairo_programs/*.cairo', 'cairo_programs/*/*.cairo' ) }}
         restore-keys: cairo-cache-
     - name: Restore timestamps
       uses: chetan/git-restore-mtime-action@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,11 +52,15 @@ jobs:
       id: cache-cairo-programs
       with:
         path: |
-          **.json
-          **.memory
-          **.trace
-          !**.rs.*
-        key: cairo-cache-${{ hashFiles( **.cairo ) }}
+          cairo_programs/*.json
+          cairo_programs/*.memory
+          cairo_programs/*.trace
+          !cairo_programs/*.rs.*
+          cairo_programs/*/*.json
+          cairo_programs/*/*.memory
+          cairo_programs/*/*.trace
+          !cairo_programs/*/*.rs.*
+        key: cairo-cache-${{ hashFiles( cairo_programs/*.cairo cairo_programs/*/*.cairo ) }}
         restore-keys: cairo-cache-
     - name: Restore timestamps
       uses: chetan/git-restore-mtime-action@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,11 +52,11 @@ jobs:
       id: cache-cairo-programs
       with:
         path: |
-          cairo_programs/**.json
-          cairo_programs/**.memory
-          cairo_programs/**.trace
-          !cairo_programs/**.rs.*
-        key: cairo-cache-${{ hashFiles( 'cairo_programs/**.cairo' ) }}
+          **.json
+          **.memory
+          **.trace
+          !**.rs.*
+        key: cairo-cache-${{ hashFiles( '**.cairo' ) }}
     - name: Restore timestamps
       uses: chetan/git-restore-mtime-action@v1
     - name: Install dependencies

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,6 +57,7 @@ jobs:
           **.trace
           !**.rs.*
         key: cairo-cache-${{ hashFiles( '**.cairo' ) }}
+        restore-keys: cairo-cache-
     - name: Restore timestamps
       uses: chetan/git-restore-mtime-action@v1
     - name: Install dependencies

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,7 +56,7 @@ jobs:
           **.memory
           **.trace
           !**.rs.*
-        key: cairo-cache-${{ hashFiles( '**.cairo' ) }}
+        key: cairo-cache-${{ hashFiles( **.cairo ) }}
         restore-keys: cairo-cache-
     - name: Restore timestamps
       uses: chetan/git-restore-mtime-action@v1


### PR DESCRIPTION
Lowers build times from <30' to about 5' for the Rust workflow by caching compiled cairo programs and the results of running them with cairo-lang, as they should not change unless we change the source files.

Future improvements:
- Single cache for all workflows.
- Parallel creation.