### PR TITLE
add llvm cov dependency in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,11 @@ A demo on how to use `cairo-rs` with WebAssembly can be found
 [here](https://github.com/lambdaclass/cairo-rs-wasm).
 
 ### Testing
-To run the test suite:
+To run the test suite you'll need `cargo-llvm-cov` dependency so make sure to run this command beforehand:
+```bash
+make deps
+```
+Now that you have the dependencies necessary to run the test suite you can run:
 ```bash
 make test
 ```


### PR DESCRIPTION
# Add llvm cov dependency in the README

## Description

Add llvm cov dependency in the README. The test suite needs to have this dependency beforehand. 

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
