### PR TITLE
Fix codecov and include e2e tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,6 +82,9 @@ jobs:
     needs: build
     runs-on: ubuntu-20.04
     steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Retrieve cached report
       uses: actions/download-artifact@master
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,29 +70,12 @@ jobs:
       run: make clippy
     - name: Coverage
       run: make coverage
-    - name: Cache Codecov-report
-      uses: actions/upload-artifact@master
-      with:
-        name: codecov-report
-        path: lcov.info
-    # NB: the following step is needed so caching doesn't cause misleading coverage in later runs
-    - name: Clean coverage artifacts
-      run: make coverage-clean
-  upload-codecov:
-    needs: build
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: Retrieve cached report
-      uses: actions/download-artifact@master
-      with:
-        name: codecov-report
-        path: lcov.info
     - name: Upload coverage to codecov.io
       uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: lcov.info
         fail_ci_if_error:     true
+    # NB: the following step is needed so caching doesn't cause misleading coverage in later runs
+    - name: Clean coverage artifacts
+      run: make coverage-clean

--- a/.tarpaulin.toml
+++ b/.tarpaulin.toml
@@ -1,6 +1,0 @@
-[cairo-rs]
-exclude-files = []
-
-[report]
-output-dir = "target/tarpaulin"
-out = ["Html", "Xml"]

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ $(TEST_PROOF_DIR)/%.json: $(TEST_PROOF_DIR)/%.cairo
 	cairo-compile --cairo_path="$(TEST_PROOF_DIR):$(PROOF_BENCH_DIR)" $< --output $@ --proof_mode
 
 $(TEST_PROOF_DIR)/%.rs.trace $(TEST_PROOF_DIR)/%.rs.memory: $(TEST_PROOF_DIR)/%.json $(RELBIN)
-	./target/release/cairo-rs-run --layout all --proof_mode $< --trace_file $@ --memory_file $(@D)/$(*F).rs.memory
+	cargo llvm-cov run --release --no-report -- --layout all --proof_mode $< --trace_file $@ --memory_file $(@D)/$(*F).rs.memory
 
 $(TEST_PROOF_DIR)/%.trace $(TEST_PROOF_DIR)/%.memory: $(TEST_PROOF_DIR)/%.json
 	cairo-run --layout all --proof_mode --program $< --trace_file $@ --memory_file $(@D)/$(*F).memory
@@ -68,7 +68,7 @@ $(TEST_DIR)/%.json: $(TEST_DIR)/%.cairo
 	cairo-compile --cairo_path="$(TEST_DIR):$(BENCH_DIR)" $< --output $@
 
 $(TEST_DIR)/%.rs.trace $(TEST_DIR)/%.rs.memory: $(TEST_DIR)/%.json $(RELBIN)
-	./target/release/cairo-rs-run --layout all $< --trace_file $@ --memory_file $(@D)/$(*F).rs.memory
+	cargo llvm-cov run --release --no-report -- --layout all $< --trace_file $@ --memory_file $(@D)/$(*F).rs.memory
 
 $(TEST_DIR)/%.trace $(TEST_DIR)/%.memory: $(TEST_DIR)/%.json
 	cairo-run --layout all --program $< --trace_file $@ --memory_file $(@D)/$(*F).memory

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,0 @@
-fixes:
-  - "/home/runner/work/cairo-rs/::"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,3 @@
 fixes:
   - "lcov.info/lcov.info::"
+  - "/home/runner/work/cairo-rs/cairo-rs/::"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+fixes:
+  - "lcov.info/lcov.info::"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,3 @@
 fixes:
   - "lcov.info/lcov.info::"
-  - "/home/runner/work/cairo-rs/cairo-rs/::"
+  - "/home/runner/work/cairo-rs/::"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,2 @@
 fixes:
-  - "lcov.info/lcov.info::"
   - "/home/runner/work/cairo-rs/::"


### PR DESCRIPTION
This fixes codecov.io uploads by collapsing the two steps again, since using the token it no longer fails on upload and the culprit was the repo wasn't checked out in the second workflow.
It also changes the compare runs so they are built with llvm-cov support and are included in the coverage report.