### PR TITLE
Re-enable Cairo cache

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,7 +42,6 @@ jobs:
     - name: Build
       run: make build
     - name: Populate cache
-      if: false
       uses: actions/cache@v3
       id: cache-cairo-programs
       with:


### PR DESCRIPTION
A PR that disabled caches for testing was merged without reverting that.
