### PR TITLE
Fix new clippy warnings in 1.67.0

### DIFF
--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -813,7 +813,7 @@ impl<const PH: u128, const PL: u128> fmt::Debug for FeltBigInt<PH, PL> {
 
 impl fmt::Display for ParseFeltError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", ParseFeltError)
+        write!(f, "{ParseFeltError:?}")
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ fn validate_layout(value: &str) -> Result<(), String> {
         "plain" | "small" | "dex" | "bitwise" | "perpetual_with_bitwise" | "recursive" | "all" => {
             Ok(())
         }
-        _ => Err(format!("{} is not a valid layout", value)),
+        _ => Err(format!("{value} is not a valid layout")),
     }
 }
 
@@ -64,7 +64,7 @@ fn main() -> Result<(), CairoRunError> {
     ) {
         Ok(runner) => runner,
         Err(error) => {
-            println!("{}", error);
+            println!("{error}");
             return Err(error);
         }
     };

--- a/src/types/errors/program_errors.rs
+++ b/src/types/errors/program_errors.rs
@@ -23,7 +23,7 @@ mod tests {
     #[test]
     fn format_entrypoint_not_found_error() {
         let error = ProgramError::EntrypointNotFound(String::from("my_function"));
-        let formatted_error = format!("{}", error);
+        let formatted_error = format!("{error}");
         assert_eq!(formatted_error, "Entrypoint my_function not found");
     }
 }

--- a/src/types/relocatable.rs
+++ b/src/types/relocatable.rs
@@ -77,7 +77,7 @@ impl Display for MaybeRelocatable {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             MaybeRelocatable::RelocatableValue(rel) => rel.fmt(f),
-            MaybeRelocatable::Int(num) => write!(f, "{}", num),
+            MaybeRelocatable::Int(num) => write!(f, "{num}"),
         }
     }
 }
@@ -237,7 +237,7 @@ impl MaybeRelocatable {
     /// Cant add two relocatable values
     pub fn add(&self, other: &MaybeRelocatable) -> Result<MaybeRelocatable, VirtualMachineError> {
         match (self, other) {
-            (&MaybeRelocatable::Int(ref num_a_ref), MaybeRelocatable::Int(num_b)) => {
+            (MaybeRelocatable::Int(num_a_ref), MaybeRelocatable::Int(num_b)) => {
                 Ok(MaybeRelocatable::Int(num_a_ref + num_b))
             }
             (&MaybeRelocatable::RelocatableValue(_), &MaybeRelocatable::RelocatableValue(_)) => {
@@ -263,7 +263,7 @@ impl MaybeRelocatable {
     /// Relocatable values can only be substracted if they belong to the same segment.
     pub fn sub(&self, other: &MaybeRelocatable) -> Result<MaybeRelocatable, VirtualMachineError> {
         match (self, other) {
-            (&MaybeRelocatable::Int(ref num_a), &MaybeRelocatable::Int(ref num_b)) => {
+            (MaybeRelocatable::Int(num_a), MaybeRelocatable::Int(num_b)) => {
                 Ok(MaybeRelocatable::Int(num_a - num_b))
             }
             (
@@ -296,7 +296,7 @@ impl MaybeRelocatable {
         other: &MaybeRelocatable,
     ) -> Result<(MaybeRelocatable, MaybeRelocatable), VirtualMachineError> {
         match (self, other) {
-            (&MaybeRelocatable::Int(ref val), &MaybeRelocatable::Int(ref div)) => Ok((
+            (MaybeRelocatable::Int(val), MaybeRelocatable::Int(div)) => Ok((
                 MaybeRelocatable::from(val / div),
                 // NOTE: elements on a field element always have multiplicative inverse
                 MaybeRelocatable::from(Felt::zero()),

--- a/src/vm/errors/vm_exception.rs
+++ b/src/vm/errors/vm_exception.rs
@@ -103,7 +103,7 @@ pub fn get_traceback(vm: &VirtualMachine, runner: &CairoRunner) -> Option<String
         }
     }
     (!traceback.is_empty())
-        .then(|| format!("Cairo traceback (most recent call last):\n{}", traceback))
+        .then(|| format!("Cairo traceback (most recent call last):\n{traceback}"))
 }
 
 // Substitutes references in the given error_message attribute with their actual value.
@@ -125,7 +125,7 @@ fn substitute_error_message_references(
             };
             // Format the variable name to make it easier to search for and replace in the error message
             // ie: x -> {x}
-            let formated_variable_name = format!("{{{}}}", cairo_variable_name);
+            let formated_variable_name = format!("{{{cairo_variable_name}}}");
             // Look for the formated name inside the error message
             if error_msg.contains(&formated_variable_name) {
                 // Get the value of the cairo variable from its reference id
@@ -137,8 +137,8 @@ fn substitute_error_message_references(
                 ) {
                     Some(cairo_variable) => {
                         // Replace the value in the error message
-                        error_msg = error_msg
-                            .replace(&formated_variable_name, &format!("{}", cairo_variable))
+                        error_msg =
+                            error_msg.replace(&formated_variable_name, &format!("{cairo_variable}"))
                     }
                     None => {
                         // If the reference is too complex or ap-based it might lead to a wrong value
@@ -154,7 +154,7 @@ fn substitute_error_message_references(
                 " (Cannot evaluate ap-based or complex references: [{}])",
                 invalid_references
                     .iter()
-                    .fold(String::new(), |acc, arg| acc + &format!("'{}'", arg))
+                    .fold(String::new(), |acc, arg| acc + &format!("'{arg}'"))
             ));
         }
     }
@@ -217,13 +217,13 @@ impl Display for VmException {
             }
             error_msg.push_str(&location_msg);
         } else {
-            error_msg.push_str(&format!("{}\n", message));
+            error_msg.push_str(&format!("{message}\n"));
         }
         if let Some(ref string) = self.traceback {
             error_msg.push_str(string);
         }
         // Write error message
-        write!(f, "{}", error_msg)
+        write!(f, "{error_msg}")
     }
 }
 
@@ -257,7 +257,7 @@ impl Location {
         }
         let start_line = split_lines[((self.start_line - 1) as usize)];
         let start_col = self.start_col as usize;
-        let mut result = format!("{}\n", start_line);
+        let mut result = format!("{start_line}\n");
         let end_col = if self.start_line == self.end_line {
             self.end_col as usize
         } else {
@@ -266,9 +266,9 @@ impl Location {
         let left_margin: String = vec![' '; start_col - 1].into_iter().collect();
         if end_col > start_col + 1 {
             let highlight: String = vec!['*'; end_col - start_col - 2].into_iter().collect();
-            result.push_str(&format!("{}^{}^", left_margin, highlight));
+            result.push_str(&format!("{left_margin}^{highlight}^"));
         } else {
-            result.push_str(&format!("{}^", left_margin))
+            result.push_str(&format!("{left_margin}^"))
         }
         result
     }

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -896,7 +896,7 @@ impl CairoRunner {
                 .get_integer(&(base, i).into())
                 .map_err(|_| RunnerError::MemoryGet((base, i).into()))?
                 .to_bigint();
-            writeln!(stdout, "{}", value).map_err(|_| RunnerError::WriteFail)?;
+            writeln!(stdout, "{value}").map_err(|_| RunnerError::WriteFail)?;
         }
 
         Ok(())


### PR DESCRIPTION
Can I bump my commit count by `1` by running `clippy --fix`?

We're locked to `1.66.1` for now but this PR fixes the new warnings that will be introduced once we move to `1.67.0`.