### PR TITLE
Fix `return_fp` value in `CairoRunner::run_from_entrypoint`

### DIFF
--- a/src/vm/runners/builtin_runner/keccak.rs
+++ b/src/vm/runners/builtin_runner/keccak.rs
@@ -679,8 +679,10 @@ mod tests {
             ((0, 35), 0)
         ];
 
-        let mut keccak_instance = KeccakInstanceDef::default();
-        keccak_instance._state_rep = vec![1; 8];
+        let keccak_instance = KeccakInstanceDef {
+            _state_rep: vec![1; 8],
+            ..Default::default()
+        };
         let builtin = KeccakBuiltinRunner::new(&keccak_instance, true);
 
         let result = builtin.deduce_memory_cell(&Relocatable::from((0, 25)), &memory);

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -963,7 +963,7 @@ impl CairoRunner {
             .iter()
             .map(|arg| vm.segments.gen_cairo_arg(arg, &mut vm.memory))
             .collect::<Result<Vec<MaybeRelocatable>, VirtualMachineError>>()?;
-        let return_fp = vm.segments.add(&mut vm.memory);
+        let return_fp = MaybeRelocatable::from(0);
         let end = self.initialize_function_entrypoint(vm, entrypoint, stack, return_fp.into())?;
 
         self.initialize_vm(vm)?;

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -964,7 +964,7 @@ impl CairoRunner {
             .map(|arg| vm.segments.gen_cairo_arg(arg, &mut vm.memory))
             .collect::<Result<Vec<MaybeRelocatable>, VirtualMachineError>>()?;
         let return_fp = MaybeRelocatable::from(0);
-        let end = self.initialize_function_entrypoint(vm, entrypoint, stack, return_fp.into())?;
+        let end = self.initialize_function_entrypoint(vm, entrypoint, stack, return_fp)?;
 
         self.initialize_vm(vm)?;
 


### PR DESCRIPTION
Same fix as in cairo_rs_py https://github.com/lambdaclass/cairo-rs-py/pull/142
