### PR TITLE
ci(codecov): upload codecov-report rather than lcov.info

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -83,14 +83,9 @@ jobs:
     needs: build
     runs-on: ubuntu-20.04
     steps:
-    - name: Retrieve cached report
-      uses: actions/download-artifact@master
-      with:
-        name: codecov-report
-        path: lcov.info
     - name: Upload coverage to codecov.io
       uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        files: lcov.info
+        files: ./codecov-report
         fail_ci_if_error:     true


### PR DESCRIPTION
# Upload Codecov reports

Related issue : https://github.com/lambdaclass/cairo-rs/issues/695 

## Description

Codecov does not see the coverage report

This PR modifies the GHA called `rust`. It uploads to codecov the file `codecov-report` rather than `lcov.info`. Moreover, it removes the step `Retrieve cached report` in job `upload-codecov` (the artifact is normally accessible by the `upload-codecov` job without downloading it. 

## Checklist
- [x] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
- [ ] Documentation has been added/updated.
