### PR TITLE
Fix `BuiltinRunner::final_stack` and remove quick fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Fix `BuiltinRunner::final_stack` and remove quick fix [#778](https://github.com/lambdaclass/cairo-rs/pull/778)
     * Public Api changes:
         * Various changes to public `BuiltinRunner` method's signatures:
-            * `final_stack(&self, vm: &VirtualMachine, pointer: Relocatable) -> Result<(Relocatable, usize), RunnerError>` to `final_stack(&mut self, segments: &MemorySegmentManager, memory: &Memory, pointer: Relocatable, ) -> Result<Relocatable,RunnerError>`.
+            * `final_stack(&self, vm: &VirtualMachine, pointer: Relocatable) -> Result<(Relocatable, usize), RunnerError>` to `final_stack(&mut self, segments: &MemorySegmentManager, memory: &Memory, pointer: Relocatable) -> Result<Relocatable,RunnerError>`.
             * `get_used_cells(&self, vm: &VirtualMachine) -> Result<usize, MemoryError>` to  `get_used_cells(&self, segments: &MemorySegmentManager) -> Result<usize, MemoryError>`.
             * `get_used_instances(&self, vm: &VirtualMachine) -> Result<usize, MemoryError>` to `get_used_instances(&self, segments: &MemorySegmentManager) -> Result<usize, MemoryError>`.
     * Bugfixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
         * Various changes to public `BuiltinRunner` method's signatures:
             * `final_stack(&self, vm: &VirtualMachine, pointer: Relocatable) -> Result<(Relocatable, usize), RunnerError>` to `final_stack(&mut self, segments: &MemorySegmentManager, memory: &Memory, pointer: Relocatable, ) -> Result<Relocatable,RunnerError>`.
             * `get_used_cells(&self, vm: &VirtualMachine) -> Result<usize, MemoryError>` to  `get_used_cells(&self, segments: &MemorySegmentManager) -> Result<usize, MemoryError>`.
-            * `pub fn get_used_instances(&self, vm: &VirtualMachine) -> Result<usize, MemoryError>` to `get_used_instances(&self, segments: &MemorySegmentManager) -> Result<usize, MemoryError>`.
+            * `get_used_instances(&self, vm: &VirtualMachine) -> Result<usize, MemoryError>` to `get_used_instances(&self, segments: &MemorySegmentManager) -> Result<usize, MemoryError>`.
     * Bugfixes:
         * `BuiltinRunner::final_stack` now updates the builtin's stop_ptr instead of returning it. This replaces the bugfix on PR #768.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,30 +1,32 @@
 ## Cairo-VM Changelog
 
 #### Upcoming Changes
+
+* Fix `BuiltinRunner::final_stack` and remove quick fix [#778](https://github.com/lambdaclass/cairo-rs/pull/778)
+    * Public Api changes:
+        * Various changes to public `BuiltinRunner` method's signatures:
+            * `final_stack(&self, vm: &VirtualMachine, pointer: Relocatable) -> Result<(Relocatable, usize), RunnerError>` to `final_stack(&mut self, segments: &MemorySegmentManager, memory: &Memory, pointer: Relocatable, ) -> Result<Relocatable,RunnerError>`.
+            * `get_used_cells(&self, vm: &VirtualMachine) -> Result<usize, MemoryError>` to  `get_used_cells(&self, segments: &MemorySegmentManager) -> Result<usize, MemoryError>`.
+            * `pub fn get_used_instances(&self, vm: &VirtualMachine) -> Result<usize, MemoryError>` to `get_used_instances(&self, segments: &MemorySegmentManager) -> Result<usize, MemoryError>`.
+    * Bugfixes:
+        * `BuiltinRunner::final_stack` now updates the builtin's stop_ptr instead of returning it. This replaces the bugfix on PR #768.
+
 * Add secure_run flag + integrate verify_secure_runner into cairo-run [#771](https://github.com/lambdaclass/cairo-rs/pull/777)
-    Public Api changes:
-    * Add command_line argument `secure_run`
-    * Add argument `secure_run: Option<bool>` to `cairo_run`
-    * `verify_secure_runner` is now called inside `cairo-run` when `secure_run` is set to true or when it not set and the run is not on `proof_mode`
-    Bugfixes:
-    * `EcOpBuiltinRunner::deduce_memory_cell` now checks that both points are on the curve instead of only the first one
-    * `EcOpBuiltinRunner::deduce_memory_cell` now returns the values of the point coordinates instead of the indices when a `PointNotOnCurve` error is returned
+    * Public Api changes:
+        * Add command_line argument `secure_run`
+        * Add argument `secure_run: Option<bool>` to `cairo_run`
+        * `verify_secure_runner` is now called inside `cairo-run` when `secure_run` is set to true or when it not set and the run is not on `proof_mode`
+    * Bugfixes:
+        * `EcOpBuiltinRunner::deduce_memory_cell` now checks that both points are on the curve instead of only the first one
+        * `EcOpBuiltinRunner::deduce_memory_cell` now returns the values of the point coordinates instead of the indices when a `PointNotOnCurve` error is returned
 
 * Refactor `Refactor verify_secure_runner` [#768](https://github.com/lambdaclass/cairo-rs/pull/768)
-    Public Api changes:
-    * Remove builtin name from the return value of `BuiltinRunner::get_memory_segment_addresses`
-    * Simplify the return value of `CairoRunner::get_builtin_segments_info` to `Vec<(usize, usize)>`
-    * CairoRunner::read_return_values now receives a mutable reference to VirtualMachine
-    Bugfixes:
-    * CairoRunner::read_return_values now updates the `stop_ptr` of each builtin after calling `BuiltinRunner::final_stack`
-
-* Refactor `Refactor verify_secure_runner` [#768](https://github.com/lambdaclass/cairo-rs/pull/768)
-    Public Api changes:
-    * Remove builtin name from the return value of `BuiltinRunner::get_memory_segment_addresses`
-    * Simplify the return value of `CairoRunner::get_builtin_segments_info` to `Vec<(usize, usize)>`
-    * CairoRunner::read_return_values now receives a mutable reference to VirtualMachine
-    Bugfixes:
-    * CairoRunner::read_return_values now updates the `stop_ptr` of each builtin after calling `BuiltinRunner::final_stack`
+    * Public Api changes:
+        * Remove builtin name from the return value of `BuiltinRunner::get_memory_segment_addresses`
+        * Simplify the return value of `CairoRunner::get_builtin_segments_info` to `Vec<(usize, usize)>`
+        * CairoRunner::read_return_values now receives a mutable reference to VirtualMachine
+    * Bugfixes:
+        * CairoRunner::read_return_values now updates the `stop_ptr` of each builtin after calling `BuiltinRunner::final_stack`
 
 * Use CairoArg enum instead of Any in CairoRunner::run_from_entrypoint [#686](https://github.com/lambdaclass/cairo-rs/pull/686)
     * Public Api changes:

--- a/src/types/instance_definitions/builtins_instance_def.rs
+++ b/src/types/instance_definitions/builtins_instance_def.rs
@@ -84,7 +84,7 @@ impl BuiltinsInstanceDef {
             _ecdsa: None,
             bitwise: Some(BitwiseInstanceDef::new(16)),
             ec_op: None,
-            keccak: Some(KeccakInstanceDef::new(2048)),
+            keccak: Some(KeccakInstanceDef::new(2048, vec![200; 8])),
         }
     }
 

--- a/src/types/instance_definitions/keccak_instance_def.rs
+++ b/src/types/instance_definitions/keccak_instance_def.rs
@@ -17,9 +17,10 @@ impl Default for KeccakInstanceDef {
 }
 
 impl KeccakInstanceDef {
-    pub(crate) fn new(_ratio: u32) -> Self {
+    pub(crate) fn new(_ratio: u32, _state_rep: Vec<u32>) -> Self {
         Self {
             _ratio,
+            _state_rep,
             ..Default::default()
         }
     }
@@ -56,7 +57,7 @@ mod tests {
             _state_rep: vec![200; 8],
             _instance_per_component: 16,
         };
-        assert_eq!(KeccakInstanceDef::new(2048), builtin_instance);
+        assert_eq!(KeccakInstanceDef::new(2048, vec![200; 8]), builtin_instance);
     }
 
     #[test]

--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -262,7 +262,9 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin.final_stack(&mut vm, pointer).unwrap(),
+            builtin
+                .final_stack(&vm.segments, &vm.memory, pointer)
+                .unwrap(),
             Relocatable::from((2, 1))
         );
     }
@@ -285,7 +287,7 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin.final_stack(&vm, pointer),
+            builtin.final_stack(&vm.segments, &vm.memory, pointer),
             Err(RunnerError::InvalidStopPointer("bitwise".to_string()))
         );
     }
@@ -308,7 +310,9 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin.final_stack(&mut vm, pointer).unwrap(),
+            builtin
+                .final_stack(&vm.segments, &vm.memory, pointer)
+                .unwrap(),
             Relocatable::from((2, 2))
         );
     }
@@ -331,7 +335,7 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin.final_stack(&vm, pointer),
+            builtin.final_stack(&vm.segments, &vm.memory, pointer),
             Err(RunnerError::FinalStack)
         );
     }
@@ -527,7 +531,7 @@ mod tests {
         let vm = vm!();
 
         assert_eq!(
-            builtin.get_used_cells(&vm),
+            builtin.get_used_cells(&vm.segments),
             Err(MemoryError::MissingSegmentUsedSizes)
         );
     }
@@ -541,7 +545,7 @@ mod tests {
         let mut vm = vm!();
 
         vm.segments.segment_used_sizes = Some(vec![0]);
-        assert_eq!(builtin.get_used_cells(&vm), Ok(0));
+        assert_eq!(builtin.get_used_cells(&vm.segments), Ok(0));
     }
 
     #[test]
@@ -553,7 +557,7 @@ mod tests {
         let mut vm = vm!();
 
         vm.segments.segment_used_sizes = Some(vec![4]);
-        assert_eq!(builtin.get_used_cells(&vm), Ok(4));
+        assert_eq!(builtin.get_used_cells(&vm.segments), Ok(4));
     }
 
     #[test]

--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -22,7 +22,7 @@ pub struct BitwiseBuiltinRunner {
     pub(crate) n_input_cells: u32,
     bitwise_builtin: BitwiseInstanceDef,
     pub(crate) stop_ptr: Option<usize>,
-    pub(crate) _included: bool,
+    pub(crate) included: bool,
     instances_per_component: u32,
 }
 
@@ -35,7 +35,7 @@ impl BitwiseBuiltinRunner {
             n_input_cells: INPUT_CELLS_PER_BITWISE,
             bitwise_builtin: instance_def.clone(),
             stop_ptr: None,
-            _included: include,
+            included: include,
             instances_per_component: 1,
         }
     }
@@ -49,7 +49,7 @@ impl BitwiseBuiltinRunner {
     }
 
     pub fn initial_stack(&self) -> Vec<MaybeRelocatable> {
-        if self._included {
+        if self.included {
             vec![MaybeRelocatable::from((self.base, 0))]
         } else {
             vec![]
@@ -124,9 +124,9 @@ impl BitwiseBuiltinRunner {
         (self.base, self.stop_ptr)
     }
 
-    pub fn get_used_cells(&self, vm: &VirtualMachine) -> Result<usize, MemoryError> {
+    pub fn get_used_cells(&self, segments: &MemorySegmentManager) -> Result<usize, MemoryError> {
         let base = self.base();
-        vm.segments
+        segments
             .get_segment_used_size(
                 base.try_into()
                     .map_err(|_| MemoryError::AddressInTemporarySegment(base))?,
@@ -144,7 +144,7 @@ impl BitwiseBuiltinRunner {
         if vm.current_step < min_step {
             Err(MemoryError::InsufficientAllocatedCells)
         } else {
-            let used = self.get_used_cells(vm)?;
+            let used = self.get_used_cells(&vm.segments)?;
             let size = cells_per_instance as usize
                 * safe_div_usize(vm.current_step, ratio)
                     .map_err(|_| MemoryError::InsufficientAllocatedCells)?;
@@ -174,40 +174,43 @@ impl BitwiseBuiltinRunner {
     }
 
     pub fn final_stack(
-        &self,
-        vm: &VirtualMachine,
+        &mut self,
+        segments: &MemorySegmentManager,
+        memory: &Memory,
         pointer: Relocatable,
-    ) -> Result<(Relocatable, usize), RunnerError> {
-        if self._included {
-            if let Ok(stop_pointer) =
-                vm.get_relocatable(&(pointer.sub_usize(1)).map_err(|_| RunnerError::FinalStack)?)
+    ) -> Result<Relocatable, RunnerError> {
+        if self.included {
+            if let Ok(stop_pointer) = memory
+                .get_relocatable(&(pointer.sub_usize(1)).map_err(|_| RunnerError::FinalStack)?)
             {
                 if self.base() != stop_pointer.segment_index {
                     return Err(RunnerError::InvalidStopPointer("bitwise".to_string()));
                 }
                 let stop_ptr = stop_pointer.offset;
                 let num_instances = self
-                    .get_used_instances(vm)
+                    .get_used_instances(segments)
                     .map_err(|_| RunnerError::FinalStack)?;
                 let used_cells = num_instances * self.cells_per_instance as usize;
                 if stop_ptr != used_cells {
                     return Err(RunnerError::InvalidStopPointer("bitwise".to_string()));
                 }
-                Ok((
-                    pointer.sub_usize(1).map_err(|_| RunnerError::FinalStack)?,
-                    stop_ptr,
-                ))
+                self.stop_ptr = Some(stop_ptr);
+                Ok(pointer.sub_usize(1).map_err(|_| RunnerError::FinalStack)?)
             } else {
                 Err(RunnerError::FinalStack)
             }
         } else {
             let stop_ptr = self.base() as usize;
-            Ok((pointer, stop_ptr))
+            self.stop_ptr = Some(stop_ptr);
+            Ok(pointer)
         }
     }
 
-    pub fn get_used_instances(&self, vm: &VirtualMachine) -> Result<usize, MemoryError> {
-        let used_cells = self.get_used_cells(vm)?;
+    pub fn get_used_instances(
+        &self,
+        segments: &MemorySegmentManager,
+    ) -> Result<usize, MemoryError> {
+        let used_cells = self.get_used_cells(segments)?;
         Ok(div_ceil(used_cells, self.cells_per_instance as usize))
     }
 }
@@ -238,12 +241,12 @@ mod tests {
 
         vm.segments.segment_used_sizes = Some(vec![1]);
 
-        assert_eq!(builtin.get_used_instances(&vm), Ok(1));
+        assert_eq!(builtin.get_used_instances(&vm.segments), Ok(1));
     }
 
     #[test]
     fn final_stack() {
-        let builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(10), true);
+        let mut builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(10), true);
 
         let mut vm = vm!();
 
@@ -259,14 +262,14 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin.final_stack(&vm, pointer).unwrap(),
-            (Relocatable::from((2, 1)), 0)
+            builtin.final_stack(&mut vm, pointer).unwrap(),
+            Relocatable::from((2, 1))
         );
     }
 
     #[test]
     fn final_stack_error_stop_pointer() {
-        let builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(10), true);
+        let mut builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(10), true);
 
         let mut vm = vm!();
 
@@ -288,7 +291,7 @@ mod tests {
     }
 
     #[test]
-    fn final_stack_error_when_not_included() {
+    fn final_stack_error_when_notincluded() {
         let builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(10), false);
 
         let mut vm = vm!();
@@ -305,8 +308,8 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin.final_stack(&vm, pointer).unwrap(),
-            (Relocatable::from((2, 2)), 0)
+            builtin.final_stack(&mut vm, pointer).unwrap(),
+            Relocatable::from((2, 2))
         );
     }
 

--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -27,7 +27,7 @@ pub struct BitwiseBuiltinRunner {
 }
 
 impl BitwiseBuiltinRunner {
-    pub(crate) fn new(instance_def: &BitwiseInstanceDef, include: bool) -> Self {
+    pub(crate) fn new(instance_def: &BitwiseInstanceDef, included: bool) -> Self {
         BitwiseBuiltinRunner {
             base: 0,
             ratio: instance_def.ratio,
@@ -35,7 +35,7 @@ impl BitwiseBuiltinRunner {
             n_input_cells: INPUT_CELLS_PER_BITWISE,
             bitwise_builtin: instance_def.clone(),
             stop_ptr: None,
-            included: include,
+            included,
             instances_per_component: 1,
         }
     }
@@ -294,7 +294,7 @@ mod tests {
 
     #[test]
     fn final_stack_error_when_notincluded() {
-        let builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(10), false);
+        let mut builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(10), false);
 
         let mut vm = vm!();
 
@@ -319,7 +319,7 @@ mod tests {
 
     #[test]
     fn final_stack_error_non_relocatable() {
-        let builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(10), true);
+        let mut builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(10), true);
 
         let mut vm = vm!();
 

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -35,7 +35,7 @@ impl EcOpBuiltinRunner {
             cells_per_instance: CELLS_PER_EC_OP,
             ec_op_builtin: instance_def.clone(),
             stop_ptr: None,
-            included: included,
+            included,
             instances_per_component: 1,
         }
     }
@@ -337,7 +337,7 @@ mod tests {
 
     #[test]
     fn final_stack() {
-        let builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::new(10), true);
+        let mut builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::new(10), true);
 
         let mut vm = vm!();
 
@@ -362,7 +362,7 @@ mod tests {
 
     #[test]
     fn final_stack_error_stop_pointer() {
-        let builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::new(10), true);
+        let mut builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::new(10), true);
 
         let mut vm = vm!();
 
@@ -385,7 +385,7 @@ mod tests {
 
     #[test]
     fn final_stack_error_when_notincluded() {
-        let builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::new(10), false);
+        let mut builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::new(10), false);
 
         let mut vm = vm!();
 
@@ -410,7 +410,7 @@ mod tests {
 
     #[test]
     fn final_stack_error_non_relocatable() {
-        let builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::new(10), true);
+        let mut builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::new(10), true);
 
         let mut vm = vm!();
 

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -330,17 +330,9 @@ mod tests {
         let builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::new(10), true);
 
         let mut vm = vm!();
-
-        vm.memory = memory![
-            ((0, 0), (0, 0)),
-            ((0, 1), (0, 1)),
-            ((2, 0), (0, 0)),
-            ((2, 1), (0, 0))
-        ];
-
         vm.segments.segment_used_sizes = Some(vec![1]);
 
-        assert_eq!(builtin.get_used_instances(&vm), Ok(1));
+        assert_eq!(builtin.get_used_instances(&vm.segments), Ok(1));
     }
 
     #[test]
@@ -361,7 +353,9 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin.final_stack(&mut vm, pointer).unwrap(),
+            builtin
+                .final_stack(&vm.segments, &vm.memory, pointer)
+                .unwrap(),
             Relocatable::from((2, 1))
         );
     }
@@ -384,7 +378,7 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin.final_stack(&vm, pointer),
+            builtin.final_stack(&vm.segments, &vm.memory, pointer),
             Err(RunnerError::InvalidStopPointer("ec_op".to_string()))
         );
     }
@@ -407,7 +401,9 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin.final_stack(&mut vm, pointer).unwrap(),
+            builtin
+                .final_stack(&vm.segments, &vm.memory, pointer)
+                .unwrap(),
             Relocatable::from((2, 2))
         );
     }
@@ -430,7 +426,7 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin.final_stack(&vm, pointer),
+            builtin.final_stack(&vm.segments, &vm.memory, pointer),
             Err(RunnerError::FinalStack)
         );
     }
@@ -996,7 +992,7 @@ mod tests {
         let vm = vm!();
 
         assert_eq!(
-            builtin.get_used_cells(&vm),
+            builtin.get_used_cells(&vm.segments),
             Err(MemoryError::MissingSegmentUsedSizes)
         );
     }
@@ -1008,7 +1004,7 @@ mod tests {
         let mut vm = vm!();
 
         vm.segments.segment_used_sizes = Some(vec![0]);
-        assert_eq!(builtin.get_used_cells(&vm), Ok(0));
+        assert_eq!(builtin.get_used_cells(&vm.segments), Ok(0));
     }
 
     #[test]
@@ -1018,7 +1014,7 @@ mod tests {
         let mut vm = vm!();
 
         vm.segments.segment_used_sizes = Some(vec![4]);
-        assert_eq!(builtin.get_used_cells(&vm), Ok(4));
+        assert_eq!(builtin.get_used_cells(&vm.segments), Ok(4));
     }
 
     #[test]

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -21,7 +21,7 @@ pub struct HashBuiltinRunner {
     pub(crate) cells_per_instance: u32,
     pub(crate) n_input_cells: u32,
     pub(crate) stop_ptr: Option<usize>,
-    pub(crate) _included: bool,
+    pub(crate) included: bool,
     instances_per_component: u32,
     // This act as a cache to optimize calls to deduce_memory_cell
     // Therefore need interior mutability
@@ -37,7 +37,7 @@ impl HashBuiltinRunner {
             n_input_cells: INPUT_CELLS_PER_HASH,
             stop_ptr: None,
             verified_addresses: RefCell::new(Vec::new()),
-            _included: included,
+            included,
             instances_per_component: 1,
         }
     }
@@ -51,7 +51,7 @@ impl HashBuiltinRunner {
     }
 
     pub fn initial_stack(&self) -> Vec<MaybeRelocatable> {
-        if self._included {
+        if self.included {
             vec![MaybeRelocatable::from((self.base, 0))]
         } else {
             vec![]
@@ -173,7 +173,7 @@ impl HashBuiltinRunner {
         memory: &Memory,
         pointer: Relocatable,
     ) -> Result<Relocatable, RunnerError> {
-        if self._included {
+        if self.included {
             if let Ok(stop_pointer) = memory
                 .get_relocatable(&(pointer.sub_usize(1)).map_err(|_| RunnerError::FinalStack)?)
             {
@@ -227,7 +227,7 @@ mod tests {
 
     #[test]
     fn final_stack() {
-        let builtin = HashBuiltinRunner::new(10, true);
+        let mut builtin = HashBuiltinRunner::new(10, true);
 
         let mut vm = vm!();
 
@@ -252,7 +252,7 @@ mod tests {
 
     #[test]
     fn final_stack_error_stop_pointer() {
-        let builtin = HashBuiltinRunner::new(10, true);
+        let mut builtin = HashBuiltinRunner::new(10, true);
 
         let mut vm = vm!();
 
@@ -274,8 +274,8 @@ mod tests {
     }
 
     #[test]
-    fn final_stack_error_when_not_included() {
-        let builtin = HashBuiltinRunner::new(10, false);
+    fn final_stack_error_when_notincluded() {
+        let mut builtin = HashBuiltinRunner::new(10, false);
 
         let mut vm = vm!();
 
@@ -300,7 +300,7 @@ mod tests {
 
     #[test]
     fn final_stack_error_non_relocatable() {
-        let builtin = HashBuiltinRunner::new(10, true);
+        let mut builtin = HashBuiltinRunner::new(10, true);
 
         let mut vm = vm!();
 

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -128,9 +128,9 @@ impl HashBuiltinRunner {
         (self.base, self.stop_ptr)
     }
 
-    pub fn get_used_cells(&self, vm: &VirtualMachine) -> Result<usize, MemoryError> {
+    pub fn get_used_cells(&self, segments: &MemorySegmentManager) -> Result<usize, MemoryError> {
         let base = self.base();
-        vm.segments
+        segments
             .get_segment_used_size(
                 base.try_into()
                     .map_err(|_| MemoryError::AddressInTemporarySegment(base))?,
@@ -148,7 +148,7 @@ impl HashBuiltinRunner {
         if vm.current_step < min_step {
             Err(MemoryError::InsufficientAllocatedCells)
         } else {
-            let used = self.get_used_cells(vm)?;
+            let used = self.get_used_cells(&vm.segments)?;
             let size = cells_per_instance as usize
                 * safe_div_usize(vm.current_step, ratio)
                     .map_err(|_| MemoryError::InsufficientAllocatedCells)?;
@@ -159,19 +159,23 @@ impl HashBuiltinRunner {
         }
     }
 
-    pub fn get_used_instances(&self, vm: &VirtualMachine) -> Result<usize, MemoryError> {
-        let used_cells = self.get_used_cells(vm)?;
+    pub fn get_used_instances(
+        &self,
+        segments: &MemorySegmentManager,
+    ) -> Result<usize, MemoryError> {
+        let used_cells = self.get_used_cells(segments)?;
         Ok(div_ceil(used_cells, self.cells_per_instance as usize))
     }
 
     pub fn final_stack(
-        &self,
-        vm: &VirtualMachine,
+        &mut self,
+        segments: &MemorySegmentManager,
+        memory: &Memory,
         pointer: Relocatable,
-    ) -> Result<(Relocatable, usize), RunnerError> {
+    ) -> Result<Relocatable, RunnerError> {
         if self._included {
-            if let Ok(stop_pointer) =
-                vm.get_relocatable(&(pointer.sub_usize(1)).map_err(|_| RunnerError::FinalStack)?)
+            if let Ok(stop_pointer) = memory
+                .get_relocatable(&(pointer.sub_usize(1)).map_err(|_| RunnerError::FinalStack)?)
             {
                 if self.base() != stop_pointer.segment_index {
                     return Err(RunnerError::InvalidStopPointer("pedersen".to_string()));
@@ -179,22 +183,21 @@ impl HashBuiltinRunner {
 
                 let stop_ptr = stop_pointer.offset;
                 let num_instances = self
-                    .get_used_instances(vm)
+                    .get_used_instances(segments)
                     .map_err(|_| RunnerError::FinalStack)?;
                 let used_cells = num_instances * self.cells_per_instance as usize;
                 if stop_ptr != used_cells {
                     return Err(RunnerError::InvalidStopPointer("pedersen".to_string()));
                 }
-                Ok((
-                    pointer.sub_usize(1).map_err(|_| RunnerError::FinalStack)?,
-                    stop_ptr,
-                ))
+                self.stop_ptr = Some(stop_ptr);
+                Ok(pointer.sub_usize(1).map_err(|_| RunnerError::FinalStack)?)
             } else {
                 Err(RunnerError::FinalStack)
             }
         } else {
             let stop_ptr = self.base() as usize;
-            Ok((pointer, stop_ptr))
+            self.stop_ptr = Some(stop_ptr);
+            Ok(pointer)
         }
     }
 }
@@ -248,8 +251,8 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin.final_stack(&vm, pointer).unwrap(),
-            (Relocatable::from((2, 1)), 0)
+            builtin.final_stack(&mut vm, pointer).unwrap(),
+            Relocatable::from((2, 1))
         );
     }
 
@@ -294,8 +297,8 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin.final_stack(&vm, pointer).unwrap(),
-            (Relocatable::from((2, 2)), 0)
+            builtin.final_stack(&mut vm, pointer).unwrap(),
+            Relocatable::from((2, 2))
         );
     }
 

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -220,17 +220,9 @@ mod tests {
         let builtin = HashBuiltinRunner::new(10, true);
 
         let mut vm = vm!();
-
-        vm.memory = memory![
-            ((0, 0), (0, 0)),
-            ((0, 1), (0, 1)),
-            ((2, 0), (0, 0)),
-            ((2, 1), (0, 0))
-        ];
-
         vm.segments.segment_used_sizes = Some(vec![1]);
 
-        assert_eq!(builtin.get_used_instances(&vm), Ok(1));
+        assert_eq!(builtin.get_used_instances(&vm.segments), Ok(1));
     }
 
     #[test]
@@ -251,7 +243,9 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin.final_stack(&mut vm, pointer).unwrap(),
+            builtin
+                .final_stack(&vm.segments, &vm.memory, pointer)
+                .unwrap(),
             Relocatable::from((2, 1))
         );
     }
@@ -274,7 +268,7 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin.final_stack(&vm, pointer),
+            builtin.final_stack(&vm.segments, &vm.memory, pointer),
             Err(RunnerError::InvalidStopPointer("pedersen".to_string()))
         );
     }
@@ -297,7 +291,9 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin.final_stack(&mut vm, pointer).unwrap(),
+            builtin
+                .final_stack(&vm.segments, &vm.memory, pointer)
+                .unwrap(),
             Relocatable::from((2, 2))
         );
     }
@@ -320,7 +316,7 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin.final_stack(&vm, pointer),
+            builtin.final_stack(&vm.segments, &vm.memory, pointer),
             Err(RunnerError::FinalStack)
         );
     }
@@ -506,7 +502,7 @@ mod tests {
         let vm = vm!();
 
         assert_eq!(
-            builtin.get_used_cells(&vm),
+            builtin.get_used_cells(&vm.segments),
             Err(MemoryError::MissingSegmentUsedSizes)
         );
     }
@@ -517,7 +513,7 @@ mod tests {
         let mut vm = vm!();
 
         vm.segments.segment_used_sizes = Some(vec![0]);
-        assert_eq!(builtin.get_used_cells(&vm), Ok(0));
+        assert_eq!(builtin.get_used_cells(&vm.segments), Ok(0));
     }
 
     #[test]
@@ -526,6 +522,6 @@ mod tests {
         let mut vm = vm!();
 
         vm.segments.segment_used_sizes = Some(vec![4]);
-        assert_eq!(builtin.get_used_cells(&vm), Ok(4));
+        assert_eq!(builtin.get_used_cells(&vm.segments), Ok(4));
     }
 }

--- a/src/vm/runners/builtin_runner/keccak.rs
+++ b/src/vm/runners/builtin_runner/keccak.rs
@@ -272,7 +272,7 @@ mod tests {
 
     #[test]
     fn get_used_instances() {
-        let builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10), true);
+        let builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10, vec![200; 8]), true);
 
         let mut vm = vm!();
         vm.segments.segment_used_sizes = Some(vec![1]);
@@ -282,7 +282,7 @@ mod tests {
 
     #[test]
     fn final_stack() {
-        let mut builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10), true);
+        let mut builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10, vec![200; 8]), true);
 
         let mut vm = vm!();
 
@@ -307,7 +307,7 @@ mod tests {
 
     #[test]
     fn final_stack_error_stop_pointer() {
-        let mut builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10), true);
+        let mut builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10, vec![200; 8]), true);
 
         let mut vm = vm!();
 
@@ -330,7 +330,8 @@ mod tests {
 
     #[test]
     fn final_stack_error_when_notincluded() {
-        let mut builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10), false);
+        let mut builtin =
+            KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10, vec![200; 8]), false);
 
         let mut vm = vm!();
 
@@ -355,7 +356,7 @@ mod tests {
 
     #[test]
     fn final_stack_error_non_relocatable() {
-        let mut builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10), true);
+        let mut builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10, vec![200; 8]), true);
 
         let mut vm = vm!();
 
@@ -379,7 +380,7 @@ mod tests {
     #[test]
     fn get_used_cells_and_allocated_size_test() {
         let builtin: BuiltinRunner =
-            KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10), true).into();
+            KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10, vec![200; 8]), true).into();
 
         let mut vm = vm!();
 
@@ -406,7 +407,7 @@ mod tests {
     #[test]
     fn get_allocated_memory_units() {
         let builtin: BuiltinRunner =
-            KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10), true).into();
+            KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10, vec![200; 8]), true).into();
 
         let mut vm = vm!();
 
@@ -678,8 +679,7 @@ mod tests {
             ((0, 35), 0)
         ];
 
-        let mut keccak_instance = KeccakInstanceDef::default();
-        keccak_instance._state_rep = vec![1; 8];
+        let keccak_instance = KeccakInstanceDef::new(2048, vec![1; 8]);
         let builtin = KeccakBuiltinRunner::new(&keccak_instance, true);
 
         let result = builtin.deduce_memory_cell(&Relocatable::from((0, 25)), &memory);

--- a/src/vm/runners/builtin_runner/keccak.rs
+++ b/src/vm/runners/builtin_runner/keccak.rs
@@ -24,7 +24,7 @@ pub struct KeccakBuiltinRunner {
     pub(crate) n_input_cells: u32,
     verified_addresses: Vec<Relocatable>,
     pub(crate) stop_ptr: Option<usize>,
-    _included: bool,
+    included: bool,
     state_rep: Vec<u32>,
     instances_per_component: u32,
 }
@@ -38,7 +38,7 @@ impl KeccakBuiltinRunner {
             cells_per_instance: instance_def._cells_per_builtin(),
             stop_ptr: None,
             verified_addresses: Vec::new(),
-            _included: included,
+            included,
             instances_per_component: instance_def._instance_per_component,
             state_rep: instance_def._state_rep.clone(),
         }
@@ -53,7 +53,7 @@ impl KeccakBuiltinRunner {
     }
 
     pub fn initial_stack(&self) -> Vec<MaybeRelocatable> {
-        if self._included {
+        if self.included {
             vec![MaybeRelocatable::from((self.base, 0))]
         } else {
             vec![]
@@ -197,7 +197,7 @@ impl KeccakBuiltinRunner {
         memory: &Memory,
         pointer: Relocatable,
     ) -> Result<Relocatable, RunnerError> {
-        if self._included {
+        if self.included {
             if let Ok(stop_pointer) = memory
                 .get_relocatable(&(pointer.sub_usize(1)).map_err(|_| RunnerError::FinalStack)?)
             {
@@ -282,7 +282,7 @@ mod tests {
 
     #[test]
     fn final_stack() {
-        let builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10), true);
+        let mut builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10), true);
 
         let mut vm = vm!();
 
@@ -307,7 +307,7 @@ mod tests {
 
     #[test]
     fn final_stack_error_stop_pointer() {
-        let builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10), true);
+        let mut builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10), true);
 
         let mut vm = vm!();
 
@@ -329,8 +329,8 @@ mod tests {
     }
 
     #[test]
-    fn final_stack_error_when_not_included() {
-        let builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10), false);
+    fn final_stack_error_when_notincluded() {
+        let mut builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10), false);
 
         let mut vm = vm!();
 
@@ -355,7 +355,7 @@ mod tests {
 
     #[test]
     fn final_stack_error_non_relocatable() {
-        let builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10), true);
+        let mut builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10), true);
 
         let mut vm = vm!();
 
@@ -524,7 +524,7 @@ mod tests {
     }
 
     #[test]
-    fn initial_stack_included_test() {
+    fn initial_stackincluded_test() {
         let keccak_builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::default(), true);
         assert_eq!(
             keccak_builtin.initial_stack(),
@@ -533,7 +533,7 @@ mod tests {
     }
 
     #[test]
-    fn initial_stack_not_included_test() {
+    fn initial_stack_notincluded_test() {
         let keccak_builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::default(), false);
         assert_eq!(keccak_builtin.initial_stack(), Vec::new())
     }

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -79,8 +79,6 @@ impl BuiltinRunner {
         }
     }
 
-    // Important note: the second returned value corresponds to the builtin's stop_ptr, which must be updated after calling this method
-    // It is not updated inside this method due to mutability problems
     pub fn final_stack(
         &mut self,
         segments: &MemorySegmentManager,

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -802,8 +802,10 @@ mod tests {
 
     #[test]
     fn get_allocated_memory_units_keccak_with_items() {
-        let builtin =
-            BuiltinRunner::Keccak(KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10), true));
+        let builtin = BuiltinRunner::Keccak(KeccakBuiltinRunner::new(
+            &KeccakInstanceDef::new(10, vec![200; 8]),
+            true,
+        ));
 
         let mut vm = vm!();
 

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -1440,7 +1440,7 @@ mod tests {
 
     #[test]
     fn runners_final_stack() {
-        let builtins = vec![
+        let mut builtins = vec![
             BuiltinRunner::Bitwise(BitwiseBuiltinRunner::new(
                 &BitwiseInstanceDef::default(),
                 false,
@@ -1460,7 +1460,7 @@ mod tests {
         ];
         let vm = vm!();
 
-        for br in builtins {
+        for br in builtins.iter_mut() {
             assert_eq!(
                 br.final_stack(&vm.segments, &vm.memory, vm.get_ap()),
                 Ok(vm.get_ap())

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -82,10 +82,10 @@ impl BuiltinRunner {
     // Important note: the second returned value corresponds to the builtin's stop_ptr, which must be updated after calling this method
     // It is not updated inside this method due to mutability problems
     pub fn final_stack(
-        &self,
+        &mut self,
         vm: &VirtualMachine,
         stack_pointer: Relocatable,
-    ) -> Result<(Relocatable, usize), RunnerError> {
+    ) -> Result<Relocatable, RunnerError> {
         match *self {
             BuiltinRunner::Bitwise(ref bitwise) => bitwise.final_stack(vm, stack_pointer),
             BuiltinRunner::EcOp(ref ec) => ec.final_stack(vm, stack_pointer),
@@ -1449,7 +1449,7 @@ mod tests {
         let vm = vm!();
 
         for br in builtins {
-            assert_eq!(br.final_stack(&vm, vm.get_ap()), Ok((vm.get_ap(), 0)));
+            assert_eq!(br.final_stack(&mut vm, vm.get_ap()), Ok(vm.get_ap()));
         }
     }
 

--- a/src/vm/runners/builtin_runner/output.rs
+++ b/src/vm/runners/builtin_runner/output.rs
@@ -9,7 +9,7 @@ use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
 pub struct OutputBuiltinRunner {
     base: isize,
     pub(crate) stop_ptr: Option<usize>,
-    pub(crate) _included: bool,
+    pub(crate) included: bool,
 }
 
 impl OutputBuiltinRunner {
@@ -17,7 +17,7 @@ impl OutputBuiltinRunner {
         OutputBuiltinRunner {
             base: 0,
             stop_ptr: None,
-            _included: included,
+            included,
         }
     }
 
@@ -30,7 +30,7 @@ impl OutputBuiltinRunner {
     }
 
     pub fn initial_stack(&self) -> Vec<MaybeRelocatable> {
-        if self._included {
+        if self.included {
             vec![MaybeRelocatable::from((self.base, 0))]
         } else {
             vec![]
@@ -92,7 +92,7 @@ impl OutputBuiltinRunner {
         memory: &Memory,
         pointer: Relocatable,
     ) -> Result<Relocatable, RunnerError> {
-        if self._included {
+        if self.included {
             if let Ok(stop_pointer) = memory
                 .get_relocatable(&(pointer.sub_usize(1)).map_err(|_| RunnerError::FinalStack)?)
             {
@@ -149,7 +149,7 @@ mod tests {
 
     #[test]
     fn final_stack() {
-        let builtin = OutputBuiltinRunner::new(true);
+        let mut builtin = OutputBuiltinRunner::new(true);
 
         let mut vm = vm!();
 
@@ -174,7 +174,7 @@ mod tests {
 
     #[test]
     fn final_stack_error_stop_pointer() {
-        let builtin = OutputBuiltinRunner::new(true);
+        let mut builtin = OutputBuiltinRunner::new(true);
 
         let mut vm = vm!();
 
@@ -196,8 +196,8 @@ mod tests {
     }
 
     #[test]
-    fn final_stack_error_when_not_included() {
-        let builtin = OutputBuiltinRunner::new(false);
+    fn final_stack_error_when_notincluded() {
+        let mut builtin = OutputBuiltinRunner::new(false);
 
         let mut vm = vm!();
 
@@ -222,7 +222,7 @@ mod tests {
 
     #[test]
     fn final_stack_error_non_relocatable() {
-        let builtin = OutputBuiltinRunner::new(true);
+        let mut builtin = OutputBuiltinRunner::new(true);
 
         let mut vm = vm!();
 

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -189,8 +189,11 @@ impl RangeCheckBuiltinRunner {
         rc_bounds
     }
 
-    pub fn get_used_instances(&self, vm: &VirtualMachine) -> Result<usize, MemoryError> {
-        self.get_used_cells(vm)
+    pub fn get_used_instances(
+        &self,
+        segments: &MemorySegmentManager,
+    ) -> Result<usize, MemoryError> {
+        self.get_used_cells(segments)
     }
 
     pub fn final_stack(
@@ -255,17 +258,9 @@ mod tests {
         let builtin = RangeCheckBuiltinRunner::new(10, 12, true);
 
         let mut vm = vm!();
-
-        vm.memory = memory![
-            ((0, 0), (0, 0)),
-            ((0, 1), (0, 1)),
-            ((2, 0), (0, 0)),
-            ((2, 1), (0, 0))
-        ];
-
         vm.segments.segment_used_sizes = Some(vec![1]);
 
-        assert_eq!(builtin.get_used_instances(&vm), Ok(1));
+        assert_eq!(builtin.get_used_instances(&vm.segments), Ok(1));
     }
 
     #[test]
@@ -286,7 +281,9 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin.final_stack(&mut vm, pointer).unwrap(),
+            builtin
+                .final_stack(&vm.segments, &vm.memory, pointer)
+                .unwrap(),
             Relocatable::from((2, 1))
         );
     }
@@ -309,7 +306,7 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin.final_stack(&vm, pointer),
+            builtin.final_stack(&vm.segments, &vm.memory, pointer),
             Err(RunnerError::InvalidStopPointer("range_check".to_string()))
         );
     }
@@ -332,7 +329,9 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin.final_stack(&mut vm, pointer).unwrap(),
+            builtin
+                .final_stack(&vm.segments, &vm.memory, pointer)
+                .unwrap(),
             Relocatable::from((2, 2))
         );
     }
@@ -355,7 +354,7 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin.final_stack(&vm, pointer),
+            builtin.final_stack(&vm.segments, &vm.memory, pointer),
             Err(RunnerError::FinalStack)
         );
     }
@@ -519,7 +518,7 @@ mod tests {
         let vm = vm!();
 
         assert_eq!(
-            builtin.get_used_cells(&vm),
+            builtin.get_used_cells(&vm.segments),
             Err(MemoryError::MissingSegmentUsedSizes)
         );
     }
@@ -530,7 +529,7 @@ mod tests {
         let mut vm = vm!();
 
         vm.segments.segment_used_sizes = Some(vec![0]);
-        assert_eq!(builtin.get_used_cells(&vm), Ok(0));
+        assert_eq!(builtin.get_used_cells(&vm.segments), Ok(0));
     }
 
     #[test]
@@ -539,7 +538,7 @@ mod tests {
         let mut vm = vm!();
 
         vm.segments.segment_used_sizes = Some(vec![4]);
-        assert_eq!(builtin.get_used_cells(&vm), Ok(4));
+        assert_eq!(builtin.get_used_cells(&vm.segments), Ok(4));
     }
 
     #[test]

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -30,7 +30,7 @@ pub struct RangeCheckBuiltinRunner {
     pub(crate) n_input_cells: u32,
     inner_rc_bound: usize,
     pub _bound: Option<Felt>,
-    pub(crate) _included: bool,
+    pub(crate) included: bool,
     n_parts: u32,
     instances_per_component: u32,
 }
@@ -54,7 +54,7 @@ impl RangeCheckBuiltinRunner {
             n_input_cells: CELLS_PER_RANGE_CHECK,
             inner_rc_bound,
             _bound,
-            _included: included,
+            included,
             n_parts,
             instances_per_component: 1,
         }
@@ -69,7 +69,7 @@ impl RangeCheckBuiltinRunner {
     }
 
     pub fn initial_stack(&self) -> Vec<MaybeRelocatable> {
-        if self._included {
+        if self.included {
             vec![MaybeRelocatable::from((self.base, 0))]
         } else {
             vec![]
@@ -202,7 +202,7 @@ impl RangeCheckBuiltinRunner {
         memory: &Memory,
         pointer: Relocatable,
     ) -> Result<Relocatable, RunnerError> {
-        if self._included {
+        if self.included {
             if let Ok(stop_pointer) = memory
                 .get_relocatable(&(pointer.sub_usize(1)).map_err(|_| RunnerError::FinalStack)?)
             {
@@ -265,7 +265,7 @@ mod tests {
 
     #[test]
     fn final_stack() {
-        let builtin = RangeCheckBuiltinRunner::new(10, 12, true);
+        let mut builtin = RangeCheckBuiltinRunner::new(10, 12, true);
 
         let mut vm = vm!();
 
@@ -290,7 +290,7 @@ mod tests {
 
     #[test]
     fn final_stack_error_stop_pointer() {
-        let builtin = RangeCheckBuiltinRunner::new(10, 12, true);
+        let mut builtin = RangeCheckBuiltinRunner::new(10, 12, true);
 
         let mut vm = vm!();
 
@@ -312,8 +312,8 @@ mod tests {
     }
 
     #[test]
-    fn final_stack_error_when_not_included() {
-        let builtin = RangeCheckBuiltinRunner::new(10, 12, false);
+    fn final_stack_error_when_notincluded() {
+        let mut builtin = RangeCheckBuiltinRunner::new(10, 12, false);
 
         let mut vm = vm!();
 
@@ -338,7 +338,7 @@ mod tests {
 
     #[test]
     fn final_stack_error_non_relocatable() {
-        let builtin = RangeCheckBuiltinRunner::new(10, 12, true);
+        let mut builtin = RangeCheckBuiltinRunner::new(10, 12, true);
 
         let mut vm = vm!();
 

--- a/src/vm/runners/builtin_runner/signature.rs
+++ b/src/vm/runners/builtin_runner/signature.rs
@@ -239,8 +239,8 @@ impl SignatureBuiltinRunner {
         pointer: Relocatable,
     ) -> Result<Relocatable, RunnerError> {
         if self.included {
-            if let Ok(stop_pointer) =
-                vm.get_relocatable(&(pointer.sub_usize(1)).map_err(|_| RunnerError::FinalStack)?)
+            if let Ok(stop_pointer) = memory
+                .get_relocatable(&(pointer.sub_usize(1)).map_err(|_| RunnerError::FinalStack)?)
             {
                 if self.base() != stop_pointer.segment_index {
                     return Err(RunnerError::InvalidStopPointer("ecdsa".to_string()));
@@ -295,17 +295,9 @@ mod tests {
         let builtin = SignatureBuiltinRunner::new(&EcdsaInstanceDef::default(), true);
 
         let mut vm = vm!();
-
-        vm.memory = memory![
-            ((0, 0), (0, 0)),
-            ((0, 1), (0, 1)),
-            ((2, 0), (0, 0)),
-            ((2, 1), (0, 0))
-        ];
-
         vm.segments.segment_used_sizes = Some(vec![1]);
 
-        assert_eq!(builtin.get_used_instances(&vm), Ok(1));
+        assert_eq!(builtin.get_used_instances(&vm.segments), Ok(1));
     }
 
     #[test]
@@ -326,14 +318,16 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin.final_stack(&mut vm, pointer).unwrap(),
+            builtin
+                .final_stack(&vm.segments, &vm.memory, pointer)
+                .unwrap(),
             Relocatable::from((2, 1))
         );
     }
 
     #[test]
     fn final_stack_error_stop_pointer() {
-        let builtin = SignatureBuiltinRunner::new(&EcdsaInstanceDef::default(), true);
+        let mut builtin = SignatureBuiltinRunner::new(&EcdsaInstanceDef::default(), true);
 
         let mut vm = vm!();
 
@@ -349,7 +343,7 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin.final_stack(&vm, pointer),
+            builtin.final_stack(&vm.segments, &vm.memory, pointer),
             Err(RunnerError::InvalidStopPointer("ecdsa".to_string()))
         );
     }
@@ -372,7 +366,7 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin.final_stack(&vm, pointer),
+            builtin.final_stack(&vm.segments, &vm.memory, pointer),
             Err(RunnerError::FinalStack)
         );
     }
@@ -439,7 +433,7 @@ mod tests {
         let vm = vm!();
 
         assert_eq!(
-            builtin.get_used_cells(&vm),
+            builtin.get_used_cells(&vm.segments),
             Err(MemoryError::MissingSegmentUsedSizes)
         );
     }
@@ -453,7 +447,7 @@ mod tests {
         let mut vm = vm!();
 
         vm.segments.segment_used_sizes = Some(vec![0]);
-        assert_eq!(builtin.get_used_cells(&vm), Ok(0));
+        assert_eq!(builtin.get_used_cells(&vm.segments), Ok(0));
     }
 
     #[test]
@@ -465,7 +459,7 @@ mod tests {
         let mut vm = vm!();
 
         vm.segments.segment_used_sizes = Some(vec![4]);
-        assert_eq!(builtin.get_used_cells(&vm), Ok(4));
+        assert_eq!(builtin.get_used_cells(&vm.segments), Ok(4));
     }
 
     #[test]

--- a/src/vm/runners/builtin_runner/signature.rs
+++ b/src/vm/runners/builtin_runner/signature.rs
@@ -302,7 +302,7 @@ mod tests {
 
     #[test]
     fn final_stack() {
-        let builtin = SignatureBuiltinRunner::new(&EcdsaInstanceDef::default(), true);
+        let mut builtin = SignatureBuiltinRunner::new(&EcdsaInstanceDef::default(), true);
 
         let mut vm = vm!();
 
@@ -350,7 +350,7 @@ mod tests {
 
     #[test]
     fn final_stack_error_non_relocatable() {
-        let builtin = SignatureBuiltinRunner::new(&EcdsaInstanceDef::default(), true);
+        let mut builtin = SignatureBuiltinRunner::new(&EcdsaInstanceDef::default(), true);
 
         let mut vm = vm!();
 

--- a/src/vm/runners/builtin_runner/signature.rs
+++ b/src/vm/runners/builtin_runner/signature.rs
@@ -193,9 +193,9 @@ impl SignatureBuiltinRunner {
         (self.base, self.stop_ptr)
     }
 
-    pub fn get_used_cells(&self, vm: &VirtualMachine) -> Result<usize, MemoryError> {
+    pub fn get_used_cells(&self, segments: &MemorySegmentManager) -> Result<usize, MemoryError> {
         let base = self.base();
-        vm.segments
+        segments
             .get_segment_used_size(
                 base.try_into()
                     .map_err(|_| MemoryError::AddressInTemporarySegment(base))?,
@@ -213,7 +213,7 @@ impl SignatureBuiltinRunner {
         if vm.current_step < min_step {
             Err(MemoryError::InsufficientAllocatedCells)
         } else {
-            let used = self.get_used_cells(vm)?;
+            let used = self.get_used_cells(&vm.segments)?;
             let size = cells_per_instance as usize
                 * safe_div_usize(vm.current_step, ratio)
                     .map_err(|_| MemoryError::InsufficientAllocatedCells)?;
@@ -224,16 +224,20 @@ impl SignatureBuiltinRunner {
         }
     }
 
-    pub fn get_used_instances(&self, vm: &VirtualMachine) -> Result<usize, MemoryError> {
-        let used_cells = self.get_used_cells(vm)?;
+    pub fn get_used_instances(
+        &self,
+        segments: &MemorySegmentManager,
+    ) -> Result<usize, MemoryError> {
+        let used_cells = self.get_used_cells(segments)?;
         Ok(div_ceil(used_cells, self.cells_per_instance as usize))
     }
 
     pub fn final_stack(
-        &self,
-        vm: &VirtualMachine,
+        &mut self,
+        segments: &MemorySegmentManager,
+        memory: &Memory,
         pointer: Relocatable,
-    ) -> Result<(Relocatable, usize), RunnerError> {
+    ) -> Result<Relocatable, RunnerError> {
         if self.included {
             if let Ok(stop_pointer) =
                 vm.get_relocatable(&(pointer.sub_usize(1)).map_err(|_| RunnerError::FinalStack)?)
@@ -243,23 +247,22 @@ impl SignatureBuiltinRunner {
                 }
                 let stop_ptr = stop_pointer.offset;
                 let num_instances = self
-                    .get_used_instances(vm)
+                    .get_used_instances(segments)
                     .map_err(|_| RunnerError::FinalStack)?;
                 let used_cells = num_instances * self.cells_per_instance as usize;
                 if stop_ptr != used_cells {
                     return Err(RunnerError::InvalidStopPointer("ecdsa".to_string()));
                 }
 
-                Ok((
-                    pointer.sub_usize(1).map_err(|_| RunnerError::FinalStack)?,
-                    stop_ptr,
-                ))
+                self.stop_ptr = Some(stop_ptr);
+                Ok(pointer.sub_usize(1).map_err(|_| RunnerError::FinalStack)?)
             } else {
                 Err(RunnerError::FinalStack)
             }
         } else {
             let stop_ptr = self.base() as usize;
-            Ok((pointer, stop_ptr))
+            self.stop_ptr = Some(stop_ptr);
+            Ok(pointer)
         }
     }
 }
@@ -323,8 +326,8 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin.final_stack(&vm, pointer).unwrap(),
-            (Relocatable::from((2, 1)), 0)
+            builtin.final_stack(&mut vm, pointer).unwrap(),
+            Relocatable::from((2, 1))
         );
     }
 

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -1063,7 +1063,7 @@ impl CairoRunner {
             return Err(RunnerError::ReadReturnValuesNoEndRun);
         }
         let mut pointer = vm.get_ap();
-        for (_, builtin_runner) in vm.builtin_runners.iter_mut() {
+        for (_, builtin_runner) in vm.builtin_runners.iter_mut().rev() {
             let new_pointer = builtin_runner.final_stack(&vm.segments, &vm.memory, pointer)?;
             pointer = new_pointer;
         }

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -4153,7 +4153,7 @@ mod tests {
             BuiltinRunner::Hash(builtin) => {
                 assert_eq!(builtin.base(), 0);
                 assert_eq!(builtin.ratio(), 32);
-                assert!(builtin._included);
+                assert!(builtin.included);
             }
             _ => unreachable!(),
         }
@@ -4181,7 +4181,7 @@ mod tests {
             BuiltinRunner::Hash(builtin) => {
                 assert_eq!(builtin.base(), 1);
                 assert_eq!(builtin.ratio(), 32);
-                assert!(builtin._included);
+                assert!(builtin.included);
             }
             _ => unreachable!(),
         }

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -1062,33 +1062,10 @@ impl CairoRunner {
         if !self.run_ended {
             return Err(RunnerError::ReadReturnValuesNoEndRun);
         }
-        let mut stop_pointers = vec![];
         let mut pointer = vm.get_ap();
-        for builtin_name in self.program.builtins.iter().rev() {
-            let builtin_runner = vm
-                .builtin_runners
-                .iter()
-                .find(|(name, _builtin)| builtin_name == name);
-
-            match builtin_runner {
-                None => return Err(RunnerError::MissingBuiltin(builtin_name.to_string())),
-                Some((_, builtin)) => {
-                    let (new_pointer, stop_ptr) = builtin.final_stack(vm, pointer)?;
-                    stop_pointers.push(stop_ptr);
-                    pointer = new_pointer;
-                }
-            }
-        }
-        //FIXME: Update stop_ptr in BuilrinRunner::final_stack, instead of doing it here
-        // Quick and ugly solution to bypass mutability restrictions
-        for (index, builtin_name) in self.program.builtins.iter().rev().enumerate() {
-            let builtin_runner = vm
-                .builtin_runners
-                .iter_mut()
-                .find(|(name, _builtin)| builtin_name == name);
-            // We checked this before so this unwrap is safe
-            // We can safely index into stop_pointers as it was built using the same iteration
-            builtin_runner.unwrap().1.set_stop_ptr(stop_pointers[index]);
+        for (_, builtin_runner) in vm.builtin_runners.iter_mut() {
+            let new_pointer = builtin_runner.final_stack(&vm, pointer)?;
+            pointer = new_pointer;
         }
         if self.segments_finalized {
             return Err(RunnerError::FailedAddingReturnValues);

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -843,7 +843,7 @@ impl CairoRunner {
         for (builtin_name, builtin_runner) in &vm.builtin_runners {
             builtin_instance_counter.insert(
                 builtin_name.to_string(),
-                builtin_runner.get_used_instances(vm)?,
+                builtin_runner.get_used_instances(&vm.segments)?,
             );
         }
 
@@ -1064,7 +1064,7 @@ impl CairoRunner {
         }
         let mut pointer = vm.get_ap();
         for (_, builtin_runner) in vm.builtin_runners.iter_mut() {
-            let new_pointer = builtin_runner.final_stack(&vm, pointer)?;
+            let new_pointer = builtin_runner.final_stack(&vm.segments, &vm.memory, pointer)?;
             pointer = new_pointer;
         }
         if self.segments_finalized {


### PR DESCRIPTION
- Update the builtin's stop_ptr in `BuiltinRunner::final_stack`
- Restrict arguments in `BuiltinRunner` methods from `&VirtualMachine` to `&MemorySegementManager` and `&Memory` to avoid double borrows
- Remove quick fix from #768 
- Misc: fix BuiltinRunner's included field name 