### PR TITLE
Parallelize end-to-end tests in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -75,9 +75,9 @@ jobs:
     - name: Run tests
       run: make -j test
     - name: Compare trace and memory
-      run: make compare_trace_memory
+      run: make -j compare_trace_memory
     - name: Compare trace and memory with proof mode
-      run: make compare_trace_memory_proof
+      run: make -j compare_trace_memory_proof
     - name: Run clippy
       run: make clippy
     - name: Coverage

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,6 +53,7 @@ jobs:
     - name: Build
       run: make build
     - name: Populate cache
+      if: false
       uses: actions/cache@v3
       id: cache-cairo-programs
       with:

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ DBGBIN:=target/debug/cairo-rs-run
 	cairo_bench_programs cairo_proof_programs cairo_test_programs \
 	cairo_trace cairo-rs_trace $(RELBIN) $(DBGBIN)
 
+# Proof mode consumes too much memory with cairo-lang to execute
+# two instances at the same time in the CI without getting killed
+.NOTPARALLEL: $(CAIRO_TRACE_PROOF) $(CAIRO_MEM_PROOF)
+
 # ===================
 # Run with proof mode
 # ===================


### PR DESCRIPTION
End-to-end tests may take a long time, specially when the cache is invalidated. This attempts to exploit parallelism in the runners.
An exception had to be added for running `cairo-run` sequentially when proof mode was enabled due to running more than one concurrently triggered the OOM killer, failing the pipeline.
The cache for all cairo-related artifacts was disabled for testing.