### PR TITLE
feat(cairo_run): add CairoRunConfig struct

### DIFF
--- a/bench/criterion_benchmark.rs
+++ b/bench/criterion_benchmark.rs
@@ -27,16 +27,16 @@ const BENCH_PATH: &str = "cairo_programs/benchmarks/";
 
 pub fn criterion_benchmarks(c: &mut Criterion) {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_vm::cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     for benchmark_name in build_bench_strings() {
         c.bench_function(&benchmark_name.0, |b| {
             b.iter(|| {
-                let cairo_run_config = cairo_vm::cairo_run::CairoRunConfig {
-                    layout: "all",
-                    ..cairo_vm::cairo_run::CairoRunConfig::default()
-                };
                 cairo_run::cairo_run(
                     black_box(Path::new(&benchmark_name.1)),
-                    cairo_run_config,
+                    &cairo_run_config,
                     None,
                     &mut hint_executor,
                 )

--- a/bench/criterion_benchmark.rs
+++ b/bench/criterion_benchmark.rs
@@ -30,13 +30,13 @@ pub fn criterion_benchmarks(c: &mut Criterion) {
     for benchmark_name in build_bench_strings() {
         c.bench_function(&benchmark_name.0, |b| {
             b.iter(|| {
+                let cairo_run_config = cairo_vm::cairo_run::CairoRunConfig {
+                    layout: "all",
+                    ..cairo_vm::cairo_run::CairoRunConfig::default()
+                };
                 cairo_run::cairo_run(
                     black_box(Path::new(&benchmark_name.1)),
-                    "main",
-                    false,
-                    false,
-                    "all",
-                    false,
+                    cairo_run_config,
                     None,
                     &mut hint_executor,
                 )

--- a/bench/iai_benchmark.rs
+++ b/bench/iai_benchmark.rs
@@ -16,16 +16,11 @@ macro_rules! iai_bench_expand_prog {
                 stringify!($val),
                 ".json"
             ));
-            cairo_run(
-                black_box(path),
-                "main",
-                false,
-                false,
-                "all",
-                false,
-                None,
-                &mut hint_executor,
-            )
+            let cairo_run_config = cairo_vm::cairo_run::CairoRunConfig {
+                layout: "all",
+                ..cairo_vm::cairo_run::CairoRunConfig::default()
+            };
+            cairo_run(black_box(path), cairo_run_config, None, &mut hint_executor)
         }
     };
 }

--- a/bench/iai_benchmark.rs
+++ b/bench/iai_benchmark.rs
@@ -10,17 +10,17 @@ use iai::{black_box, main};
 macro_rules! iai_bench_expand_prog {
     ($val: ident) => {
         fn $val() -> Result<CairoRunner, CairoRunError> {
+            let cairo_run_config = cairo_vm::cairo_run::CairoRunConfig {
+                layout: "all",
+                ..cairo_vm::cairo_run::CairoRunConfig::default()
+            };
             let mut hint_executor = BuiltinHintProcessor::new_empty();
             let path = Path::new(concat!(
                 "cairo_programs/benchmarks/",
                 stringify!($val),
                 ".json"
             ));
-            let cairo_run_config = cairo_vm::cairo_run::CairoRunConfig {
-                layout: "all",
-                ..cairo_vm::cairo_run::CairoRunConfig::default()
-            };
-            cairo_run(black_box(path), cairo_run_config, None, &mut hint_executor)
+            cairo_run(black_box(path), &cairo_run_config, None, &mut hint_executor)
         }
     };
 }

--- a/src/cairo_run.rs
+++ b/src/cairo_run.rs
@@ -38,10 +38,9 @@ impl<'a> Default for CairoRunConfig<'a> {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 pub fn cairo_run(
     path: &Path,
-    cairo_run_config: CairoRunConfig,
+    cairo_run_config: &CairoRunConfig,
     secure_run: Option<bool>,
     hint_executor: &mut dyn HintProcessor,
 ) -> Result<CairoRunner, CairoRunError> {
@@ -236,7 +235,7 @@ mod tests {
         let cairo_run_config = CairoRunConfig::default();
         assert!(cairo_run(
             no_data_program_path,
-            cairo_run_config,
+            &cairo_run_config,
             None,
             &mut hint_processor
         )
@@ -252,7 +251,7 @@ mod tests {
         let cairo_run_config = CairoRunConfig::default();
         assert!(cairo_run(
             no_main_program_path,
-            cairo_run_config,
+            &cairo_run_config,
             None,
             &mut hint_processor
         )
@@ -266,7 +265,7 @@ mod tests {
         let mut hint_processor = BuiltinHintProcessor::new_empty();
         let invalid_memory = Path::new("cairo_programs/invalid_memory.json");
         let cairo_run_config = CairoRunConfig::default();
-        assert!(cairo_run(invalid_memory, cairo_run_config, None, &mut hint_processor).is_err());
+        assert!(cairo_run(invalid_memory, &cairo_run_config, None, &mut hint_processor).is_err());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,13 +49,16 @@ fn main() -> Result<(), CairoRunError> {
     let args = Args::parse();
     let trace_enabled = args.trace_file.is_some();
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        entrypoint: &args.entrypoint,
+        trace_enabled: trace_enabled,
+        print_output: args.print_output,
+        layout: &args.layout,
+        proof_mode: args.proof_mode,
+    };
     let cairo_runner = match cairo_run::cairo_run(
         &args.filename,
-        &args.entrypoint,
-        trace_enabled,
-        args.print_output,
-        &args.layout,
-        args.proof_mode,
+        cairo_run_config,
         args.secure_run,
         &mut hint_executor,
     ) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ fn main() -> Result<(), CairoRunError> {
     };
     let cairo_runner = match cairo_run::cairo_run(
         &args.filename,
-        cairo_run_config,
+        &cairo_run_config,
         args.secure_run,
         &mut hint_executor,
     ) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ fn main() -> Result<(), CairoRunError> {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
     let cairo_run_config = cairo_run::CairoRunConfig {
         entrypoint: &args.entrypoint,
-        trace_enabled: trace_enabled,
+        trace_enabled,
         print_output: args.print_output,
         layout: &args.layout,
         proof_mode: args.proof_mode,

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -1038,13 +1038,13 @@ mod tests {
     #[test]
     fn catch_point_same_x() {
         let program = Path::new("cairo_programs/bad_programs/ec_op_same_x.json");
+        let cairo_run_config = crate::cairo_run::CairoRunConfig {
+            layout: "all",
+            ..crate::cairo_run::CairoRunConfig::default()
+        };
         let result = crate::cairo_run::cairo_run(
             program,
-            "main",
-            false,
-            false,
-            "all",
-            false,
+            cairo_run_config,
             None,
             &mut BuiltinHintProcessor::new_empty(),
         );
@@ -1062,13 +1062,13 @@ mod tests {
     #[test]
     fn catch_point_not_in_curve() {
         let program = Path::new("cairo_programs/bad_programs/ec_op_not_in_curve.json");
+        let cairo_run_config = crate::cairo_run::CairoRunConfig {
+            layout: "all",
+            ..crate::cairo_run::CairoRunConfig::default()
+        };
         let result = crate::cairo_run::cairo_run(
             program,
-            "main",
-            false,
-            false,
-            "all",
-            false,
+            cairo_run_config,
             None,
             &mut BuiltinHintProcessor::new_empty(),
         );

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -1044,7 +1044,7 @@ mod tests {
         };
         let result = crate::cairo_run::cairo_run(
             program,
-            cairo_run_config,
+            &cairo_run_config,
             None,
             &mut BuiltinHintProcessor::new_empty(),
         );
@@ -1068,7 +1068,7 @@ mod tests {
         };
         let result = crate::cairo_run::cairo_run(
             program,
-            cairo_run_config,
+            &cairo_run_config,
             None,
             &mut BuiltinHintProcessor::new_empty(),
         );

--- a/tests/cairo_run_test.rs
+++ b/tests/cairo_run_test.rs
@@ -11,7 +11,7 @@ fn cairo_run_test() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/fibonacci.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -27,7 +27,7 @@ fn cairo_run_array_sum() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/array_sum.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -43,7 +43,7 @@ fn cairo_run_big_struct() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/big_struct.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -59,7 +59,7 @@ fn cairo_run_call_function_assign_param_by_name() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/call_function_assign_param_by_name.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -75,7 +75,7 @@ fn cairo_run_function_return() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/function_return.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -91,7 +91,7 @@ fn cairo_run_function_return_if_print() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/function_return_if_print.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -107,7 +107,7 @@ fn cairo_run_function_return_to_variable() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/function_return_to_variable.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -123,7 +123,7 @@ fn cairo_run_if_and_prime() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/if_and_prime.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -139,7 +139,7 @@ fn cairo_run_if_in_function() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/if_in_function.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -155,7 +155,7 @@ fn cairo_run_if_list() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/if_list.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -171,7 +171,7 @@ fn cairo_run_jmp() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/jmp.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -187,7 +187,7 @@ fn cairo_run_jmp_if_condition() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/jmp_if_condition.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -203,7 +203,7 @@ fn cairo_run_pointers() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/pointers.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -219,7 +219,7 @@ fn cairo_run_print() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/print.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -235,7 +235,7 @@ fn cairo_run_return() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/return.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -251,7 +251,7 @@ fn cairo_run_reversed_register_instructions() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/reversed_register_instructions.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -267,7 +267,7 @@ fn cairo_run_simple_print() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/simple_print.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -283,7 +283,7 @@ fn cairo_run_test_addition_if() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/test_addition_if.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -299,7 +299,7 @@ fn cairo_run_test_reverse_if() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/test_reverse_if.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -315,7 +315,7 @@ fn cairo_run_test_subtraction_if() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/test_subtraction_if.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -331,7 +331,7 @@ fn cairo_run_use_imported_module() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/use_imported_module.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -347,7 +347,7 @@ fn cairo_run_bitwise_output() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/bitwise_output.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -363,7 +363,7 @@ fn cairo_run_bitwise_recursion() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/bitwise_recursion.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -379,7 +379,7 @@ fn cairo_run_integration() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/integration.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -395,7 +395,7 @@ fn cairo_run_integration_with_alloc_locals() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/integration_with_alloc_locals.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -411,7 +411,7 @@ fn cairo_run_compare_arrays() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/compare_arrays.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -427,7 +427,7 @@ fn cairo_run_compare_greater_array() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/compare_greater_array.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -443,7 +443,7 @@ fn cairo_run_compare_lesser_array() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/compare_lesser_array.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -459,7 +459,7 @@ fn cairo_run_assert_le_felt_hint() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/assert_le_felt_hint.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -475,7 +475,7 @@ fn cairo_run_assert_250_bit_element_array() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/assert_250_bit_element_array.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -491,7 +491,7 @@ fn cairo_abs_value() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/abs_value_array.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -507,7 +507,7 @@ fn cairo_run_compare_different_arrays() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/compare_different_arrays.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -523,7 +523,7 @@ fn cairo_run_assert_nn() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/assert_nn.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -539,7 +539,7 @@ fn cairo_run_sqrt() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/sqrt.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -555,7 +555,7 @@ fn cairo_run_assert_not_zero() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/assert_not_zero.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -571,7 +571,7 @@ fn cairo_run_split_int() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/split_int.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -587,7 +587,7 @@ fn cairo_run_split_int_big() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/split_int_big.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -603,7 +603,7 @@ fn cairo_run_split_felt() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/split_felt.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -619,7 +619,7 @@ fn cairo_run_math_cmp() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/math_cmp.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -635,7 +635,7 @@ fn cairo_run_unsigned_div_rem() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/unsigned_div_rem.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -651,7 +651,7 @@ fn cairo_run_signed_div_rem() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/signed_div_rem.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -667,7 +667,7 @@ fn cairo_run_assert_lt_felt() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/assert_lt_felt.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -683,7 +683,7 @@ fn cairo_run_memcpy() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/memcpy_test.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -699,7 +699,7 @@ fn cairo_run_memset() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/memset.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -715,7 +715,7 @@ fn cairo_run_pow() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/pow.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -731,7 +731,7 @@ fn cairo_run_dict() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/dict.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -747,7 +747,7 @@ fn cairo_run_dict_update() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/dict_update.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -763,7 +763,7 @@ fn cairo_run_uint256() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/uint256.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -779,7 +779,7 @@ fn cairo_run_find_element() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/find_element.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -795,7 +795,7 @@ fn cairo_run_search_sorted_lower() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/search_sorted_lower.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -811,7 +811,7 @@ fn cairo_run_usort() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/usort.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -827,7 +827,7 @@ fn cairo_run_usort_bad() {
     };
     let err = cairo_run::cairo_run(
         Path::new("cairo_programs/bad_programs/bad_usort.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     );
@@ -848,7 +848,7 @@ fn cairo_run_dict_write_bad() {
     };
     assert!(cairo_run::cairo_run(
         Path::new("cairo_programs/bad_programs/bad_dict_new.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -860,7 +860,7 @@ fn cairo_run_dict_write_bad() {
     };
     let err = cairo_run::cairo_run(
         Path::new("cairo_programs/bad_programs/bad_dict_new.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -880,7 +880,7 @@ fn cairo_run_dict_update_bad() {
     };
     assert!(cairo_run::cairo_run(
         Path::new("cairo_programs/bad_programs/bad_dict_update.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -892,7 +892,7 @@ fn cairo_run_dict_update_bad() {
     };
     let err = cairo_run::cairo_run(
         Path::new("cairo_programs/bad_programs/bad_dict_update.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -911,7 +911,7 @@ fn cairo_run_squash_dict() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/squash_dict.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -927,7 +927,7 @@ fn cairo_run_dict_squash() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/dict_squash.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -943,7 +943,7 @@ fn cairo_run_set_add() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/set_add.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -959,7 +959,7 @@ fn cairo_run_secp() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/secp.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -975,7 +975,7 @@ fn cairo_run_signature() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/signature.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -991,7 +991,7 @@ fn cairo_run_secp_ec() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/secp_ec.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1007,7 +1007,7 @@ fn cairo_run_blake2s_hello_world_hash() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/blake2s_hello_world_hash.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1023,7 +1023,7 @@ fn cairo_run_finalize_blake2s() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/finalize_blake2s.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1038,7 +1038,7 @@ fn cairo_run_unsafe_keccak() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/unsafe_keccak.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1054,7 +1054,7 @@ fn cairo_run_blake2s_felts() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/blake2s_felts.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1070,7 +1070,7 @@ fn cairo_run_unsafe_keccak_finalize() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/unsafe_keccak_finalize.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1086,7 +1086,7 @@ fn cairo_run_keccak_add_uint256() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/keccak_add_uint256.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1102,7 +1102,7 @@ fn cairo_run_private_keccak() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/_keccak.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1118,7 +1118,7 @@ fn cairo_run_keccak_copy_inputs() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/keccak_copy_inputs.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1134,7 +1134,7 @@ fn cairo_run_finalize_keccak() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/cairo_finalize_keccak.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1150,7 +1150,7 @@ fn cairo_run_operations_with_data() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/operations_with_data_structures.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1166,7 +1166,7 @@ fn cairo_run_sha256() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/sha256.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1182,7 +1182,7 @@ fn cairo_run_math_cmp_and_pow_integration() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/math_cmp_and_pow_integration_tests.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1198,7 +1198,7 @@ fn cairo_run_uint256_integration() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/uint256_integration_tests.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1214,7 +1214,7 @@ fn cairo_run_set_integration() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/set_integration_tests.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1230,7 +1230,7 @@ fn cairo_run_memory_module_integration() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/memory_integration_tests.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1246,7 +1246,7 @@ fn cairo_run_dict_integration() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/dict_integration_tests.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1262,7 +1262,7 @@ fn cairo_run_secp_integration() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/secp_integration_tests.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1278,7 +1278,7 @@ fn cairo_run_keccak_integration() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/keccak_integration_tests.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1294,7 +1294,7 @@ fn cairo_run_blake2s_integration() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/blake2s_integration_tests.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1310,7 +1310,7 @@ fn cairo_run_relocate_segments() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/relocate_segments.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1326,7 +1326,7 @@ fn cairo_run_error_msg_attr() {
     };
     let err = cairo_run::cairo_run(
         Path::new("cairo_programs/bad_programs/error_msg_attr.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1345,7 +1345,7 @@ fn cairo_run_error_msg_attr_ap_based_reference() {
     };
     let err = cairo_run::cairo_run(
         Path::new("cairo_programs/bad_programs/error_msg_attr_tempvar.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1364,7 +1364,7 @@ fn cairo_run_error_msg_attr_complex_reference() {
     };
     let err = cairo_run::cairo_run(
         Path::new("cairo_programs/bad_programs/error_msg_attr_struct.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1382,7 +1382,7 @@ fn cairo_run_dict_store_cast_pointer() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/dict_store_cast_ptr.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1398,7 +1398,7 @@ fn cairo_run_verify_signature_hint() {
     };
     cairo_run::cairo_run(
         Path::new("cairo_programs/common_signature.json"),
-        cairo_run_config,
+        &cairo_run_config,
         None,
         &mut hint_executor,
     )

--- a/tests/cairo_run_test.rs
+++ b/tests/cairo_run_test.rs
@@ -5,13 +5,13 @@ use std::path::Path;
 #[test]
 fn cairo_run_test() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "small",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/fibonacci.json"),
-        "main",
-        false,
-        false,
-        "small",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -21,13 +21,13 @@ fn cairo_run_test() {
 #[test]
 fn cairo_run_array_sum() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "small",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/array_sum.json"),
-        "main",
-        false,
-        false,
-        "small",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -37,13 +37,13 @@ fn cairo_run_array_sum() {
 #[test]
 fn cairo_run_big_struct() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "small",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/big_struct.json"),
-        "main",
-        false,
-        false,
-        "small",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -53,13 +53,13 @@ fn cairo_run_big_struct() {
 #[test]
 fn cairo_run_call_function_assign_param_by_name() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "small",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/call_function_assign_param_by_name.json"),
-        "main",
-        false,
-        false,
-        "small",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -69,13 +69,13 @@ fn cairo_run_call_function_assign_param_by_name() {
 #[test]
 fn cairo_run_function_return() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "small",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/function_return.json"),
-        "main",
-        false,
-        false,
-        "small",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -85,13 +85,13 @@ fn cairo_run_function_return() {
 #[test]
 fn cairo_run_function_return_if_print() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "small",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/function_return_if_print.json"),
-        "main",
-        false,
-        false,
-        "small",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -101,13 +101,13 @@ fn cairo_run_function_return_if_print() {
 #[test]
 fn cairo_run_function_return_to_variable() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "small",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/function_return_to_variable.json"),
-        "main",
-        false,
-        false,
-        "small",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -117,13 +117,13 @@ fn cairo_run_function_return_to_variable() {
 #[test]
 fn cairo_run_if_and_prime() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "small",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/if_and_prime.json"),
-        "main",
-        false,
-        false,
-        "small",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -133,13 +133,13 @@ fn cairo_run_if_and_prime() {
 #[test]
 fn cairo_run_if_in_function() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "small",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/if_in_function.json"),
-        "main",
-        false,
-        false,
-        "small",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -149,13 +149,13 @@ fn cairo_run_if_in_function() {
 #[test]
 fn cairo_run_if_list() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "small",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/if_list.json"),
-        "main",
-        false,
-        false,
-        "small",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -165,13 +165,13 @@ fn cairo_run_if_list() {
 #[test]
 fn cairo_run_jmp() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "small",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/jmp.json"),
-        "main",
-        false,
-        false,
-        "small",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -181,13 +181,13 @@ fn cairo_run_jmp() {
 #[test]
 fn cairo_run_jmp_if_condition() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "small",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/jmp_if_condition.json"),
-        "main",
-        false,
-        false,
-        "small",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -197,13 +197,13 @@ fn cairo_run_jmp_if_condition() {
 #[test]
 fn cairo_run_pointers() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "small",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/pointers.json"),
-        "main",
-        false,
-        false,
-        "small",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -213,13 +213,13 @@ fn cairo_run_pointers() {
 #[test]
 fn cairo_run_print() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "small",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/print.json"),
-        "main",
-        false,
-        false,
-        "small",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -229,13 +229,13 @@ fn cairo_run_print() {
 #[test]
 fn cairo_run_return() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "small",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/return.json"),
-        "main",
-        false,
-        false,
-        "small",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -245,13 +245,13 @@ fn cairo_run_return() {
 #[test]
 fn cairo_run_reversed_register_instructions() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "small",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/reversed_register_instructions.json"),
-        "main",
-        false,
-        false,
-        "small",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -261,13 +261,13 @@ fn cairo_run_reversed_register_instructions() {
 #[test]
 fn cairo_run_simple_print() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "small",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/simple_print.json"),
-        "main",
-        false,
-        false,
-        "small",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -277,13 +277,13 @@ fn cairo_run_simple_print() {
 #[test]
 fn cairo_run_test_addition_if() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "small",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/test_addition_if.json"),
-        "main",
-        false,
-        false,
-        "small",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -293,13 +293,13 @@ fn cairo_run_test_addition_if() {
 #[test]
 fn cairo_run_test_reverse_if() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "small",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/test_reverse_if.json"),
-        "main",
-        false,
-        false,
-        "small",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -309,13 +309,13 @@ fn cairo_run_test_reverse_if() {
 #[test]
 fn cairo_run_test_subtraction_if() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "small",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/test_subtraction_if.json"),
-        "main",
-        false,
-        false,
-        "small",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -325,13 +325,13 @@ fn cairo_run_test_subtraction_if() {
 #[test]
 fn cairo_run_use_imported_module() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/use_imported_module.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -341,13 +341,13 @@ fn cairo_run_use_imported_module() {
 #[test]
 fn cairo_run_bitwise_output() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/bitwise_output.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -357,13 +357,13 @@ fn cairo_run_bitwise_output() {
 #[test]
 fn cairo_run_bitwise_recursion() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/bitwise_recursion.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -373,13 +373,13 @@ fn cairo_run_bitwise_recursion() {
 #[test]
 fn cairo_run_integration() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/integration.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -389,13 +389,13 @@ fn cairo_run_integration() {
 #[test]
 fn cairo_run_integration_with_alloc_locals() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/integration_with_alloc_locals.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -405,13 +405,13 @@ fn cairo_run_integration_with_alloc_locals() {
 #[test]
 fn cairo_run_compare_arrays() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/compare_arrays.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -421,13 +421,13 @@ fn cairo_run_compare_arrays() {
 #[test]
 fn cairo_run_compare_greater_array() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/compare_greater_array.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -437,13 +437,13 @@ fn cairo_run_compare_greater_array() {
 #[test]
 fn cairo_run_compare_lesser_array() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/compare_lesser_array.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -453,13 +453,13 @@ fn cairo_run_compare_lesser_array() {
 #[test]
 fn cairo_run_assert_le_felt_hint() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/assert_le_felt_hint.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -469,13 +469,13 @@ fn cairo_run_assert_le_felt_hint() {
 #[test]
 fn cairo_run_assert_250_bit_element_array() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/assert_250_bit_element_array.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -485,13 +485,13 @@ fn cairo_run_assert_250_bit_element_array() {
 #[test]
 fn cairo_abs_value() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/abs_value_array.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -501,13 +501,13 @@ fn cairo_abs_value() {
 #[test]
 fn cairo_run_compare_different_arrays() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/compare_different_arrays.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -517,13 +517,13 @@ fn cairo_run_compare_different_arrays() {
 #[test]
 fn cairo_run_assert_nn() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/assert_nn.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -533,13 +533,13 @@ fn cairo_run_assert_nn() {
 #[test]
 fn cairo_run_sqrt() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/sqrt.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -549,13 +549,13 @@ fn cairo_run_sqrt() {
 #[test]
 fn cairo_run_assert_not_zero() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/assert_not_zero.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -565,13 +565,13 @@ fn cairo_run_assert_not_zero() {
 #[test]
 fn cairo_run_split_int() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/split_int.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -581,13 +581,13 @@ fn cairo_run_split_int() {
 #[test]
 fn cairo_run_split_int_big() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/split_int_big.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -597,13 +597,13 @@ fn cairo_run_split_int_big() {
 #[test]
 fn cairo_run_split_felt() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/split_felt.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -613,13 +613,13 @@ fn cairo_run_split_felt() {
 #[test]
 fn cairo_run_math_cmp() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/math_cmp.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -629,13 +629,13 @@ fn cairo_run_math_cmp() {
 #[test]
 fn cairo_run_unsigned_div_rem() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/unsigned_div_rem.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -645,13 +645,13 @@ fn cairo_run_unsigned_div_rem() {
 #[test]
 fn cairo_run_signed_div_rem() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/signed_div_rem.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -661,13 +661,13 @@ fn cairo_run_signed_div_rem() {
 #[test]
 fn cairo_run_assert_lt_felt() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/assert_lt_felt.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -677,13 +677,13 @@ fn cairo_run_assert_lt_felt() {
 #[test]
 fn cairo_run_memcpy() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/memcpy_test.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -693,13 +693,13 @@ fn cairo_run_memcpy() {
 #[test]
 fn cairo_run_memset() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/memset.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -709,13 +709,13 @@ fn cairo_run_memset() {
 #[test]
 fn cairo_run_pow() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/pow.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -725,13 +725,13 @@ fn cairo_run_pow() {
 #[test]
 fn cairo_run_dict() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/dict.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -741,13 +741,13 @@ fn cairo_run_dict() {
 #[test]
 fn cairo_run_dict_update() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/dict_update.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -757,13 +757,13 @@ fn cairo_run_dict_update() {
 #[test]
 fn cairo_run_uint256() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/uint256.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -773,13 +773,13 @@ fn cairo_run_uint256() {
 #[test]
 fn cairo_run_find_element() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/find_element.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -789,13 +789,13 @@ fn cairo_run_find_element() {
 #[test]
 fn cairo_run_search_sorted_lower() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/search_sorted_lower.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -805,13 +805,13 @@ fn cairo_run_search_sorted_lower() {
 #[test]
 fn cairo_run_usort() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/usort.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -821,13 +821,13 @@ fn cairo_run_usort() {
 #[test]
 fn cairo_run_usort_bad() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     let err = cairo_run::cairo_run(
         Path::new("cairo_programs/bad_programs/bad_usort.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     );
@@ -842,25 +842,25 @@ fn cairo_run_usort_bad() {
 #[test]
 fn cairo_run_dict_write_bad() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     assert!(cairo_run::cairo_run(
         Path::new("cairo_programs/bad_programs/bad_dict_new.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
     .is_err());
 
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     let err = cairo_run::cairo_run(
         Path::new("cairo_programs/bad_programs/bad_dict_new.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -874,24 +874,25 @@ fn cairo_run_dict_write_bad() {
 #[test]
 fn cairo_run_dict_update_bad() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     assert!(cairo_run::cairo_run(
         Path::new("cairo_programs/bad_programs/bad_dict_update.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
     .is_err());
+
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     let err = cairo_run::cairo_run(
         Path::new("cairo_programs/bad_programs/bad_dict_update.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -904,13 +905,13 @@ fn cairo_run_dict_update_bad() {
 #[test]
 fn cairo_run_squash_dict() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/squash_dict.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -920,13 +921,13 @@ fn cairo_run_squash_dict() {
 #[test]
 fn cairo_run_dict_squash() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/dict_squash.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -936,13 +937,13 @@ fn cairo_run_dict_squash() {
 #[test]
 fn cairo_run_set_add() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/set_add.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -952,13 +953,13 @@ fn cairo_run_set_add() {
 #[test]
 fn cairo_run_secp() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/secp.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -968,13 +969,13 @@ fn cairo_run_secp() {
 #[test]
 fn cairo_run_signature() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/signature.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -984,13 +985,13 @@ fn cairo_run_signature() {
 #[test]
 fn cairo_run_secp_ec() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/secp_ec.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1000,13 +1001,13 @@ fn cairo_run_secp_ec() {
 #[test]
 fn cairo_run_blake2s_hello_world_hash() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/blake2s_hello_world_hash.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1016,13 +1017,13 @@ fn cairo_run_blake2s_hello_world_hash() {
 #[test]
 fn cairo_run_finalize_blake2s() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/finalize_blake2s.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1031,13 +1032,13 @@ fn cairo_run_finalize_blake2s() {
 #[test]
 fn cairo_run_unsafe_keccak() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/unsafe_keccak.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1047,13 +1048,13 @@ fn cairo_run_unsafe_keccak() {
 #[test]
 fn cairo_run_blake2s_felts() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/blake2s_felts.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1063,13 +1064,13 @@ fn cairo_run_blake2s_felts() {
 #[test]
 fn cairo_run_unsafe_keccak_finalize() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/unsafe_keccak_finalize.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1079,13 +1080,13 @@ fn cairo_run_unsafe_keccak_finalize() {
 #[test]
 fn cairo_run_keccak_add_uint256() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/keccak_add_uint256.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1095,13 +1096,13 @@ fn cairo_run_keccak_add_uint256() {
 #[test]
 fn cairo_run_private_keccak() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/_keccak.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1111,13 +1112,13 @@ fn cairo_run_private_keccak() {
 #[test]
 fn cairo_run_keccak_copy_inputs() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/keccak_copy_inputs.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1127,13 +1128,13 @@ fn cairo_run_keccak_copy_inputs() {
 #[test]
 fn cairo_run_finalize_keccak() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/cairo_finalize_keccak.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1143,13 +1144,13 @@ fn cairo_run_finalize_keccak() {
 #[test]
 fn cairo_run_operations_with_data() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/operations_with_data_structures.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1159,13 +1160,13 @@ fn cairo_run_operations_with_data() {
 #[test]
 fn cairo_run_sha256() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/sha256.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1175,13 +1176,13 @@ fn cairo_run_sha256() {
 #[test]
 fn cairo_run_math_cmp_and_pow_integration() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/math_cmp_and_pow_integration_tests.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1191,13 +1192,13 @@ fn cairo_run_math_cmp_and_pow_integration() {
 #[test]
 fn cairo_run_uint256_integration() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/uint256_integration_tests.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1207,13 +1208,13 @@ fn cairo_run_uint256_integration() {
 #[test]
 fn cairo_run_set_integration() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/set_integration_tests.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1223,13 +1224,13 @@ fn cairo_run_set_integration() {
 #[test]
 fn cairo_run_memory_module_integration() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/memory_integration_tests.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1239,13 +1240,13 @@ fn cairo_run_memory_module_integration() {
 #[test]
 fn cairo_run_dict_integration() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/dict_integration_tests.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1255,13 +1256,13 @@ fn cairo_run_dict_integration() {
 #[test]
 fn cairo_run_secp_integration() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/secp_integration_tests.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1271,13 +1272,13 @@ fn cairo_run_secp_integration() {
 #[test]
 fn cairo_run_keccak_integration() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/keccak_integration_tests.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1287,13 +1288,13 @@ fn cairo_run_keccak_integration() {
 #[test]
 fn cairo_run_blake2s_integration() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/blake2s_integration_tests.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1303,13 +1304,13 @@ fn cairo_run_blake2s_integration() {
 #[test]
 fn cairo_run_relocate_segments() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "small",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/relocate_segments.json"),
-        "main",
-        false,
-        false,
-        "small",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1319,13 +1320,13 @@ fn cairo_run_relocate_segments() {
 #[test]
 fn cairo_run_error_msg_attr() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     let err = cairo_run::cairo_run(
         Path::new("cairo_programs/bad_programs/error_msg_attr.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1338,13 +1339,13 @@ fn cairo_run_error_msg_attr() {
 #[test]
 fn cairo_run_error_msg_attr_ap_based_reference() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     let err = cairo_run::cairo_run(
         Path::new("cairo_programs/bad_programs/error_msg_attr_tempvar.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1357,13 +1358,13 @@ fn cairo_run_error_msg_attr_ap_based_reference() {
 #[test]
 fn cairo_run_error_msg_attr_complex_reference() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     let err = cairo_run::cairo_run(
         Path::new("cairo_programs/bad_programs/error_msg_attr_struct.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1375,13 +1376,13 @@ fn cairo_run_error_msg_attr_complex_reference() {
 #[test]
 fn cairo_run_dict_store_cast_pointer() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "small",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/dict_store_cast_ptr.json"),
-        "main",
-        false,
-        false,
-        "small",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )
@@ -1391,13 +1392,13 @@ fn cairo_run_dict_store_cast_pointer() {
 #[test]
 fn cairo_run_verify_signature_hint() {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
+    let cairo_run_config = cairo_run::CairoRunConfig {
+        layout: "all",
+        ..cairo_vm::cairo_run::CairoRunConfig::default()
+    };
     cairo_run::cairo_run(
         Path::new("cairo_programs/common_signature.json"),
-        "main",
-        false,
-        false,
-        "all",
-        false,
+        cairo_run_config,
         None,
         &mut hint_executor,
     )


### PR DESCRIPTION
# Add a CairoRunConfig `struct` to replace numerous arguments

## Description

As described in https://github.com/lambdaclass/cairo-rs/issues/772 the `cairo_run()` function receives many arguments corresponding to optional flags, this makes using `cairo_run` outside the command line quite bothersome.

This PS adds a `CairoRunConfig` struct with a default trait. Which makes it easier to use outside the command line :
* Tests (`cairo_run` and VM Runners)
* benchmarks

## Checklist
- [x] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
- [ ] Documentation has been added/updated.

closes https://github.com/lambdaclass/cairo-rs/issues/772 