### PR TITLE
docs(readme): add mention to valgrind for benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,10 +183,23 @@ Running a [Cairo program](./cairo_programs/benchmarks/fibonacci_1000_multirun.ca
 * [Flamegraph](./docs/benchmarks/flamegraph.svg)
 * Github action [results](https://lambdaclass.github.io/cairo-rs/)
 
-Run the benchmark suite with cargo:
+Note before running the benchmark suite: the benchmark named [iai_benchmark](https://github.com/lambdaclass/cairo-rs/blob/8dba86dbec935fa04a255e2edf3d5d184950fa22/Cargo.toml#L59) depends on Valgrind. Please make your it is installed prior to running the `iai_benchmark` benchmark.
+
+Run the complete benchmark suite with cargo:
 ```bash
 cargo bench
 ```
+
+Run only the `criterion_benchmark` benchmark suite with cargo:
+```bash
+cargo bench --bench criterion_benchmark
+```
+
+Run only the `iai_benchmark` benchmark suite with cargo:
+```bash
+cargo bench --bench iai_benchmark
+```
+
 
 ## 📜 Changelog
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Running a [Cairo program](./cairo_programs/benchmarks/fibonacci_1000_multirun.ca
 * [Flamegraph](./docs/benchmarks/flamegraph.svg)
 * Github action [results](https://lambdaclass.github.io/cairo-rs/)
 
-Note before running the benchmark suite: the benchmark named [iai_benchmark](https://github.com/lambdaclass/cairo-rs/blob/8dba86dbec935fa04a255e2edf3d5d184950fa22/Cargo.toml#L59) depends on Valgrind. Please make your it is installed prior to running the `iai_benchmark` benchmark.
+Note before running the benchmark suite: the benchmark named [iai_benchmark](https://github.com/lambdaclass/cairo-rs/blob/8dba86dbec935fa04a255e2edf3d5d184950fa22/Cargo.toml#L59) depends on Valgrind. Please make sure it is installed prior to running the `iai_benchmark` benchmark.
 
 Run the complete benchmark suite with cargo:
 ```bash


### PR DESCRIPTION
# Add mention to `valgrind` in global readme

## Description

`iai_benchmark` benchmark depends on `valgrind` to be installed on the system running the benchmark. 
This PR just mentions that valgrind should be installed prior to running `iai_benchmark`. 

It also adds instructions to run the two benchmarks separately : `iai_benchmark` and `criterion_benchmark`. 

## Checklist
- [x] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
- [x] Documentation has been added/updated.

closes https://github.com/lambdaclass/cairo-rs/issues/806 