### PR TITLE
Add method `CairoRunner::get_builtins_final_stack`

### DIFF
--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -213,7 +213,6 @@ impl RangeCheckBuiltinRunner {
                 let num_instances = self
                     .get_used_instances(segments)
                     .map_err(|_| RunnerError::FinalStack)?;
-
                 let used_cells = num_instances * self.cells_per_instance as usize;
                 if stop_ptr != used_cells {
                     return Err(RunnerError::InvalidStopPointer("range_check".to_string()));

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -213,6 +213,7 @@ impl RangeCheckBuiltinRunner {
                 let num_instances = self
                     .get_used_instances(segments)
                     .map_err(|_| RunnerError::FinalStack)?;
+
                 let used_cells = num_instances * self.cells_per_instance as usize;
                 if stop_ptr != used_cells {
                     return Err(RunnerError::InvalidStopPointer("range_check".to_string()));

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -1105,6 +1105,27 @@ impl CairoRunner {
             offset: 0,
         }
     }
+
+    // Iterates over the program builtins in reverse, calling BuiltinRunner::final_stack on each of them and returns the final pointer
+    // This method is used by cairo_rs_py to replace starknet functionality
+    pub fn get_builtins_final_stack(
+        &self,
+        vm: &mut VirtualMachine,
+        stack_ptr: Relocatable,
+    ) -> Result<Relocatable, RunnerError> {
+        let mut stack_ptr = Relocatable::from(&stack_ptr);
+        for (_, runner) in
+            vm.builtin_runners
+                .iter_mut()
+                .rev()
+                .filter(|(builtin_name, _builtin_runner)| {
+                    self.get_program_builtins().contains(builtin_name)
+                })
+        {
+            stack_ptr = runner.final_stack(&vm.segments, &vm.memory, stack_ptr)?
+        }
+        Ok(stack_ptr)
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -4287,4 +4287,64 @@ mod tests {
         let value = vec![MaybeRelocatable::from((0, 0))];
         assert_eq!(expected, value.into())
     }
+
+    #[test]
+    fn get_builtins_final_stack_range_check_builtin() {
+        let program = Program::from_file(
+            Path::new("cairo_programs/assert_le_felt_hint.json"),
+            Some("main"),
+        )
+        .unwrap();
+        let mut runner = cairo_runner!(program);
+        let mut vm = vm!();
+        let end = runner.initialize(&mut vm).unwrap();
+        runner
+            .run_until_pc(end, &mut vm, &mut BuiltinHintProcessor::new_empty())
+            .unwrap();
+        vm.segments.compute_effective_sizes(&vm.memory);
+        let initial_pointer = vm.get_ap();
+        let expected_pointer = vm.get_ap().sub_usize(1).unwrap();
+        assert_eq!(
+            runner.get_builtins_final_stack(&mut vm, initial_pointer),
+            Ok(expected_pointer)
+        );
+    }
+
+    #[test]
+    fn get_builtins_final_stack_4_builtins() {
+        let program =
+            Program::from_file(Path::new("cairo_programs/integration.json"), Some("main")).unwrap();
+        let mut runner = cairo_runner!(program);
+        let mut vm = vm!();
+        let end = runner.initialize(&mut vm).unwrap();
+        runner
+            .run_until_pc(end, &mut vm, &mut BuiltinHintProcessor::new_empty())
+            .unwrap();
+        vm.segments.compute_effective_sizes(&vm.memory);
+        let initial_pointer = vm.get_ap();
+        let expected_pointer = vm.get_ap().sub_usize(4).unwrap();
+        assert_eq!(
+            runner.get_builtins_final_stack(&mut vm, initial_pointer),
+            Ok(expected_pointer)
+        );
+    }
+
+    #[test]
+    fn get_builtins_final_stack_no_builtins() {
+        let program =
+            Program::from_file(Path::new("cairo_programs/fibonacci.json"), Some("main")).unwrap();
+        let mut runner = cairo_runner!(program);
+        let mut vm = vm!();
+        let end = runner.initialize(&mut vm).unwrap();
+        runner
+            .run_until_pc(end, &mut vm, &mut BuiltinHintProcessor::new_empty())
+            .unwrap();
+        vm.segments.compute_effective_sizes(&vm.memory);
+        let initial_pointer = vm.get_ap();
+        let expected_pointer = vm.get_ap();
+        assert_eq!(
+            runner.get_builtins_final_stack(&mut vm, initial_pointer),
+            Ok(expected_pointer)
+        );
+    }
 }


### PR DESCRIPTION
After the changes in #778, it is now not possible to implement this function from cairo_rs_py. So we need to expose it here.
Depends on #778 