### PR TITLE
Switch from Tarpaulin to llvm-cov

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,8 @@ jobs:
 
     - name: Install Nextest
       uses: taiki-e/install-action@nextest
+    - name: Install cargo-llvm-cov
+      uses: taiki-e/install-action@cargo-llvm-cov
 
     - name: Set up cargo cache
       uses: actions/cache@v3
@@ -83,7 +85,7 @@ jobs:
       uses: actions/upload-artifact@master
       with:
         name: codecov-report
-        path: target/tarpaulin
+        path: lcov.info
   upload-codecov:
     needs: build
     runs-on: ubuntu-20.04
@@ -92,9 +94,10 @@ jobs:
       uses: actions/download-artifact@master
       with:
         name: codecov-report
-        path: target/tarpaulin
+        path: lcov.info
     - name: Upload coverage to codecov.io
       uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        files: lcov.info
         fail_ci_if_error:     true

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,7 @@ deps:
 	cargo install --version 0.6.1 flamegraph
 	cargo install --version 1.14.0 hyperfine
 	cargo install --version 0.9.49 cargo-nextest
+	cargo install --version 0.5.9 cargo-llvm-cov
 	pyenv install pypy3.7-7.3.9
 	pyenv global pypy3.7-7.3.9
 	pip install cairo_lang
@@ -115,13 +116,13 @@ cairo_trace: $(CAIRO_TRACE) $(CAIRO_MEM)
 cairo-rs_trace: $(CAIRO_RS_TRACE) $(CAIRO_RS_MEM)
 
 test: $(COMPILED_PROOF_TESTS) $(COMPILED_TESTS) $(COMPILED_BAD_TESTS) $(COMPILED_NORETROCOMPAT_TESTS)
-	cargo nextest run --workspace --features test_utils
+	cargo llvm-cov nextest --no-report --workspace --features test_utils
 
 clippy:
 	cargo clippy --tests --examples --all-features -- -D warnings
 
 coverage:
-	docker run --security-opt seccomp=unconfined -v "${PWD}:/volume" xd009642/tarpaulin
+	cargo llvm-cov report --lcov --output-path lcov.info
 
 benchmark: $(COMPILED_BENCHES)
 	cargo criterion --bench criterion_benchmark


### PR DESCRIPTION
llvm-cov is both more accurate and portable (works natively in MacOS) than tarpaulin.
It also allows doing a single run for coverage and it can be used to report coverage from the memory comparison programs (will be addressed later).