### PR TITLE
Add proptests for felt operations

### DIFF
--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -845,7 +845,7 @@ mod test {
         }
 
         #[test]
-        // Property-based test that ensures, for 100 {x} and {y} values that are randomly generated each time tests are run, that a multiplication with assignment between two felts {x} and {y} and doesn't fall outside the range [0, p]. The values of {x} and {y} can be either [0] or a very large number.
+        // Property-based test that ensures, for 100 pairs of {x} and {y} values that are randomly generated each time tests are run, that a multiplication with assignment between two felts {x} and {y} and doesn't fall outside the range [0, p]. The values of {x} and {y} can be either [0] or a very large number.
         fn mul_assign_in_range(ref x in "(0|[1-9][0-9]*)", ref y in "(0|[1-9][0-9]*)") {
             let mut x = Felt::parse_bytes(x.as_bytes(), 10).unwrap();
             let y = &Felt::parse_bytes(y.as_bytes(), 10).unwrap();
@@ -857,7 +857,7 @@ mod test {
         }
 
         #[test]
-        // Property-based test that ensures, for 100 {x} and {y} values that are randomly generated each time tests are run, that the result of the division of {x} by {y} is the inverse multiplicative of {x} --that is, multiplying the result by {y} returns the original number {x}. The values of {x} and {y} can be either [0] or a very large number.
+        // Property-based test that ensures, for 100 pairs of {x} and {y} values that are randomly generated each time tests are run, that the result of the division of {x} by {y} is the inverse multiplicative of {x} --that is, multiplying the result by {y} returns the original number {x}. The values of {x} and {y} can be either [0] or a very large number.
         fn div_is_mul_inv(ref x in "(0|[1-9][0-9]*)", ref y in "[1-9][0-9]*") {
             let x = &Felt::parse_bytes(x.as_bytes(), 10).unwrap();
             let y = &Felt::parse_bytes(y.as_bytes(), 10).unwrap();
@@ -902,7 +902,7 @@ mod test {
         }
 
         #[test]
-        // Property based test that ensures, for a pair of 100 values {x} and {y} generated at random each time tests are run, that performing a BitAnd operation between them returns a result that is inside of the range [0, p].
+        // Property based test that ensures, for 100 pairs of values {x} and {y} generated at random each time tests are run, that performing a BitAnd operation between them returns a result that is inside of the range [0, p].
         fn bitand_in_range(ref x in "(0|[1-9][0-9]*)", ref y in "(0|[1-9][0-9]*)"){
             let x = Felt::parse_bytes(x.as_bytes(), 10).unwrap();
             let y = Felt::parse_bytes(y.as_bytes(), 10).unwrap();
@@ -913,7 +913,7 @@ mod test {
         }
 
         #[test]
-        // Property based test that ensures, for a pair of 100 values {x} and {y} generated at random each time tests are run, that performing a BitOr operation between them returns a result that is inside of the range [0, p].
+        // Property based test that ensures, for 100 pairs of values {x} and {y} generated at random each time tests are run, that performing a BitOr operation between them returns a result that is inside of the range [0, p].
         fn bitor_in_range(ref x in "(0|[1-9][0-9]*)", ref y in "(0|[1-9][0-9]*)"){
             let x = Felt::parse_bytes(x.as_bytes(), 10).unwrap();
             let y = Felt::parse_bytes(y.as_bytes(), 10).unwrap();
@@ -923,7 +923,7 @@ mod test {
         }
 
         #[test]
-        // Property based test that ensures, for a pair of 100 values {x} and {y} generated at random each time tests are run, that performing a BitXor operation between them returns a result that is inside of the range [0, p].
+        // Property based test that ensures, for 100 pairs of values {x} and {y} generated at random each time tests are run, that performing a BitXor operation between them returns a result that is inside of the range [0, p].
         fn bitxor_in_range(ref x in "(0|[1-9][0-9]*)", ref y in "(0|[1-9][0-9]*)"){
             let x = Felt::parse_bytes(x.as_bytes(), 10).unwrap();
             let y = Felt::parse_bytes(y.as_bytes(), 10).unwrap();
@@ -943,6 +943,18 @@ mod test {
             let as_uint = &result.to_biguint();
             prop_assert!(as_uint < p, "{}", as_uint);
         }
+
+        #[test]
+        // Property based test that ensures, for 100 pairs of values {x} and {y} generated at random each time tests are run, that performing a Sum operation between them returns a result that is inside of the range [0, p].
+        fn sum_in_range(ref x in "[1-9][0-9]*", ref y in "[0-9][0-9]*"){
+            let x = &Felt::parse_bytes(x.as_bytes(), 10).unwrap();
+            let y = &Felt::parse_bytes(y.as_bytes(), 10).unwrap();
+            let p = &BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
+
+            let prod = x + y;
+            let as_uint = &prod.to_biguint();
+            prop_assert!(as_uint < p, "{}", as_uint);
+       }
 
         #[test]
         // Property test to check that lcm(x, y) works. Since we're operating in a prime field, lcm

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -977,27 +977,48 @@ mod test {
     }
 
     #[test]
-    // Checks that the result of adding two zeroes falls in range
+    // Checks that the result of adding two zeroes is zero
     fn sum_zeros_in_range() {
-        let x = &Felt::new(0);
-        let y = &Felt::new(0);
-        let p = &BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
-
-        let result = x + y;
-        let as_uint = &result.to_biguint();
-        assert!(as_uint < p, "{}", as_uint)
+        let x = Felt::new(0);
+        let y = Felt::new(0);
+        let z = Felt::new(0);
+        assert_eq!(x + y, z)
     }
 
     #[test]
-    // Checks that the result of multiplying two zeroes falls in range
+    // Checks that the result of multiplying two zeroes is zero
     fn mul_zeros_in_range() {
-        let x = &Felt::new(0);
-        let y = &Felt::new(0);
-        let p = &BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
+        let x = Felt::new(0);
+        let y = Felt::new(0);
+        let z = Felt::new(0);
+        assert_eq!(x * y, z)
+    }
 
-        let result = x * y;
-        let as_uint = &result.to_biguint();
-        println!("{}, {}, {}", x, y, result);
-        assert!(as_uint < p, "{}", as_uint)
+    #[test]
+    // Checks that the result of perfforming a bit and operation between zeroes is zero
+    fn bit_and_zeros_in_range() {
+        let x = Felt::new(0);
+        let y = Felt::new(0);
+        let z = Felt::new(0);
+        assert_eq!(&x & &y, z)
+    }
+
+    #[test]
+    // Checks that the result of perfforming a bit or operation between zeroes is zero
+    fn bit_or_zeros_in_range() {
+        let x = Felt::new(0);
+        let y = Felt::new(0);
+        let z = Felt::new(0);
+        assert_eq!(&x | &y, z)
+    }
+
+    #[test]
+    // Checks that the result of perfforming a bit xor operation between zeroes is zero
+    fn bit_xor_zeros_in_range() {
+        let x = Felt::new(0);
+        let y = Felt::new(0);
+        let z = Felt::new(0);
+        assert_eq!(&x ^ &y, z)
     }
 }
+

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -951,8 +951,8 @@ mod test {
             let y = &Felt::parse_bytes(y.as_bytes(), 10).unwrap();
             let p = &BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
 
-            let prod = x + y;
-            let as_uint = &prod.to_biguint();
+            let result = x + y;
+            let as_uint = &result.to_biguint();
             prop_assert!(as_uint < p, "{}", as_uint);
        }
 
@@ -963,7 +963,7 @@ mod test {
             let x = Felt::parse_bytes(x.as_bytes(), 10).unwrap();
             let y = Felt::parse_bytes(y.as_bytes(), 10).unwrap();
             let lcm = x.lcm(&y);
-            prop_assert!(lcm == std::cmp::max(x, y))
+            prop_assert!(lcm == std::cmp::max(x, y));
         }
 
         #[test]
@@ -972,7 +972,32 @@ mod test {
         fn is_multiple_of_doesnt_panic(ref x in "(0|[1-9][0-9]*)", ref y in "(0|[1-9][0-9]*)") {
             let x = Felt::parse_bytes(x.as_bytes(), 10).unwrap();
             let y = Felt::parse_bytes(y.as_bytes(), 10).unwrap();
-            assert!(x.is_multiple_of(&y));
+            prop_assert!(x.is_multiple_of(&y));
         }
+    }
+
+    #[test]
+     // Checks that the result of adding two zeroes falls in range
+    fn sum_zeros_in_range(){
+        let x = &Felt::new(0);
+        let y = &Felt::new(0);
+        let p = &BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
+
+        let result = x + y;
+        let as_uint = &result.to_biguint();
+        assert!(as_uint < p, "{}", as_uint)
+    }
+
+    #[test]
+    // Checks that the result of multiplying two zeroes falls in range
+    fn mul_zeros_in_range(){
+        let x = &Felt::new(0);
+        let y = &Felt::new(0);
+        let p = &BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
+
+        let result = x * y;
+        let as_uint = &result.to_biguint();
+        println!("{}, {}, {}", x, y, result);
+        assert!(as_uint < p, "{}", as_uint)
     }
 }

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -1021,4 +1021,3 @@ mod test {
         assert_eq!(&x ^ &y, z)
     }
 }
-

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -977,8 +977,8 @@ mod test {
     }
 
     #[test]
-     // Checks that the result of adding two zeroes falls in range
-    fn sum_zeros_in_range(){
+    // Checks that the result of adding two zeroes falls in range
+    fn sum_zeros_in_range() {
         let x = &Felt::new(0);
         let y = &Felt::new(0);
         let p = &BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();
@@ -990,7 +990,7 @@ mod test {
 
     #[test]
     // Checks that the result of multiplying two zeroes falls in range
-    fn mul_zeros_in_range(){
+    fn mul_zeros_in_range() {
         let x = &Felt::new(0);
         let y = &Felt::new(0);
         let p = &BigUint::parse_bytes(PRIME_STR[2..].as_bytes(), 16).unwrap();


### PR DESCRIPTION
# Add proptests for felts

## Description

Add more property tests using the proptest library for operations performed on felts.

## Checklist
- [x] Linked to Github Issue https://github.com/lambdaclass/cairo-rs/issues/700
- [x] Unit tests added 
- [-] Integration tests added.
- [x] This change requires new documentation.
  - [x] Documentation has been added/updated. Tests are documented in code comments
