### PR TITLE
Move `Memory` into `MemorySegmentManager`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 #### Upcoming Changes
 
+* Move `Memory` into `MemorySegmentManager` [#830](https://github.com/lambdaclass/cairo-rs/pull/830)
+    * Structural changes:
+        * Remove `memory: Memory` field from `VirtualMachine`
+        * Add `memory: Memory` field to `MemorySegmentManager`
+    * As a result of this, multiple public methods' signatures changed:
+        * `BuiltinRunner` (and its inner enum types):
+            * `initialize_segments(&mut self, segments: &mut MemorySegmentManager, memory: &mut Memory)` -> `initialize_segments(&mut self, segments: &mut MemorySegmentManager)`
+            * `final_stack(&mut self, segments: &MemorySegmentManager, memory: &Memory, stack_pointer: Relocatable) -> Result<Relocatable, RunnerError>` -> `final_stack(&mut self, segments: &MemorySegmentManager, stack_pointer: Relocatable) -> Result<Relocatable, RunnerError>`
+        * `MemorySegmentManager`
+            * `add(&mut self, memory: &mut Memory) -> Relocatable` -> `add(&mut self) -> Relocatable`
+            * `add_temporary_segment(&mut self, memory: &mut Memory) -> Relocatable` -> `add_temporary_segment(&mut self) -> Relocatable`
+            * `load_data(&mut self, memory: &mut Memory, ptr: &MaybeRelocatable, data: &Vec<MaybeRelocatable>) -> Result<MaybeRelocatable, MemoryError>` -> `load_data(&mut self, ptr: &MaybeRelocatable, data: &Vec<MaybeRelocatable>) -> Result<MaybeRelocatable, MemoryError>`
+            * `compute_effective_sizes(&mut self, memory: &Memory) -> &Vec<usize>` -> `compute_effective_sizes(&mut self) -> &Vec<usize>`
+            * `gen_arg(&mut self, arg: &dyn Any, memory: &mut Memory) -> Result<MaybeRelocatable, VirtualMachineError>` -> `gen_arg(&mut self, arg: &dyn Any) -> Result<MaybeRelocatable, VirtualMachineError>`
+            * `gen_cairo_arg(&mut self, arg: &CairoArg, memory: &mut Memory) -> Result<MaybeRelocatable, VirtualMachineError>` -> `gen_cairo_arg(&mut self, arg: &CairoArg) -> Result<MaybeRelocatable, VirtualMachineError>`
+            * `write_arg(&mut self, memory: &mut Memory, ptr: &Relocatable, arg: &dyn Any) -> Result<MaybeRelocatable, MemoryError>` -> `write_arg(&mut self, ptr: &Relocatable, arg: &dyn Any) -> Result<MaybeRelocatable, MemoryError>`
+
 * Refactor `Memory::relocate memory` [#784](https://github.com/lambdaclass/cairo-rs/pull/784)
     * Bugfixes:
         * `Memory::relocate_memory` now moves data in the temporary memory relocated by a relocation rule to the real memory

--- a/src/hint_processor/builtin_hint_processor/blake2s_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/blake2s_utils.rs
@@ -218,6 +218,7 @@ pub fn blake2s_add_uint256_bigend(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
     use crate::{
         any_box,
         hint_processor::{

--- a/src/hint_processor/builtin_hint_processor/blake2s_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/blake2s_utils.rs
@@ -241,7 +241,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 1;
         //Insert ids into memory (output)
-        vm.memory = memory![((1, 0), (2, 5))];
+        vm.segments = segments![((1, 0), (2, 5))];
         //Create hint data
         let ids_data = ids_data!["output"];
         //Execute the hint
@@ -261,7 +261,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 1;
         //Insert ids into memory (output)
-        vm.memory = memory![((1, 0), (2, 26))];
+        vm.segments = segments![((1, 0), (2, 26))];
         add_segments!(vm, 1);
         //Create hint data
         let ids_data = ids_data!["output"];
@@ -282,7 +282,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 1;
         //Insert ids into memory (output)
-        vm.memory = memory![((1, 0), 12)];
+        vm.segments = segments![((1, 0), 12)];
         //Create hint data
         let ids_data = ids_data!["output"];
         //Execute the hint
@@ -302,7 +302,7 @@ mod tests {
         //Initialize fp
         //Insert ids into memory
         vm.run_context.fp = 1;
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 0), (2, 26)),
             ((2, 0), 7842562439562793675803603603688959_i128),
             ((2, 1), 7842562439562793675803603603688959_i128),
@@ -330,7 +330,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 1;
         //Insert ids into memory (output)
-        vm.memory = memory![((1, 0), (2, 26)), ((2, 0), (5, 5))];
+        vm.segments = segments![((1, 0), (2, 26)), ((2, 0), (5, 5))];
         //Create hint data
         let ids_data = ids_data!["output"];
         //Execute the hint
@@ -350,7 +350,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 1;
         //Insert ids into memory (output)
-        vm.memory = memory![((1, 0), (2, 0))];
+        vm.segments = segments![((1, 0), (2, 0))];
         add_segments!(vm, 1);
         //Create hint data
         let ids_data = ids_data!["blake2s_ptr_end"];
@@ -379,7 +379,8 @@ mod tests {
         ];
         //Get data from memory
         let data = get_fixed_size_u32_array::<204>(
-            &vm.memory
+            &vm.segments
+                .memory
                 .get_integer_range(&relocatable!(2, 0), 204)
                 .unwrap(),
         )
@@ -395,7 +396,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 1;
         //Insert ids into memory (output)
-        vm.memory = memory![((1, 0), (2, 0)), ((2, 0), (2, 0))];
+        vm.segments = segments![((1, 0), (2, 0)), ((2, 0), (2, 0))];
         let ids_data = ids_data!["blake2s_ptr_end"];
         //Execute the hint
         assert_eq!(
@@ -432,14 +433,14 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 3;
         //Insert ids into memory
-        vm.memory = memory![((1, 0), (2, 0)), ((1, 1), 0), ((1, 2), 0)];
-        vm.segments.add(&mut vm.memory);
+        vm.segments = segments![((1, 0), (2, 0)), ((1, 1), 0), ((1, 2), 0)];
+        vm.segments.add();
         let ids_data = ids_data!["data", "high", "low"];
         //Execute the hint
         assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
         //Check data ptr
         check_memory![
-            vm.memory,
+            vm.segments.memory,
             ((2, 0), 0),
             ((2, 1), 0),
             ((2, 2), 0),
@@ -449,7 +450,10 @@ mod tests {
             ((2, 6), 0),
             ((2, 7), 0)
         ];
-        assert_eq!(vm.memory.get(&MaybeRelocatable::from((2, 8))), Ok(None));
+        assert_eq!(
+            vm.segments.memory.get(&MaybeRelocatable::from((2, 8))),
+            Ok(None)
+        );
     }
 
     #[test]
@@ -460,14 +464,14 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 3;
         //Insert ids into memory
-        vm.memory = memory![((1, 0), (2, 0)), ((1, 1), 25), ((1, 2), 20)];
-        vm.segments.add(&mut vm.memory);
+        vm.segments = segments![((1, 0), (2, 0)), ((1, 1), 25), ((1, 2), 20)];
+        vm.segments.add();
         let ids_data = ids_data!["data", "high", "low"];
         //Execute the hint
         assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
         //Check data ptr
         check_memory![
-            vm.memory,
+            vm.segments.memory,
             ((2, 0), 20),
             ((2, 1), 0),
             ((2, 2), 0),
@@ -477,7 +481,10 @@ mod tests {
             ((2, 6), 0),
             ((2, 7), 0)
         ];
-        assert_eq!(vm.memory.get(&MaybeRelocatable::from((2, 8))), Ok(None));
+        assert_eq!(
+            vm.segments.memory.get(&MaybeRelocatable::from((2, 8))),
+            Ok(None)
+        );
     }
 
     #[test]
@@ -488,14 +495,14 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 3;
         //Insert ids into memory
-        vm.memory = memory![((1, 0), (2, 0)), ((1, 1), 0), ((1, 2), 0)];
+        vm.segments = segments![((1, 0), (2, 0)), ((1, 1), 0), ((1, 2), 0)];
         add_segments!(vm, 1);
         let ids_data = ids_data!["data", "high", "low"];
         //Execute the hint
         assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
         //Check data ptr
         check_memory![
-            vm.memory,
+            vm.segments.memory,
             ((2, 0), 0),
             ((2, 1), 0),
             ((2, 2), 0),
@@ -505,7 +512,10 @@ mod tests {
             ((2, 6), 0),
             ((2, 7), 0)
         ];
-        assert_eq!(vm.memory.get(&MaybeRelocatable::from((2, 8))), Ok(None));
+        assert_eq!(
+            vm.segments.memory.get(&MaybeRelocatable::from((2, 8))),
+            Ok(None)
+        );
     }
 
     #[test]
@@ -516,14 +526,14 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 3;
         //Insert ids into memory
-        vm.memory = memory![((1, 0), (2, 0)), ((1, 1), 25), ((1, 2), 20)];
-        vm.segments.add(&mut vm.memory);
+        vm.segments = segments![((1, 0), (2, 0)), ((1, 1), 25), ((1, 2), 20)];
+        vm.segments.add();
         let ids_data = ids_data!["data", "high", "low"];
         //Execute the hint
         assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
         //Check data ptr
         check_memory![
-            vm.memory,
+            vm.segments.memory,
             ((2, 0), 0),
             ((2, 1), 0),
             ((2, 2), 0),
@@ -533,6 +543,9 @@ mod tests {
             ((2, 6), 0),
             ((2, 7), 20)
         ];
-        assert_eq!(vm.memory.get(&MaybeRelocatable::from((2, 8))), Ok(None));
+        assert_eq!(
+            vm.segments.memory.get(&MaybeRelocatable::from((2, 8))),
+            Ok(None)
+        );
     }
 }

--- a/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -497,11 +497,11 @@ mod tests {
     fn run_alloc_hint_ap_is_not_empty() {
         let hint_code = "memory[ap] = segments.add()";
         let mut vm = vm!();
-        //Add 3 segments to the memory
-        add_segments!(vm, 3);
         vm.run_context.ap = 6;
         //Insert something into ap
         vm.segments = segments![((1, 6), (1, 6))];
+        //Add 1 extra segment to the memory
+        add_segments!(vm, 1);
         //ids and references are not needed for this test
         assert_eq!(
             run_hint!(vm, HashMap::new(), hint_code),

--- a/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -474,7 +474,7 @@ mod tests {
         //first new segment is added
         assert_eq!(vm.segments.num_segments, 2);
         //new segment base (1,0) is inserted into ap (1,0)
-        check_memory![vm.memory, ((1, 0), (1, 0))];
+        check_memory![vm.segments.memory, ((1, 0), (1, 0))];
     }
 
     #[test]
@@ -489,7 +489,7 @@ mod tests {
         //Segment N°4 is added
         assert_eq!(vm.segments.num_segments, 4);
         //new segment base (3,0) is inserted into ap (1,6)
-        check_memory![vm.memory, ((1, 6), (3, 0))];
+        check_memory![vm.segments.memory, ((1, 6), (3, 0))];
     }
 
     #[test]
@@ -500,7 +500,7 @@ mod tests {
         add_segments!(vm, 3);
         vm.run_context.ap = 6;
         //Insert something into ap
-        vm.memory = memory![((1, 6), (1, 6))];
+        vm.segments = segments![((1, 6), (1, 6))];
         //ids and references are not needed for this test
         assert_eq!(
             run_hint!(vm, HashMap::new(), hint_code),
@@ -533,7 +533,7 @@ mod tests {
         // initialize fp
         vm.run_context.fp = 2;
         // insert ids.len into memory
-        vm.memory = memory![((1, 1), 5)];
+        vm.segments = segments![((1, 1), 5)];
         let ids_data = ids_data!["len"];
         assert!(run_hint!(vm, ids_data, hint_code).is_ok());
     }
@@ -548,7 +548,7 @@ mod tests {
         vm.run_context.fp = 2;
         // insert ids.len into memory
         // we insert a relocatable value in the address of ids.len so that it raises an error.
-        vm.memory = memory![((1, 1), (1, 0))];
+        vm.segments = segments![((1, 1), (1, 0))];
 
         let ids_data = ids_data!["len"];
         assert_eq!(
@@ -571,7 +571,7 @@ mod tests {
         let mut exec_scopes = scope![("n", Felt::one())];
         // initialize ids.continue_copying
         // we create a memory gap so that there is None in (1, 0), the actual addr of continue_copying
-        vm.memory = memory![((1, 2), 5)];
+        vm.segments = segments![((1, 2), 5)];
         let ids_data = ids_data!["continue_copying"];
         assert!(run_hint!(vm, ids_data, hint_code, &mut exec_scopes).is_ok());
     }
@@ -586,7 +586,7 @@ mod tests {
         vm.run_context.fp = 3;
         // we don't initialize `n` now:
         // initialize ids
-        vm.memory = memory![((0, 2), 5)];
+        vm.segments = segments![((0, 2), 5)];
         let ids_data = ids_data!["continue_copying"];
         assert_eq!(
             run_hint!(vm, ids_data, hint_code),
@@ -606,7 +606,7 @@ mod tests {
         let mut exec_scopes = scope![("n", Felt::one())];
         // initialize ids.continue_copying
         // a value is written in the address so the hint cant insert value there
-        vm.memory = memory![((1, 1), 5)];
+        vm.segments = segments![((1, 1), 5)];
 
         let ids_data = ids_data!["continue_copying"];
         assert_eq!(
@@ -675,7 +675,7 @@ mod tests {
         // initialize fp
         vm.run_context.fp = 5;
         // insert ids into memory
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 1), 3),
             ((2, 0), 1),
             ((2, 1), 1),
@@ -697,7 +697,7 @@ mod tests {
         // initialize fp
         vm.run_context.fp = 5;
         // insert ids into memory
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 1), 5),
             ((2, 0), 1),
             ((2, 1), 1),
@@ -721,7 +721,7 @@ mod tests {
         // initialize fp
         vm.run_context.fp = 4;
         // insert ids into memory
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 1), 18446744073709551616_i128),
             ((1, 5), 0),
             ((2, 0), 1),
@@ -742,7 +742,7 @@ mod tests {
         // initialize fp
         vm.run_context.fp = 5;
         // insert ids into memory
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 1), 3),
             ((1, 5), 0),
             ((2, 0), (-1)),
@@ -766,7 +766,7 @@ mod tests {
         add_segments!(vm, 2);
         // initialize fp
         vm.run_context.fp = 9;
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 1), (1, 2)),
             ((1, 2), (1, 4)),
             ((1, 3), (1, 5)),
@@ -786,7 +786,7 @@ mod tests {
         add_segments!(vm, 2);
         // initialize fp
         vm.run_context.fp = 9;
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 1), (1, 2)),
             ((1, 2), (1, 4)),
             ((1, 3), (1, 5)),
@@ -808,7 +808,7 @@ mod tests {
         add_segments!(vm, 2);
         // initialize fp
         vm.run_context.fp = 9;
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 1), (1, 2)),
             ((1, 2), (1, 4)),
             ((1, 3), (1, 5)),

--- a/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -447,6 +447,7 @@ impl HintProcessor for BuiltinHintProcessor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
     use crate::{
         any_box,
         hint_processor::hint_processor_definition::HintProcessor,

--- a/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -488,7 +488,7 @@ mod tests {
         //ids and references are not needed for this test
         run_hint!(vm, HashMap::new(), hint_code).expect("Error while executing hint");
         //Segment N°4 is added
-        assert_eq!(vm.segments.num_segments, 4);
+        assert_eq!(vm.segments.num_segments(), 4);
         //new segment base (3,0) is inserted into ap (1,6)
         check_memory![vm.segments.memory, ((1, 6), (3, 0))];
     }

--- a/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -473,7 +473,7 @@ mod tests {
         //ids and references are not needed for this test
         run_hint!(vm, HashMap::new(), hint_code).expect("Error while executing hint");
         //first new segment is added
-        assert_eq!(vm.segments.num_segments, 2);
+        assert_eq!(vm.segments.num_segments(), 2);
         //new segment base (1,0) is inserted into ap (1,0)
         check_memory![vm.segments.memory, ((1, 0), (1, 0))];
     }

--- a/src/hint_processor/builtin_hint_processor/cairo_keccak/keccak_hints.rs
+++ b/src/hint_processor/builtin_hint_processor/cairo_keccak/keccak_hints.rs
@@ -254,6 +254,7 @@ pub fn u64_array_to_mayberelocatable_vec(array: &[u64]) -> Vec<MaybeRelocatable>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
     use crate::{
         any_box,
         hint_processor::{

--- a/src/hint_processor/builtin_hint_processor/cairo_keccak/keccak_hints.rs
+++ b/src/hint_processor/builtin_hint_processor/cairo_keccak/keccak_hints.rs
@@ -275,7 +275,7 @@ mod tests {
     fn keccak_write_args_valid_test() {
         let hint_code = "segments.write_arg(ids.inputs, [ids.low % 2 ** 64, ids.low // 2 ** 64])\nsegments.write_arg(ids.inputs + 2, [ids.high % 2 ** 64, ids.high // 2 ** 64])";
         let mut vm = vm_with_range_check!();
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 0), 233),
             ((1, 1), 351),
             ((1, 2), (2, 0)),
@@ -292,7 +292,7 @@ mod tests {
     fn keccak_write_args_write_error() {
         let hint_code = "segments.write_arg(ids.inputs, [ids.low % 2 ** 64, ids.low // 2 ** 64])\nsegments.write_arg(ids.inputs + 2, [ids.high % 2 ** 64, ids.high // 2 ** 64])";
         let mut vm = vm_with_range_check!();
-        vm.memory = memory![((1, 0), 233), ((1, 1), 351), ((1, 2), (2, 0))];
+        vm.segments = segments![((1, 0), 233), ((1, 1), 351), ((1, 2), (2, 0))];
         //Initialize fp
         vm.run_context.fp = 3;
         //Create ids
@@ -310,8 +310,8 @@ mod tests {
             "memory[ap] = to_felt_or_relocatable(ids.n_bytes >= ids.KECCAK_FULL_RATE_IN_BYTES)";
         let mut vm = vm_with_range_check!();
 
-        vm.segments.add(&mut vm.memory);
-        vm.memory = memory![((1, 0), 24)];
+        vm.segments.add();
+        vm.segments = segments![((1, 0), 24)];
 
         run_context!(vm, 0, 1, 1);
         let ids_data = ids_data!["n_bytes"];
@@ -337,8 +337,8 @@ mod tests {
 
         let mut vm = vm_with_range_check!();
 
-        vm.segments.add(&mut vm.memory);
-        vm.memory = memory![((1, 0), 24)];
+        vm.segments.add();
+        vm.segments = segments![((1, 0), 24)];
 
         run_context!(vm, 0, 1, 1);
 
@@ -364,8 +364,8 @@ mod tests {
             "memory[ap] = to_felt_or_relocatable(ids.n_bytes >= ids.KECCAK_FULL_RATE_IN_BYTES)";
         let mut vm = vm_with_range_check!();
 
-        vm.segments.add(&mut vm.memory);
-        vm.memory = memory![((1, 0), 24)];
+        vm.segments.add();
+        vm.segments = segments![((1, 0), 24)];
 
         run_context!(vm, 0, 1, 1);
 

--- a/src/hint_processor/builtin_hint_processor/dict_hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/dict_hint_utils.rs
@@ -260,6 +260,7 @@ mod tests {
     use crate::types::exec_scope::ExecutionScopes;
     use crate::vm::errors::vm_errors::VirtualMachineError;
     use crate::vm::vm_memory::memory::Memory;
+    use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
     use crate::{
         hint_processor::builtin_hint_processor::dict_manager::{DictManager, DictTracker},
         relocatable,

--- a/src/hint_processor/builtin_hint_processor/dict_hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/dict_hint_utils.rs
@@ -333,7 +333,7 @@ mod tests {
                 )
             ))) if x == MaybeRelocatable::from((1, 0)) &&
                     y == MaybeRelocatable::from(1) &&
-                    z == MaybeRelocatable::from((0, 0))
+                    z == MaybeRelocatable::from((2, 0))
         );
     }
 

--- a/src/hint_processor/builtin_hint_processor/dict_hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/dict_hint_utils.rs
@@ -285,7 +285,7 @@ mod tests {
         run_hint!(vm, HashMap::new(), hint_code, &mut exec_scopes)
             .expect("Error while executing hint");
         //first new segment is added for the dictionary
-        assert_eq!(vm.segments.num_segments, 2);
+        assert_eq!(vm.segments.num_segments(), 2);
         //new segment base (1,0) is inserted into ap (1,0)
         check_memory![vm.segments.memory, ((1, 0), (1, 0))];
         //Check the dict manager has a tracker for segment 0,

--- a/src/hint_processor/builtin_hint_processor/dict_hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/dict_hint_utils.rs
@@ -286,7 +286,7 @@ mod tests {
         //first new segment is added for the dictionary
         assert_eq!(vm.segments.num_segments, 2);
         //new segment base (1,0) is inserted into ap (1,0)
-        check_memory![vm.memory, ((1, 0), (1, 0))];
+        check_memory![vm.segments.memory, ((1, 0), (1, 0))];
         //Check the dict manager has a tracker for segment 0,
         //and that tracker contains the ptr (1,0) and an empty dict
         assert_eq!(
@@ -319,7 +319,7 @@ mod tests {
             "initial_dict",
             HashMap::<MaybeRelocatable, MaybeRelocatable>::new()
         )];
-        vm.memory = memory![((1, 0), 1)];
+        vm.segments = segments![((1, 0), 1)];
         //ids and references are not needed for this test
         assert_eq!(
             run_hint!(vm, HashMap::new(), hint_code, &mut exec_scopes),
@@ -340,7 +340,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 3;
         //Insert ids into memory
-        vm.memory = memory![((1, 0), 5), ((1, 2), (2, 0))];
+        vm.segments = segments![((1, 0), 5), ((1, 2), (2, 0))];
         let ids_data = ids_data!["key", "value", "dict_ptr"];
         add_segments!(vm, 1);
         let mut exec_scopes = ExecutionScopes::new();
@@ -349,7 +349,8 @@ mod tests {
         assert_eq!(run_hint!(vm, ids_data, hint_code, &mut exec_scopes), Ok(()));
         //Check that value variable (at address (1,1)) contains the proper value
         assert_eq!(
-            vm.memory
+            vm.segments
+                .memory
                 .get(&MaybeRelocatable::from((1, 1)))
                 .unwrap()
                 .unwrap()
@@ -367,7 +368,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 3;
         //Insert ids into memory
-        vm.memory = memory![((1, 0), 6), ((1, 2), (2, 0))];
+        vm.segments = segments![((1, 0), 6), ((1, 2), (2, 0))];
         let ids_data = ids_data!["key", "value", "dict_ptr"];
         //Execute the hint
         let mut exec_scopes = ExecutionScopes::new();
@@ -387,7 +388,7 @@ mod tests {
         let mut exec_scopes = scope![("dict_manager", Rc::new(RefCell::new(DictManager::new())))];
 
         //Insert ids into memory
-        vm.memory = memory![((1, 0), 6), ((1, 2), (2, 0))];
+        vm.segments = segments![((1, 0), 6), ((1, 2), (2, 0))];
         add_segments!(vm, 1);
         let ids_data = ids_data!["key", "value", "dict_ptr"];
         //Execute the hint
@@ -403,14 +404,14 @@ mod tests {
         let mut vm = vm!();
         run_context!(vm, 0, 1, 1);
         //insert ids.default_value into memory
-        vm.memory = memory![((1, 0), 17)];
+        vm.segments = segments![((1, 0), 17)];
         let ids_data = ids_data!["default_value"];
         let mut exec_scopes = ExecutionScopes::new();
         run_hint!(vm, ids_data, hint_code, &mut exec_scopes).expect("Error while executing hint");
         //third new segment is added for the dictionary
-        assert_eq!(vm.memory.data.len(), 3);
+        assert_eq!(vm.segments.memory.data.len(), 3);
         //new segment base (0,0) is inserted into ap (0,0)
-        check_memory![vm.memory, ((1, 1), (0, 0))];
+        check_memory![vm.segments.memory, ((1, 1), (0, 0))];
         //Check the dict manager has a tracker for segment 0,
         //and that tracker contains the ptr (0,0) and an empty dict
         assert_eq!(
@@ -450,7 +451,7 @@ mod tests {
         let mut exec_scopes = ExecutionScopes::new();
         dict_manager_default!(&mut exec_scopes, 2, 2);
         //Insert ids into memory
-        vm.memory = memory![((1, 0), 5), ((1, 1), 17), ((1, 2), (2, 0))];
+        vm.segments = segments![((1, 0), 5), ((1, 1), 17), ((1, 2), (2, 0))];
         add_segments!(vm, 1);
         //ids.value (at (1, 0))
         //ids.dict_ptr (2, 0):
@@ -465,7 +466,7 @@ mod tests {
         //Check that the tracker's current_ptr has moved accordingly
         check_dict_ptr!(exec_scopes, 2, (2, 3));
         //Check the value of dict_ptr.prev_value, should be equal to the default_value (2)
-        check_memory![vm.memory, ((2, 1), 2)];
+        check_memory![vm.segments.memory, ((2, 1), 2)];
     }
 
     #[test]
@@ -477,7 +478,7 @@ mod tests {
         let mut exec_scopes = ExecutionScopes::new();
         dict_manager_default!(exec_scopes, 2, 2, (5, 10));
         //Insert ids into memory
-        vm.memory = memory![((1, 0), 5), ((1, 1), 17), ((1, 2), (2, 0))];
+        vm.segments = segments![((1, 0), 5), ((1, 1), 17), ((1, 2), (2, 0))];
         add_segments!(vm, 1);
         //ids.value (at (1, 0))
         //ids.dict_ptr (2, 0):
@@ -492,7 +493,7 @@ mod tests {
         //Check that the tracker's current_ptr has moved accordingly
         check_dict_ptr!(exec_scopes, 2, (2, 3));
         //Check the value of dict_ptr.prev_value, should be equal to the previously inserted value (10)
-        check_memory![vm.memory, ((2, 1), 10)];
+        check_memory![vm.segments.memory, ((2, 1), 10)];
     }
 
     #[test]
@@ -504,7 +505,7 @@ mod tests {
         let mut exec_scopes = ExecutionScopes::new();
         dict_manager!(exec_scopes, 2, (5, 10));
         //Insert ids into memory
-        vm.memory = memory![((1, 0), 5), ((1, 1), 17), ((1, 2), (2, 0))];
+        vm.segments = segments![((1, 0), 5), ((1, 1), 17), ((1, 2), (2, 0))];
         add_segments!(vm, 1);
         //ids.value (at (2, 0))
         //ids.dict_ptr (2, 0):
@@ -520,7 +521,7 @@ mod tests {
         check_dict_ptr!(exec_scopes, 2, (2, 3));
         check_dict_ptr!(exec_scopes, 2, (2, 3));
         //Check the value of dict_ptr.prev_value, should be equal to the previously inserted value (10)
-        check_memory![vm.memory, ((2, 1), 10)];
+        check_memory![vm.segments.memory, ((2, 1), 10)];
     }
 
     #[test]
@@ -532,7 +533,7 @@ mod tests {
         let mut exec_scopes = ExecutionScopes::new();
         dict_manager!(exec_scopes, 2);
         //Insert ids into memory
-        vm.memory = memory![((1, 0), 5), ((1, 1), 17), ((1, 2), (2, 0))];
+        vm.segments = segments![((1, 0), 5), ((1, 1), 17), ((1, 2), (2, 0))];
         add_segments!(vm, 1);
         //ids.value (at (1, 0))
         //ids.dict_ptr (2, 0):
@@ -556,7 +557,7 @@ mod tests {
         let mut exec_scopes = ExecutionScopes::new();
         dict_manager!(exec_scopes, 2, (5, 10));
         //Insert ids into memory
-        vm.memory = memory![((1, 0), 5), ((1, 1), 10), ((1, 2), 20), ((1, 3), (2, 0))];
+        vm.segments = segments![((1, 0), 5), ((1, 1), 10), ((1, 2), 20), ((1, 3), (2, 0))];
         add_segments!(vm, 1);
         //ids.dict_ptr (2, 0):
         //  dict_ptr.key = (2, 1)
@@ -580,7 +581,7 @@ mod tests {
         let mut exec_scopes = ExecutionScopes::new();
         dict_manager!(exec_scopes, 2, (5, 10));
         //Insert ids into memory
-        vm.memory = memory![((1, 0), 5), ((1, 1), 10), ((1, 2), 10), ((1, 3), (2, 0))];
+        vm.segments = segments![((1, 0), 5), ((1, 1), 10), ((1, 2), 10), ((1, 3), (2, 0))];
         add_segments!(vm, 1);
         //ids.dict_ptr (2, 0):
         //  dict_ptr.key = (2, 1)
@@ -604,7 +605,7 @@ mod tests {
         let mut exec_scopes = ExecutionScopes::new();
         dict_manager!(exec_scopes, 2, (5, 10));
         //Insert ids into memory
-        vm.memory = memory![((1, 0), 5), ((1, 1), 11), ((1, 2), 20), ((1, 3), (2, 0))];
+        vm.segments = segments![((1, 0), 5), ((1, 1), 11), ((1, 2), 20), ((1, 3), (2, 0))];
         add_segments!(vm, 1);
         //ids.dict_ptr (2, 0):
         //  dict_ptr.key = (2, 1)
@@ -631,7 +632,7 @@ mod tests {
         let mut exec_scopes = ExecutionScopes::new();
         dict_manager!(exec_scopes, 2, (5, 10));
         //Insert ids into memory
-        vm.memory = memory![((1, 0), 6), ((1, 1), 10), ((1, 2), 10), ((1, 3), (2, 0))];
+        vm.segments = segments![((1, 0), 6), ((1, 1), 10), ((1, 2), 10), ((1, 3), (2, 0))];
         add_segments!(vm, 1);
         //ids.dict_ptr (2, 0):
         //  dict_ptr.key = (2, 1)
@@ -654,7 +655,7 @@ mod tests {
         let mut exec_scopes = ExecutionScopes::new();
         dict_manager!(exec_scopes, 2, (5, 10));
         //Insert ids into memory
-        vm.memory = memory![((1, 0), 5), ((1, 1), 10), ((1, 2), 20), ((1, 3), (2, 0))];
+        vm.segments = segments![((1, 0), 5), ((1, 1), 10), ((1, 2), 20), ((1, 3), (2, 0))];
         add_segments!(vm, 1);
         //ids.dict_ptr (2, 0):
         //  dict_ptr.key = (2, 1)
@@ -678,7 +679,7 @@ mod tests {
         let mut exec_scopes = ExecutionScopes::new();
         dict_manager!(exec_scopes, 2, (5, 10));
         //Insert ids into memory
-        vm.memory = memory![((1, 0), 5), ((1, 1), 10), ((1, 2), 10), ((1, 3), (2, 0))];
+        vm.segments = segments![((1, 0), 5), ((1, 1), 10), ((1, 2), 10), ((1, 3), (2, 0))];
         add_segments!(vm, 1);
         //ids.dict_ptr (2, 0):
         //  dict_ptr.key = (2, 1)
@@ -702,7 +703,7 @@ mod tests {
         let mut exec_scopes = ExecutionScopes::new();
         dict_manager!(exec_scopes, 2, (5, 10));
         //Insert ids into memory
-        vm.memory = memory![((1, 0), 5), ((1, 1), 11), ((1, 2), 10), ((1, 3), (2, 0))];
+        vm.segments = segments![((1, 0), 5), ((1, 1), 11), ((1, 2), 10), ((1, 3), (2, 0))];
         add_segments!(vm, 1);
         //ids.dict_ptr (2, 0):
         //  dict_ptr.key = (2, 1)
@@ -729,7 +730,7 @@ mod tests {
         let mut exec_scopes = ExecutionScopes::new();
         dict_manager_default!(exec_scopes, 2, 17, (5, 10));
         //Insert ids into memory
-        vm.memory = memory![((1, 0), 6), ((1, 1), 10), ((1, 2), 10), ((1, 3), (2, 0))];
+        vm.segments = segments![((1, 0), 6), ((1, 1), 10), ((1, 2), 10), ((1, 3), (2, 0))];
         add_segments!(vm, 1);
         //ids.dict_ptr (2, 0):
         //  dict_ptr.key = (2, 1)
@@ -756,7 +757,7 @@ mod tests {
         let mut exec_scopes = ExecutionScopes::new();
         dict_manager_default!(exec_scopes, 2, 17);
         //Insert ids into memory
-        vm.memory = memory![((1, 0), 5), ((1, 1), 17), ((1, 2), 20), ((1, 3), (2, 0))];
+        vm.segments = segments![((1, 0), 5), ((1, 1), 17), ((1, 2), 20), ((1, 3), (2, 0))];
         add_segments!(vm, 1);
         //ids.dict_ptr (2, 0):
         //  dict_ptr.key = (2, 1)
@@ -778,7 +779,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 1;
         //ids.dict_access
-        vm.memory = memory![((1, 0), (2, 0))];
+        vm.segments = segments![((1, 0), (2, 0))];
         add_segments!(vm, 1);
         let ids_data = ids_data!["dict_accesses_end"];
         //Execute the hint
@@ -805,7 +806,7 @@ mod tests {
         let mut vm = vm!();
         //Initialize fp
         vm.run_context.fp = 1;
-        vm.memory = memory![((1, 0), (2, 0))];
+        vm.segments = segments![((1, 0), (2, 0))];
         add_segments!(vm, 1);
         let ids_data = ids_data!["dict_accesses_end"];
         //Execute the hint
@@ -840,7 +841,7 @@ mod tests {
         let dict_manager = DictManager::new();
         let mut exec_scopes = scope![("dict_manager", Rc::new(RefCell::new(dict_manager)))];
 
-        vm.memory = memory![((1, 0), (2, 0))];
+        vm.segments = segments![((1, 0), (2, 0))];
         add_segments!(vm, 1);
         let ids_data = ids_data!["dict_accesses_end"];
         //Execute the hint
@@ -859,7 +860,7 @@ mod tests {
         //Create manager
         let dict_manager = DictManager::new();
         let mut exec_scopes = scope![("dict_manager", Rc::new(RefCell::new(dict_manager)))];
-        vm.memory = memory![((1, 0), (2, 0)), ((1, 1), (2, 3))];
+        vm.segments = segments![((1, 0), (2, 0)), ((1, 1), (2, 3))];
         add_segments!(vm, 1);
         //Create ids
         let ids_data = ids_data!["squashed_dict_start", "squashed_dict_end"];
@@ -879,7 +880,7 @@ mod tests {
         let mut exec_scopes = ExecutionScopes::new();
         dict_manager![exec_scopes, 2, (1, 2)];
         //ids.squash_dict_start
-        vm.memory = memory![((1, 0), (2, 0)), ((1, 1), (2, 3))];
+        vm.segments = segments![((1, 0), (2, 0)), ((1, 1), (2, 3))];
         add_segments!(vm, 1);
         //Create ids
         let ids_data = ids_data!["squashed_dict_start", "squashed_dict_end"];
@@ -897,7 +898,7 @@ mod tests {
         vm.run_context.fp = 2;
         let mut exec_scopes = ExecutionScopes::new();
         dict_manager!(exec_scopes, 2, (1, 2));
-        vm.memory = memory![((1, 0), (2, 3)), ((1, 1), (2, 6))];
+        vm.segments = segments![((1, 0), (2, 3)), ((1, 1), (2, 6))];
         add_segments!(vm, 1);
         //Create ids
         let ids_data = ids_data!["squashed_dict_start", "squashed_dict_end"];
@@ -920,7 +921,7 @@ mod tests {
         dict_manager_default!(&mut exec_scopes, 2, 2);
         // First we run dict_write hint
         //Insert ids into memory
-        vm.memory = memory![((1, 0), 5), ((1, 1), (1, 7)), ((1, 2), (2, 0))];
+        vm.segments = segments![((1, 0), 5), ((1, 1), (1, 7)), ((1, 2), (2, 0))];
         add_segments!(vm, 1);
         // new_value here is (1,7)
         let ids_data = ids_data!["key", "new_value", "dict_ptr"];

--- a/src/hint_processor/builtin_hint_processor/dict_hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/dict_hint_utils.rs
@@ -413,7 +413,7 @@ mod tests {
         assert_eq!(vm.segments.memory.data.len(), 3);
         //new segment base (2,0) is inserted into ap (0,0)
         check_memory![vm.segments.memory, ((1, 1), (2, 0))];
-        //Check the dict manager has a tracker for segment 0,
+        //Check the dict manager has a tracker for segment 2,
         //and that tracker contains the ptr (2,0) and an empty dict
         assert_eq!(
             exec_scopes
@@ -421,7 +421,7 @@ mod tests {
                 .unwrap()
                 .borrow()
                 .trackers
-                .get(&0),
+                .get(&2),
             Some(&DictTracker::new_default_dict(
                 &relocatable!(2, 0),
                 &MaybeRelocatable::from(17),

--- a/src/hint_processor/builtin_hint_processor/dict_hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/dict_hint_utils.rs
@@ -328,7 +328,7 @@ mod tests {
                 MemoryError::InconsistentMemory(
                     MaybeRelocatable::from((1, 0)),
                     MaybeRelocatable::from(1),
-                    MaybeRelocatable::from((0, 0))
+                    MaybeRelocatable::from((2, 0))
                 )
             )))
         );
@@ -411,10 +411,10 @@ mod tests {
         run_hint!(vm, ids_data, hint_code, &mut exec_scopes).expect("Error while executing hint");
         //third new segment is added for the dictionary
         assert_eq!(vm.segments.memory.data.len(), 3);
-        //new segment base (0,0) is inserted into ap (0,0)
-        check_memory![vm.segments.memory, ((1, 1), (0, 0))];
+        //new segment base (2,0) is inserted into ap (0,0)
+        check_memory![vm.segments.memory, ((1, 1), (2, 0))];
         //Check the dict manager has a tracker for segment 0,
-        //and that tracker contains the ptr (0,0) and an empty dict
+        //and that tracker contains the ptr (2,0) and an empty dict
         assert_eq!(
             exec_scopes
                 .get_dict_manager()
@@ -423,7 +423,7 @@ mod tests {
                 .trackers
                 .get(&0),
             Some(&DictTracker::new_default_dict(
-                &relocatable!(0, 0),
+                &relocatable!(2, 0),
                 &MaybeRelocatable::from(17),
                 None
             ))

--- a/src/hint_processor/builtin_hint_processor/dict_manager.rs
+++ b/src/hint_processor/builtin_hint_processor/dict_manager.rs
@@ -253,7 +253,7 @@ mod tests {
             dict_manager.trackers.get(&0),
             Some(&DictTracker::new_empty(&relocatable!(0, 0)))
         );
-        assert_eq!(vm.segments.num_segments, 1);
+        assert_eq!(vm.segments.num_segments(), 1);
     }
 
     #[test]
@@ -271,7 +271,7 @@ mod tests {
                 None
             ))
         );
-        assert_eq!(vm.segments.num_segments, 1);
+        assert_eq!(vm.segments.num_segments(), 1);
     }
 
     #[test]
@@ -290,7 +290,7 @@ mod tests {
                 initial_dict
             ))
         );
-        assert_eq!(vm.segments.num_segments, 1);
+        assert_eq!(vm.segments.num_segments(), 1);
     }
 
     #[test]
@@ -314,7 +314,7 @@ mod tests {
                 Some(initial_dict)
             ))
         );
-        assert_eq!(vm.segments.num_segments, 1);
+        assert_eq!(vm.segments.num_segments(), 1);
     }
 
     #[test]

--- a/src/hint_processor/builtin_hint_processor/find_element_hint.rs
+++ b/src/hint_processor/builtin_hint_processor/find_element_hint.rs
@@ -160,7 +160,7 @@ mod tests {
         vm.run_context.fp = FP_OFFSET_START;
 
         for _ in 0..3 {
-            vm.segments.add(&mut vm.memory);
+            vm.segments.add();
         }
 
         let addresses = vec![
@@ -199,7 +199,8 @@ mod tests {
             let value_to_insert = values_to_override
                 .get(default_values[i].0)
                 .unwrap_or(&default_values[i].1);
-            vm.memory
+            vm.segments
+                .memory
                 .insert(memory_cell, value_to_insert)
                 .expect("Unexpected memory insert fail");
         }
@@ -224,7 +225,7 @@ mod tests {
             run_hint!(vm, ids_data, hint_code::FIND_ELEMENT.to_string()),
             Ok(())
         );
-        check_memory![vm.memory, ((1, 3), 1)];
+        check_memory![vm.segments.memory, ((1, 3), 1)];
     }
 
     #[test]
@@ -235,7 +236,7 @@ mod tests {
             run_hint!(vm, ids_data, hint_code::FIND_ELEMENT, &mut exec_scopes),
             Ok(())
         );
-        check_memory![vm.memory, ((1, 3), 1)];
+        check_memory![vm.segments.memory, ((1, 3), 1)];
     }
 
     #[test]
@@ -373,7 +374,7 @@ mod tests {
             Ok(())
         );
 
-        check_memory![vm.memory, ((1, 3), 1)];
+        check_memory![vm.segments.memory, ((1, 3), 1)];
     }
 
     #[test]
@@ -386,7 +387,7 @@ mod tests {
             run_hint!(vm, ids_data, hint_code::SEARCH_SORTED_LOWER),
             Ok(())
         );
-        check_memory![vm.memory, ((1, 3), 2)];
+        check_memory![vm.segments.memory, ((1, 3), 2)];
     }
 
     #[test]

--- a/src/hint_processor/builtin_hint_processor/hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/hint_utils.rs
@@ -117,6 +117,7 @@ pub fn get_reference_from_var_name<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
     use crate::{
         hint_processor::hint_processor_definition::HintReference,
         relocatable,

--- a/src/hint_processor/builtin_hint_processor/hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/hint_utils.rs
@@ -132,7 +132,7 @@ mod tests {
     #[test]
     fn get_ptr_from_var_name_immediate_value() {
         let mut vm = vm!();
-        vm.memory = memory![((1, 0), (0, 0))];
+        vm.segments = segments![((1, 0), (0, 0))];
         let mut hint_ref = HintReference::new(0, 0, true, false);
         hint_ref.offset2 = OffsetValue::Value(2);
         let ids_data = HashMap::from([("imm".to_string(), hint_ref)]);
@@ -146,7 +146,7 @@ mod tests {
     #[test]
     fn get_maybe_relocatable_from_var_name_valid() {
         let mut vm = vm!();
-        vm.memory = memory![((1, 0), (0, 0))];
+        vm.segments = segments![((1, 0), (0, 0))];
         let hint_ref = HintReference::new_simple(0);
         let ids_data = HashMap::from([("value".to_string(), hint_ref)]);
 
@@ -159,7 +159,7 @@ mod tests {
     #[test]
     fn get_maybe_relocatable_from_var_name_invalid() {
         let mut vm = vm!();
-        vm.memory = Memory::new();
+        vm.segments.memory = Memory::new();
         let hint_ref = HintReference::new_simple(0);
         let ids_data = HashMap::from([("value".to_string(), hint_ref)]);
 
@@ -172,7 +172,7 @@ mod tests {
     #[test]
     fn get_ptr_from_var_name_valid() {
         let mut vm = vm!();
-        vm.memory = memory![((1, 0), (0, 0))];
+        vm.segments = segments![((1, 0), (0, 0))];
         let hint_ref = HintReference::new_simple(0);
         let ids_data = HashMap::from([("value".to_string(), hint_ref)]);
 
@@ -185,7 +185,7 @@ mod tests {
     #[test]
     fn get_ptr_from_var_name_invalid() {
         let mut vm = vm!();
-        vm.memory = memory![((1, 0), 0)];
+        vm.segments = segments![((1, 0), 0)];
         let hint_ref = HintReference::new_simple(0);
         let ids_data = HashMap::from([("value".to_string(), hint_ref)]);
 
@@ -200,7 +200,7 @@ mod tests {
     #[test]
     fn get_relocatable_from_var_name_valid() {
         let mut vm = vm!();
-        vm.memory = memory![((1, 0), (0, 0))];
+        vm.segments = segments![((1, 0), (0, 0))];
         let hint_ref = HintReference::new_simple(0);
         let ids_data = HashMap::from([("value".to_string(), hint_ref)]);
 
@@ -213,7 +213,7 @@ mod tests {
     #[test]
     fn get_relocatable_from_var_name_invalid() {
         let mut vm = vm!();
-        vm.memory = Memory::new();
+        vm.segments.memory = Memory::new();
         let hint_ref = HintReference::new_simple(-8);
         let ids_data = HashMap::from([("value".to_string(), hint_ref)]);
 
@@ -226,7 +226,7 @@ mod tests {
     #[test]
     fn get_integer_from_var_name_valid() {
         let mut vm = vm!();
-        vm.memory = memory![((1, 0), 1)];
+        vm.segments = segments![((1, 0), 1)];
         let hint_ref = HintReference::new_simple(0);
         let ids_data = HashMap::from([("value".to_string(), hint_ref)]);
 
@@ -239,7 +239,7 @@ mod tests {
     #[test]
     fn get_integer_from_var_name_invalid() {
         let mut vm = vm!();
-        vm.memory = memory![((1, 0), (0, 0))];
+        vm.segments = segments![((1, 0), (0, 0))];
         let hint_ref = HintReference::new_simple(0);
         let ids_data = HashMap::from([("value".to_string(), hint_ref)]);
 

--- a/src/hint_processor/builtin_hint_processor/math_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/math_utils.rs
@@ -540,6 +540,7 @@ fn div_prime_by_bound(bound: Felt) -> Result<Felt, VirtualMachineError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
     use crate::{
         any_box,
         hint_processor::builtin_hint_processor::{

--- a/src/hint_processor/builtin_hint_processor/math_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/math_utils.rs
@@ -567,14 +567,14 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 10;
         //Insert ids into memory
-        vm.memory = memory![((1, 9), (-1))];
+        vm.segments = segments![((1, 9), (-1))];
         add_segments!(vm, 1);
         //Create ids_data & hint_data
         let ids_data = ids_data!["a"];
         //Execute the hint
         run_hint!(vm, ids_data, hint_code).expect("Error while executing hint");
         //Check that ap now contains false (1)
-        check_memory![vm.memory, ((1, 0), 1)];
+        check_memory![vm.segments.memory, ((1, 0), 1)];
     }
 
     #[test]
@@ -584,14 +584,14 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
-        vm.memory = memory![((1, 4), 1)];
+        vm.segments = segments![((1, 4), 1)];
         add_segments!(vm, 1);
         //Create ids_data
         let ids_data = ids_data!["a"];
         //Execute the hint
         run_hint!(vm, ids_data, hint_code).expect("Error while executing hint");
         //Check that ap now contains true (0)
-        check_memory![vm.memory, ((1, 0), 0)];
+        check_memory![vm.segments.memory, ((1, 0), 0)];
     }
 
     #[test]
@@ -603,7 +603,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
-        vm.memory = memory![(
+        vm.segments = segments![(
             (1, 4),
             (
                 "-3618502788666131213697322783095070105623107215331596699973092056135872020480",
@@ -615,7 +615,7 @@ mod tests {
         //Execute the hint
         run_hint!(vm, ids_data, hint_code).expect("Error while executing hint");
         //Check that ap now contains true (0)
-        check_memory![vm.memory, ((1, 0), 0)];
+        check_memory![vm.segments.memory, ((1, 0), 0)];
     }
 
     #[test]
@@ -625,7 +625,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
-        vm.memory = memory![((1, 4), 1)];
+        vm.segments = segments![((1, 4), 1)];
         //Create ids_data
         let ids_data = ids_data!["a"];
         //Execute the hint
@@ -678,7 +678,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
-        vm.memory = memory![((1, 4), (2, 3))];
+        vm.segments = segments![((1, 4), (2, 3))];
         //Create ids_data
         let ids_data = ids_data!["a"];
         //Execute the hint
@@ -707,7 +707,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 3;
         //Insert ids into memory
-        vm.memory = memory![((1, 0), 1), ((1, 1), 2), ((1, 2), (2, 0))];
+        vm.segments = segments![((1, 0), 1), ((1, 1), 2), ((1, 2), (2, 0))];
         add_segments!(vm, 1);
         //Create ids_data & hint_data
         let ids_data = ids_data!["a", "b", "range_check_ptr"];
@@ -726,13 +726,13 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 10;
         //Insert ids into memory
-        vm.memory = memory![((1, 8), 1), ((1, 9), 2)];
+        vm.segments = segments![((1, 8), 1), ((1, 9), 2)];
         add_segments!(vm, 1);
         let ids_data = ids_data!["a", "b"];
         //Execute the hint
         assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
         //Check result
-        check_memory![vm.memory, ((1, 0), 0)];
+        check_memory![vm.segments.memory, ((1, 0), 0)];
     }
 
     #[test]
@@ -741,7 +741,7 @@ mod tests {
         let mut vm = vm_with_range_check!();
         //Initialize fp
         vm.run_context.fp = 2;
-        vm.memory = memory![((1, 0), 1), ((1, 1), 2)];
+        vm.segments = segments![((1, 0), 1), ((1, 1), 2)];
         //Create ids_data & hint_data
         let ids_data = ids_data!["a", "b"];
         //Execute the hint
@@ -762,7 +762,7 @@ mod tests {
         let hint_code = "memory[ap] = 0 if (ids.a % PRIME) <= (ids.b % PRIME) else 1";
         let mut vm = vm!();
         vm.run_context.fp = 10;
-        vm.memory = memory![((1, 8), 1), ((1, 9), 2)];
+        vm.segments = segments![((1, 8), 1), ((1, 9), 2)];
         //Create ids_data & hint_data
         let ids_data = ids_data!["a", "c"];
         assert_eq!(
@@ -778,7 +778,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 1;
         //Insert ids into memory
-        vm.memory = memory![((1, 0), 1)];
+        vm.segments = segments![((1, 0), 1)];
         //Create ids_data & hint_data
         let ids_data = ids_data!["a"];
         //Execute the hint
@@ -793,7 +793,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 1;
         //Insert ids into memory
-        vm.memory = memory![((1, 0), (-1))];
+        vm.segments = segments![((1, 0), (-1))];
         //Create ids_data & hint_data
         let ids_data = ids_data!["a"];
         //Execute the hint
@@ -810,7 +810,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 4;
         //Insert ids into memory
-        vm.memory = memory![((1, 0), (-1))];
+        vm.segments = segments![((1, 0), (-1))];
         let ids_data = ids_data!["incorrect_id"];
         //Execute the hint
         assert_eq!(
@@ -826,7 +826,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 4;
         //Insert ids into memory
-        vm.memory = memory![((1, 0), (10, 10))];
+        vm.segments = segments![((1, 0), (10, 10))];
         let ids_data = ids_data!["a"];
         //Execute the hint
         assert_eq!(
@@ -844,7 +844,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 1;
         //Insert ids into memory
-        vm.memory = memory![((1, 0), 1)];
+        vm.segments = segments![((1, 0), 1)];
         let ids_data = ids_data!["a"];
         //Execute the hint
         assert_eq!(
@@ -889,7 +889,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 3;
         //Insert ids into memory
-        vm.memory = memory![((1, 0), 2), ((1, 1), 1), ((1, 2), (2, 0))];
+        vm.segments = segments![((1, 0), 2), ((1, 1), 1), ((1, 2), (2, 0))];
         let ids_data = ids_data!["a", "b", "range_check_ptr"];
         add_segments!(vm, 1);
         //Execute the hint
@@ -916,7 +916,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 3;
         //Insert ids into memory
-        vm.memory = memory![((1, 0), (1, 0)), ((1, 1), 1), ((1, 2), (2, 0))];
+        vm.segments = segments![((1, 0), (1, 0)), ((1, 1), 1), ((1, 2), (2, 0))];
         let ids_data = ids_data!["a", "b", "range_check_ptr"];
         //Execute the hint
         assert_eq!(
@@ -944,7 +944,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 3;
         //Insert ids into memory
-        vm.memory = memory![((1, 0), 1), ((1, 1), (1, 0)), ((1, 2), (2, 0))];
+        vm.segments = segments![((1, 0), 1), ((1, 1), (1, 0)), ((1, 2), (2, 0))];
         let ids_data = ids_data!["a", "b", "range_check_builtin"];
         //Execute the hint
         assert_eq!(
@@ -963,13 +963,13 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
-        vm.memory = memory![((1, 4), 2)];
+        vm.segments = segments![((1, 4), 2)];
         add_segments!(vm, 1);
         //Create ids_data
         let ids_data = ids_data!["a"];
         //Execute the hint
         run_hint!(vm, ids_data, hint_code).expect("Error while executing hint");
-        check_memory![vm.memory, ((1, 0), 1)];
+        check_memory![vm.segments.memory, ((1, 0), 1)];
     }
 
     #[test]
@@ -980,13 +980,13 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
-        vm.memory = memory![((1, 4), (-1))];
+        vm.segments = segments![((1, 4), (-1))];
         add_segments!(vm, 1);
         //Create ids_data
         let ids_data = ids_data!["a"];
         //Execute the hint
         run_hint!(vm, ids_data, hint_code).expect("Error while executing hint");
-        check_memory![vm.memory, ((1, 0), 0)];
+        check_memory![vm.segments.memory, ((1, 0), 0)];
     }
     #[test]
     fn run_assert_not_equal_int_false() {
@@ -995,7 +995,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 10;
         //Insert ids into memory
-        vm.memory = memory![((1, 8), 1), ((1, 9), 1)];
+        vm.segments = segments![((1, 8), 1), ((1, 9), 1)];
         let ids_data = ids_data!["a", "b"];
         //Execute the hint
         assert_eq!(
@@ -1014,7 +1014,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 10;
         //Insert ids into memory
-        vm.memory = memory![((1, 8), 1), ((1, 9), 3)];
+        vm.segments = segments![((1, 8), 1), ((1, 9), 3)];
         let ids_data = ids_data!["a", "b"];
         //Execute the hint
         assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
@@ -1028,7 +1028,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 10;
         //Insert ids into memory
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 8), (-1)),
             (
                 (1, 9),
@@ -1050,7 +1050,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 10;
         //Insert ids into memory
-        vm.memory = memory![((1, 8), (1, 0)), ((1, 9), (1, 0))];
+        vm.segments = segments![((1, 8), (1, 0)), ((1, 9), (1, 0))];
         let ids_data = ids_data!["a", "b"];
         //Execute the hint
         assert_eq!(
@@ -1069,7 +1069,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 10;
         //Insert ids into memory
-        vm.memory = memory![((1, 8), (0, 1)), ((1, 9), (0, 0))];
+        vm.segments = segments![((1, 8), (0, 1)), ((1, 9), (0, 0))];
         let ids_data = ids_data!["a", "b"];
         //Execute the hint
         assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
@@ -1082,7 +1082,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 10;
         //Insert ids into memory
-        vm.memory = memory![((1, 8), (2, 0)), ((1, 9), (1, 0))];
+        vm.segments = segments![((1, 8), (2, 0)), ((1, 9), (1, 0))];
         let ids_data = ids_data!["a", "b"];
         //Execute the hint
         assert_eq!(
@@ -1101,7 +1101,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 10;
         //Insert ids into memory
-        vm.memory = memory![((1, 8), (1, 0)), ((1, 9), 1)];
+        vm.segments = segments![((1, 8), (1, 0)), ((1, 9), 1)];
         let ids_data = ids_data!["a", "b"];
         //Execute the hint
         assert_eq!(
@@ -1123,7 +1123,7 @@ mod tests {
         // //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
-        vm.memory = memory![((1, 4), 5)];
+        vm.segments = segments![((1, 4), 5)];
         //Create ids
         let ids_data = ids_data!["value"];
 
@@ -1138,7 +1138,7 @@ mod tests {
         // //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
-        vm.memory = memory![((1, 4), 0)];
+        vm.segments = segments![((1, 4), 0)];
         //Create ids
         let ids_data = ids_data!["value"];
         assert_eq!(
@@ -1158,7 +1158,7 @@ mod tests {
         // //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
-        vm.memory = memory![((1, 4), 0)];
+        vm.segments = segments![((1, 4), 0)];
         //Create invalid id key
         let ids_data = ids_data!["incorrect_id"];
         assert_eq!(
@@ -1175,7 +1175,7 @@ mod tests {
         // //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
-        vm.memory = memory![((1, 4), (1, 0))];
+        vm.segments = segments![((1, 4), (1, 0))];
         //Create ids_data & hint_data
         let ids_data = ids_data!["value"];
         assert_eq!(
@@ -1193,7 +1193,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
-        vm.memory = memory![((1, 4), 1)];
+        vm.segments = segments![((1, 4), 1)];
         let ids_data = ids_data!["value"];
         //Execute the hint
         assert_eq!(
@@ -1209,7 +1209,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
-        vm.memory = memory![((1, 4), 0)];
+        vm.segments = segments![((1, 4), 0)];
         let ids_data = ids_data!["value"];
         //Execute the hint
         assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
@@ -1222,12 +1222,12 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 4;
         //Insert ids into memory
-        vm.memory = memory![((1, 0), (2, 0)), ((1, 1), 2), ((1, 2), 10), ((1, 3), 100)];
+        vm.segments = segments![((1, 0), (2, 0)), ((1, 1), 2), ((1, 2), 10), ((1, 3), 100)];
         add_segments!(vm, 2);
         let ids_data = ids_data!["output", "value", "base", "bound"];
         //Execute the hint
         assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
-        check_memory![vm.memory, ((2, 0), 2)];
+        check_memory![vm.segments.memory, ((2, 0), 2)];
     }
 
     #[test]
@@ -1237,7 +1237,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 4;
         //Insert ids into memory
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 0), (2, 0)),
             ((1, 1), 100),
             ((1, 2), 10000),
@@ -1260,14 +1260,14 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 2;
         //Insert ids.value into memory
-        vm.memory = memory![((1, 0), 250)];
+        vm.segments = segments![((1, 0), 250)];
         //Dont insert ids.is_positive as we need to modify it inside the hint
         //Create ids
         let ids_data = ids_data!["value", "is_positive"];
         //Execute the hint
         run_hint!(vm, ids_data, hint_code).expect("Error while executing hint");
         //Check that is_positive now contains 1 (true)
-        check_memory![vm.memory, ((1, 1), 1)];
+        check_memory![vm.segments.memory, ((1, 1), 1)];
     }
 
     #[test]
@@ -1278,13 +1278,13 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 2;
         //Insert ids.value into memory
-        vm.memory = memory![((1, 0), (-250))];
+        vm.segments = segments![((1, 0), (-250))];
         //Dont insert ids.is_positive as we need to modify it inside the hint
         let ids_data = ids_data!["value", "is_positive"];
         //Execute the hint
         run_hint!(vm, ids_data, hint_code).expect("Error while executing hint");
         //Check that is_positive now contains 0 (false)
-        check_memory![vm.memory, ((1, 1), 0)];
+        check_memory![vm.segments.memory, ((1, 1), 0)];
     }
 
     #[test]
@@ -1295,7 +1295,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 2;
         //Insert ids.value into memory
-        vm.memory = memory![(
+        vm.segments = segments![(
             (1, 0),
             (
                 "618502761706184546546682988428055018603476541694452277432519575032261771265",
@@ -1321,7 +1321,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 2;
         //Insert ids into memory
-        vm.memory = memory![((1, 0), 2), ((1, 1), 4)];
+        vm.segments = segments![((1, 0), 2), ((1, 1), 4)];
         let ids_data = ids_data!["value", "is_positive"];
         //Execute the hint
         assert_eq!(
@@ -1343,13 +1343,13 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 2;
         //Insert ids.value into memory
-        vm.memory = memory![((1, 0), 81)];
+        vm.segments = segments![((1, 0), 81)];
         //Create ids
         let ids_data = ids_data!["value", "root"];
         //Execute the hint
         assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
         //Check that root (0,1) has the square root of 81
-        check_memory![vm.memory, ((1, 1), 9)];
+        check_memory![vm.segments.memory, ((1, 1), 9)];
     }
 
     #[test]
@@ -1359,7 +1359,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 2;
         //Insert ids.value into memory
-        vm.memory = memory![((1, 0), (-81))];
+        vm.segments = segments![((1, 0), (-81))];
         //Create ids
         let ids_data = ids_data!["value", "root"];
         //Execute the hint
@@ -1378,7 +1378,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 2;
         //Insert ids.value into memory
-        vm.memory = memory![((1, 0), 81), ((1, 1), 7)];
+        vm.segments = segments![((1, 0), 81), ((1, 1), 7)];
         //Create ids
         let ids_data = ids_data!["value", "root"];
         //Execute the hint
@@ -1401,12 +1401,12 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 4;
         //Insert ids into memory
-        vm.memory = memory![((1, 2), 5), ((1, 3), 7)];
+        vm.segments = segments![((1, 2), 5), ((1, 3), 7)];
         //Create ids
         let ids_data = ids_data!["r", "q", "div", "value"];
         //Execute the hint
         assert!(run_hint!(vm, ids_data, hint_code).is_ok());
-        check_memory![vm.memory, ((1, 0), 2), ((1, 1), 1)];
+        check_memory![vm.segments.memory, ((1, 0), 2), ((1, 1), 1)];
     }
 
     #[test]
@@ -1416,7 +1416,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 4;
         //Insert ids into memory
-        vm.memory = memory![((1, 2), (-5)), ((1, 3), 7)];
+        vm.segments = segments![((1, 2), (-5)), ((1, 3), 7)];
         //Create ids
         let ids_data = ids_data!["r", "q", "div", "value"];
         //Execute the hint
@@ -1436,7 +1436,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 4;
         //Insert ids into memory
-        vm.memory = memory![((1, 2), 5), ((1, 3), 7)];
+        vm.segments = segments![((1, 2), 5), ((1, 3), 7)];
         //Create ids_data
         let ids_data = ids_data!["r", "q", "div", "value"];
         assert_eq!(
@@ -1454,7 +1454,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 4;
         //Insert ids into memory
-        vm.memory = memory![((1, 0), 5), ((1, 2), 5), ((1, 3), 7)];
+        vm.segments = segments![((1, 0), 5), ((1, 2), 5), ((1, 3), 7)];
         //Create ids_data
         let ids_data = ids_data!["r", "q", "div", "value"];
         //Execute the hint
@@ -1477,7 +1477,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 4;
         //Insert ids into memory
-        vm.memory = memory![((1, 2), 5), ((1, 3), 7)];
+        vm.segments = segments![((1, 2), 5), ((1, 3), 7)];
         //Create ids
         let ids_data = ids_data!["a", "b", "iv", "vlue"];
         //Execute the hint
@@ -1494,12 +1494,12 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 6;
         //Insert ids into memory
-        vm.memory = memory![((1, 3), 5), ((1, 4), 10), ((1, 5), 29)];
+        vm.segments = segments![((1, 3), 5), ((1, 4), 10), ((1, 5), 29)];
         //Create ids
         let ids_data = ids_data!["r", "biased_q", "range_check_ptr", "div", "value", "bound"];
         //Execute the hint
         assert!(run_hint!(vm, ids_data, hint_code).is_ok());
-        check_memory![vm.memory, ((1, 0), 0), ((1, 1), 31)];
+        check_memory![vm.segments.memory, ((1, 0), 0), ((1, 1), 31)];
     }
 
     #[test]
@@ -1509,12 +1509,12 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 6;
         //Insert ids into memory
-        vm.memory = memory![((1, 3), 7), ((1, 4), (-10)), ((1, 5), 29)];
+        vm.segments = segments![((1, 3), 7), ((1, 4), (-10)), ((1, 5), 29)];
         //Create ids
         let ids_data = ids_data!["r", "biased_q", "range_check_ptr", "div", "value", "bound"];
         //Execute the hint
         assert!(run_hint!(vm, ids_data, hint_code).is_ok());
-        check_memory![vm.memory, ((1, 0), 4), ((1, 1), 27)];
+        check_memory![vm.segments.memory, ((1, 0), 4), ((1, 1), 27)];
     }
 
     #[test]
@@ -1524,7 +1524,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 6;
         //Insert ids into memory
-        vm.memory = memory![((1, 3), (-5)), ((1, 4), 10), ((1, 5), 29)];
+        vm.segments = segments![((1, 3), (-5)), ((1, 4), 10), ((1, 5), 29)];
         //Create ids
         let ids_data = ids_data!["r", "biased_q", "range_check_ptr", "div", "value", "bound"];
         //Execute the hint
@@ -1544,7 +1544,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 6;
         //Insert ids into memory
-        vm.memory = memory![((1, 3), 5), ((1, 4), 10), ((1, 5), 29)];
+        vm.segments = segments![((1, 3), 5), ((1, 4), 10), ((1, 5), 29)];
         //Create ids
         let ids_data = ids_data!["r", "biased_q", "range_check_ptr", "div", "value", "bound"];
         assert_eq!(
@@ -1562,7 +1562,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 6;
         //Insert ids into memory
-        vm.memory = memory![((1, 1), 10), ((1, 3), 5), ((1, 4), 10), ((1, 5), 29)];
+        vm.segments = segments![((1, 1), 10), ((1, 3), 5), ((1, 4), 10), ((1, 5), 29)];
         //Create ids
         let ids_data = ids_data!["r", "biased_q", "range_check_ptr", "div", "value", "bound"];
         //Execute the hint
@@ -1585,7 +1585,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 6;
         //Insert ids into memory
-        vm.memory = memory![((1, 3), 5), ((1, 4), 10), ((1, 5), 29)];
+        vm.segments = segments![((1, 3), 5), ((1, 4), 10), ((1, 5), 29)];
         //Create ids
         let ids_data = ids_data!["r", "b", "r", "d", "v", "b"];
         //Execute the hint
@@ -1602,14 +1602,14 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 3;
         //Insert ids into memory
-        vm.memory = memory![((1, 0), 1)];
+        vm.segments = segments![((1, 0), 1)];
         //Create ids
         let ids_data = ids_data!["value", "high", "low"];
         //Execute the hint
         assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
         //Hint would return an error if the assertion fails
         //Check ids.high and ids.low values
-        check_memory![vm.memory, ((1, 1), 0), ((1, 2), 1)];
+        check_memory![vm.segments.memory, ((1, 1), 0), ((1, 2), 1)];
     }
 
     #[test]
@@ -1620,7 +1620,7 @@ mod tests {
         vm.run_context.fp = 3;
         //Insert ids into memory
         //ids.value
-        vm.memory = memory![(
+        vm.segments = segments![(
             (1, 0),
             (
                 "3618502788666131106986593281521497120414687020801267626233049500247285301248",
@@ -1641,7 +1641,7 @@ mod tests {
         let hint_code =
         "from starkware.cairo.common.math_utils import assert_integer\nassert ids.MAX_HIGH < 2**128 and ids.MAX_LOW < 2**128\nassert PRIME - 1 == ids.MAX_HIGH * 2**128 + ids.MAX_LOW\nassert_integer(ids.value)\nids.low = ids.value & ((1 << 128) - 1)\nids.high = ids.value >> 128";
         let mut vm = vm_with_range_check!();
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 3), ("335438970432432812899076431678123043273", 10)),
             ((1, 4), (2, 0))
         ];
@@ -1658,7 +1658,7 @@ mod tests {
         assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
         //Check hint memory inserts
         check_memory![
-            vm.memory,
+            vm.segments.memory,
             ((2, 0), ("335438970432432812899076431678123043273", 10)),
             ((2, 1), 0)
         ];
@@ -1669,7 +1669,7 @@ mod tests {
         let hint_code =
         "from starkware.cairo.common.math_utils import assert_integer\nassert ids.MAX_HIGH < 2**128 and ids.MAX_LOW < 2**128\nassert PRIME - 1 == ids.MAX_HIGH * 2**128 + ids.MAX_LOW\nassert_integer(ids.value)\nids.low = ids.value & ((1 << 128) - 1)\nids.high = ids.value >> 128";
         let mut vm = vm_with_range_check!();
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 3), ("335438970432432812899076431678123043273", 10)),
             ((1, 4), (2, 0))
         ];
@@ -1690,7 +1690,7 @@ mod tests {
         let hint_code =
         "from starkware.cairo.common.math_utils import assert_integer\nassert ids.MAX_HIGH < 2**128 and ids.MAX_LOW < 2**128\nassert PRIME - 1 == ids.MAX_HIGH * 2**128 + ids.MAX_LOW\nassert_integer(ids.value)\nids.low = ids.value & ((1 << 128) - 1)\nids.high = ids.value >> 128";
         let mut vm = vm_with_range_check!();
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 3), ("335438970432432812899076431678123043273", 10)),
             ((1, 4), (2, 0)),
             ((2, 0), 99)
@@ -1722,7 +1722,7 @@ mod tests {
         let hint_code =
         "from starkware.cairo.common.math_utils import assert_integer\nassert ids.MAX_HIGH < 2**128 and ids.MAX_LOW < 2**128\nassert PRIME - 1 == ids.MAX_HIGH * 2**128 + ids.MAX_LOW\nassert_integer(ids.value)\nids.low = ids.value & ((1 << 128) - 1)\nids.high = ids.value >> 128";
         let mut vm = vm_with_range_check!();
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 4), (2, 0)),
             ((1, 3), ("335438970432432812899076431678123043273", 10)),
             ((2, 1), 99)
@@ -1754,7 +1754,7 @@ mod tests {
         let hint_code =
         "from starkware.cairo.common.math_utils import assert_integer\nassert ids.MAX_HIGH < 2**128 and ids.MAX_LOW < 2**128\nassert PRIME - 1 == ids.MAX_HIGH * 2**128 + ids.MAX_LOW\nassert_integer(ids.value)\nids.low = ids.value & ((1 << 128) - 1)\nids.high = ids.value >> 128";
         let mut vm = vm_with_range_check!();
-        vm.memory = memory![((1, 3), (1, 0)), ((1, 4), (2, 0))];
+        vm.segments = segments![((1, 3), (1, 0)), ((1, 4), (2, 0))];
         //Initialize fp
         vm.run_context.fp = 7;
         //Create ids_data & hint_data
@@ -1780,7 +1780,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 3;
         //Insert ids into memory
-        vm.memory = memory![((1, 1), 1), ((1, 2), 2)];
+        vm.segments = segments![((1, 1), 1), ((1, 2), 2)];
         //Create ids
         let ids_data = ids_data!["a", "b"];
         //Execute the hint
@@ -1794,7 +1794,7 @@ mod tests {
         let mut vm = vm_with_range_check!();
         //Initialize fp
         vm.run_context.fp = 3;
-        vm.memory = memory![((1, 1), 3), ((1, 2), 2)];
+        vm.segments = segments![((1, 1), 3), ((1, 2), 2)];
         let ids_data = ids_data!["a", "b"];
         //Execute the hint
         assert_eq!(
@@ -1810,7 +1810,7 @@ mod tests {
         let mut vm = vm_with_range_check!();
         //Initialize fp
         vm.run_context.fp = 3;
-        vm.memory = memory![((1, 1), 1), ((1, 2), 2)];
+        vm.segments = segments![((1, 1), 1), ((1, 2), 2)];
         //Create Incorrects ids
         let ids_data = ids_data!["a"];
         //Execute the hint
@@ -1827,7 +1827,7 @@ mod tests {
         let mut vm = vm_with_range_check!();
         //Initialize fp
         vm.run_context.fp = 3;
-        vm.memory = memory![((1, 1), (1, 0)), ((1, 2), 2)];
+        vm.segments = segments![((1, 1), (1, 0)), ((1, 2), 2)];
         let ids_data = ids_data!["a", "b"];
         //Execute the hint
         assert_eq!(
@@ -1845,7 +1845,7 @@ mod tests {
         let mut vm = vm_with_range_check!();
         //Initialize fp
         vm.run_context.fp = 3;
-        vm.memory = memory![((1, 1), 1), ((1, 2), (1, 0))];
+        vm.segments = segments![((1, 1), 1), ((1, 2), (1, 0))];
         let ids_data = ids_data!["a", "b"];
         //Execute the hint
         assert_eq!(
@@ -1864,7 +1864,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 3;
         //Insert ids.a into memory
-        vm.memory = memory![((1, 1), 1)];
+        vm.segments = segments![((1, 1), 1)];
         let ids_data = ids_data!["a", "b"];
         //Execute the hint
         assert_eq!(

--- a/src/hint_processor/builtin_hint_processor/memcpy_hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/memcpy_hint_utils.rs
@@ -74,6 +74,7 @@ pub fn memcpy_continue_copying(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
     use crate::{
         types::relocatable::MaybeRelocatable,
         utils::test_utils::*,

--- a/src/hint_processor/builtin_hint_processor/memcpy_hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/memcpy_hint_utils.rs
@@ -87,7 +87,7 @@ mod tests {
     fn get_integer_from_var_name_valid() {
         let mut vm = vm!();
         // initialize memory segments
-        vm.segments.add(&mut vm.memory);
+        vm.segments.add();
 
         // initialize fp
         vm.run_context.fp = 1;
@@ -98,7 +98,7 @@ mod tests {
         let ids_data = ids_data![var_name];
 
         //Insert ids.prev_locs.exp into memory
-        vm.memory = memory![((1, 0), 10)];
+        vm.segments = segments![((1, 0), 10)];
 
         assert_eq!(
             get_integer_from_var_name(var_name, &vm, &ids_data, &ApTracking::default())
@@ -121,7 +121,7 @@ mod tests {
         let ids_data = ids_data![var_name];
 
         //Insert ids.variable into memory as a RelocatableValue
-        vm.memory = memory![((1, 0), (1, 1))];
+        vm.segments = segments![((1, 0), (1, 1))];
 
         assert_eq!(
             get_integer_from_var_name(var_name, &vm, &ids_data, &ApTracking::default()),

--- a/src/hint_processor/builtin_hint_processor/memset_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/memset_utils.rs
@@ -56,6 +56,7 @@ pub fn memset_continue_loop(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
     use crate::{
         any_box,
         hint_processor::{

--- a/src/hint_processor/builtin_hint_processor/memset_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/memset_utils.rs
@@ -80,7 +80,7 @@ mod tests {
         // initialize fp
         vm.run_context.fp = 2;
         // insert ids into memory
-        vm.memory = memory![((1, 1), 5)];
+        vm.segments = segments![((1, 1), 5)];
         let ids_data = ids_data!["n"];
         assert!(run_hint!(vm, ids_data, hint_code).is_ok());
     }
@@ -93,7 +93,7 @@ mod tests {
         vm.run_context.fp = 2;
         // insert ids.n into memory
         // insert a relocatable value in the address of ids.len so that it raises an error.
-        vm.memory = memory![((1, 1), (1, 0))];
+        vm.segments = segments![((1, 1), (1, 0))];
         let ids_data = ids_data!["n"];
         assert_eq!(
             run_hint!(vm, ids_data, hint_code),
@@ -113,11 +113,11 @@ mod tests {
         let mut exec_scopes = scope![("n", Felt::one())];
         // initialize ids.continue_loop
         // we create a memory gap so that there is None in (1, 0), the actual addr of continue_loop
-        vm.memory = memory![((1, 1), 5)];
+        vm.segments = segments![((1, 1), 5)];
         let ids_data = ids_data!["continue_loop"];
         assert!(run_hint!(vm, ids_data, hint_code, &mut exec_scopes).is_ok());
         // assert ids.continue_loop = 0
-        check_memory![vm.memory, ((1, 0), 0)];
+        check_memory![vm.segments.memory, ((1, 0), 0)];
     }
 
     #[test]
@@ -130,12 +130,12 @@ mod tests {
         let mut exec_scopes = scope![("n", Felt::new(5))];
         // initialize ids.continue_loop
         // we create a memory gap so that there is None in (0, 0), the actual addr of continue_loop
-        vm.memory = memory![((1, 2), 5)];
+        vm.segments = segments![((1, 2), 5)];
         let ids_data = ids_data!["continue_loop"];
         assert!(run_hint!(vm, ids_data, hint_code, &mut exec_scopes).is_ok());
 
         // assert ids.continue_loop = 1
-        check_memory![vm.memory, ((1, 0), 1)];
+        check_memory![vm.segments.memory, ((1, 0), 1)];
     }
 
     #[test]
@@ -151,7 +151,7 @@ mod tests {
 
         // initialize ids.continue_loop
         // we create a memory gap so that there is None in (0, 1), the actual addr of continue_loop
-        vm.memory = memory![((1, 2), 5)];
+        vm.segments = segments![((1, 2), 5)];
         let ids_data = ids_data!["continue_loop"];
         assert_eq!(
             run_hint!(vm, ids_data, hint_code),
@@ -169,7 +169,7 @@ mod tests {
         let mut exec_scopes = scope![("n", Felt::one())];
         // initialize ids.continue_loop
         // a value is written in the address so the hint cant insert value there
-        vm.memory = memory![((1, 0), 5)];
+        vm.segments = segments![((1, 0), 5)];
         let ids_data = ids_data!["continue_loop"];
         assert_eq!(
             run_hint!(vm, ids_data, hint_code, &mut exec_scopes),

--- a/src/hint_processor/builtin_hint_processor/pow_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/pow_utils.rs
@@ -56,11 +56,11 @@ mod tests {
         let mut vm = vm_with_range_check!();
         //Initialize ap
         vm.run_context.fp = 12;
-        vm.memory = memory![((1, 11), 3)];
+        vm.segments = segments![((1, 11), 3)];
         let ids_data = non_continuous_ids_data![("prev_locs", -5), ("locs", 0)];
         assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
         //Check hint memory inserts
-        check_memory![vm.memory, ((1, 12), 1)];
+        check_memory![vm.segments.memory, ((1, 12), 1)];
     }
 
     #[test]
@@ -106,7 +106,7 @@ mod tests {
         //Create hint_data
         let ids_data = non_continuous_ids_data![("prev_locs", -5), ("locs", -12)];
         //Insert ids.prev_locs.exp into memory as a RelocatableValue
-        vm.memory = memory![((1, 10), (1, 11))];
+        vm.segments = segments![((1, 10), (1, 11))];
         add_segments!(vm, 1);
         //Execute the hint
         assert_eq!(
@@ -126,7 +126,7 @@ mod tests {
         //Create hint_data
         let ids_data = non_continuous_ids_data![("prev_locs", -5), ("locs", 0)];
         //Insert ids into memory
-        vm.memory = memory![((1, 10), 3), ((1, 11), 3)];
+        vm.segments = segments![((1, 10), 3), ((1, 11), 3)];
         //Execute the hint
         assert_eq!(
             run_hint!(vm, ids_data, hint_code),

--- a/src/hint_processor/builtin_hint_processor/pow_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/pow_utils.rs
@@ -31,6 +31,7 @@ pub fn pow(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
     use crate::{
         any_box,
         hint_processor::{

--- a/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
@@ -111,7 +111,7 @@ mod tests {
         );
         //Check hint memory inserts
         check_memory![
-            &vm.memory,
+            vm.segments.memory,
             ((1, 11), 773712524553362_u64),
             ((1, 12), 57408430697461422066401280_u128),
             ((1, 13), 1292469707114105_u64)

--- a/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
@@ -407,6 +407,7 @@ pub fn ec_mul_inner(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
     use crate::{
         any_box,
         hint_processor::{

--- a/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
@@ -432,7 +432,7 @@ mod tests {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\n\ny = pack(ids.point.y, PRIME) % SECP_P\n# The modulo operation in python always returns a nonnegative number.\nvalue = (-y) % SECP_P";
         let mut vm = vm_with_range_check!();
 
-        vm.memory = memory![((1, 3), 2645i32), ((1, 4), 454i32), ((1, 5), 206i32)];
+        vm.segments = segments![((1, 3), 2645i32), ((1, 4), 454i32), ((1, 5), 206i32)];
         //Initialize fp
         vm.run_context.fp = 1;
         //Create hint_data
@@ -474,7 +474,7 @@ mod tests {
     fn run_compute_doubling_slope_ok() {
         let hint_code = "from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack\nfrom starkware.python.math_utils import ec_double_slope\n\n# Compute the slope.\nx = pack(ids.point.x, PRIME)\ny = pack(ids.point.y, PRIME)\nvalue = slope = ec_double_slope(point=(x, y), alpha=0, p=SECP_P)";
         let mut vm = vm_with_range_check!();
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 0), 614323u64),
             ((1, 1), 5456867u64),
             ((1, 2), 101208u64),
@@ -537,7 +537,7 @@ mod tests {
         let mut vm = vm_with_range_check!();
 
         //Insert ids.point0 and ids.point1 into memory
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 0), 134),
             ((1, 1), 5123),
             ((1, 2), 140),
@@ -608,7 +608,7 @@ mod tests {
         let mut vm = vm_with_range_check!();
 
         //Insert ids.point and ids.slope into memory
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 0), 134),
             ((1, 1), 5123),
             ((1, 2), 140),
@@ -760,7 +760,7 @@ mod tests {
         let mut vm = vm_with_range_check!();
 
         //Insert ids.point0, ids.point1.x and ids.slope into memory
-        vm.memory = memory![
+        vm.segments = segments![
             //ids.point0
             ((1, 0), 89712),
             ((1, 1), 56),
@@ -909,7 +909,7 @@ mod tests {
 
         let scalar = 89712_i32;
         //Insert ids.scalar into memory
-        vm.memory = memory![((1, 0), scalar)];
+        vm.segments = segments![((1, 0), scalar)];
 
         //Initialize RunContext
         run_context!(vm, 0, 2, 1);
@@ -920,6 +920,6 @@ mod tests {
         assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
 
         //Check hint memory inserts
-        check_memory![&vm.memory, ((1, 2), 0)];
+        check_memory![vm.segments.memory, ((1, 2), 0)];
     }
 }

--- a/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
@@ -156,6 +156,7 @@ pub fn is_zero_assign_scope_variables(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
     use crate::{
         any_box,
         hint_processor::{

--- a/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
@@ -185,7 +185,7 @@ mod tests {
         run_context!(vm, 0, 9, 9);
         //Create hint data
         let ids_data = non_continuous_ids_data![("val", -5), ("q", 0)];
-        vm.memory = memory![((1, 4), 0), ((1, 5), 0), ((1, 6), 0)];
+        vm.segments = segments![((1, 4), 0), ((1, 5), 0), ((1, 6), 0)];
         //Execute the hint
         assert_eq!(
             run_hint!(
@@ -211,7 +211,7 @@ mod tests {
         );
         //Check hint memory inserts
         //ids.q
-        check_memory![&vm.memory, ((1, 9), 0)];
+        check_memory![vm.segments.memory, ((1, 9), 0)];
     }
 
     #[test]
@@ -223,7 +223,7 @@ mod tests {
         run_context!(vm, 0, 9, 9);
         //Create hint data
         let ids_data = non_continuous_ids_data![("val", -5), ("q", 0)];
-        vm.memory = memory![((1, 4), 0), ((1, 5), 0), ((1, 6), 150)];
+        vm.segments = segments![((1, 4), 0), ((1, 5), 0), ((1, 6), 150)];
         //Execute the hint
         assert_eq!(
             run_hint!(
@@ -262,7 +262,7 @@ mod tests {
 
         //Create hint data
         let ids_data = non_continuous_ids_data![("val", -5), ("q", 0)];
-        vm.memory = memory![((1, 4), 0), ((1, 5), 0), ((1, 6), 0), ((1, 9), 55)];
+        vm.segments = segments![((1, 4), 0), ((1, 5), 0), ((1, 6), 0), ((1, 9), 55)];
         //Execute the hint
         assert_eq!(
             run_hint!(
@@ -306,7 +306,7 @@ mod tests {
         //Create hint data
         let ids_data = non_continuous_ids_data![("x", -5)];
 
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 20), ("132181232131231239112312312313213083892150", 10)),
             ((1, 21), 10),
             ((1, 22), 10)
@@ -396,7 +396,7 @@ mod tests {
         //Create hint data
         let ids_data = HashMap::from([("x".to_string(), HintReference::new_simple(-5))]);
         //Insert ids.x.d0, ids.x.d1, ids.x.d2 into memory
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 10), 232113757366008801543585_i128),
             ((1, 11), 232113757366008801543585_i128),
             ((1, 12), 232113757366008801543585_i128)
@@ -503,7 +503,7 @@ mod tests {
 
         //Check hint memory insert
         //memory[ap] = to_felt_or_relocatable(x == 0)
-        check_memory!(&vm.memory, ((1, 15), 1));
+        check_memory!(vm.segments.memory, ((1, 15), 1));
     }
 
     #[test]
@@ -529,7 +529,7 @@ mod tests {
 
         //Check hint memory insert
         //memory[ap] = to_felt_or_relocatable(x == 0)
-        check_memory!(&vm.memory, ((1, 15), 0));
+        check_memory!(vm.segments.memory, ((1, 15), 0));
     }
 
     #[test]
@@ -558,7 +558,7 @@ mod tests {
         let mut vm = vm_with_range_check!();
 
         //Insert a value in ap before the hint execution, so the hint memory insert fails
-        vm.memory = memory![((1, 15), 55)];
+        vm.segments = segments![((1, 15), 55)];
 
         //Initialize ap
         vm.run_context.ap = 15;

--- a/src/hint_processor/builtin_hint_processor/secp/signature.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/signature.rs
@@ -140,6 +140,7 @@ pub fn get_point_from_x(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
     use crate::{
         any_box,
         hint_processor::{

--- a/src/hint_processor/builtin_hint_processor/secp/signature.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/signature.rs
@@ -164,7 +164,7 @@ mod tests {
         let hint_code = hint_code::DIV_MOD_N_PACKED_DIVMOD;
         let mut vm = vm!();
 
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 0), 15),
             ((1, 1), 3),
             ((1, 2), 40),
@@ -224,7 +224,7 @@ mod tests {
     fn get_point_from_x_ok() {
         let hint_code = hint_code::GET_POINT_FROM_X;
         let mut vm = vm!();
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 0), 18),
             ((1, 1), 2147483647),
             ((1, 2), 2147483647),
@@ -264,7 +264,7 @@ mod tests {
         let hint_code = hint_code::GET_POINT_FROM_X;
         let mut vm = vm!();
         let mut exec_scopes = ExecutionScopes::new();
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 0), 1),
             ((1, 1), 2147483647),
             ((1, 2), 2147483647),

--- a/src/hint_processor/builtin_hint_processor/segments.rs
+++ b/src/hint_processor/builtin_hint_processor/segments.rs
@@ -72,7 +72,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 2;
         //Insert ids into memory
-        vm.memory = memory![((1, 0), (-2, 0)), ((1, 1), (3, 0)), ((3, 0), 42)];
+        vm.segments = segments![((1, 0), (-2, 0)), ((1, 1), (3, 0)), ((3, 0), 42)];
 
         //Create ids_data & hint_data
         let ids_data = ids_data!["src_ptr", "dest_ptr"];
@@ -80,7 +80,8 @@ mod tests {
         //Execute the hint
         assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
 
-        vm.memory
+        vm.segments
+            .memory
             .relocate_memory()
             .expect("Couldn't relocate memory.");
     }
@@ -90,8 +91,8 @@ mod tests {
         let hint_code = hint_code::TEMPORARY_ARRAY;
         //Initialize vm
         let mut vm = vm!();
-        vm.segments.add(&mut vm.memory);
-        vm.segments.add(&mut vm.memory);
+        vm.segments.add();
+        vm.segments.add();
         //Initialize fp
         vm.run_context.fp = 1;
 
@@ -100,6 +101,6 @@ mod tests {
 
         //Execute the hint
         assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
-        check_memory!(vm.memory, ((1, 0), (-1, 0)));
+        check_memory!(vm.segments.memory, ((1, 0), (-1, 0)));
     }
 }

--- a/src/hint_processor/builtin_hint_processor/segments.rs
+++ b/src/hint_processor/builtin_hint_processor/segments.rs
@@ -47,6 +47,7 @@ pub fn temporary_array(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
     use crate::{
         any_box,
         hint_processor::{

--- a/src/hint_processor/builtin_hint_processor/set.rs
+++ b/src/hint_processor/builtin_hint_processor/set.rs
@@ -72,6 +72,7 @@ pub fn set_add(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
     use crate::{
         any_box,
         hint_processor::{

--- a/src/hint_processor/builtin_hint_processor/set.rs
+++ b/src/hint_processor/builtin_hint_processor/set.rs
@@ -106,7 +106,7 @@ mod tests {
         let elm_a = elm_a.unwrap_or(2);
         let elm_b = elm_b.unwrap_or(3);
 
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 2), (set_ptr.0, set_ptr.1)),
             ((1, 3), elm_size),
             ((1, 4), (3, 0)),
@@ -135,7 +135,8 @@ mod tests {
         let (mut vm, ids_data) = init_vm_ids_data(None, None, None, None);
         assert_eq!(run_hint!(vm, ids_data, HINT_CODE), Ok(()));
         assert_eq!(
-            vm.memory
+            vm.segments
+                .memory
                 .get(&MaybeRelocatable::from((1, 0)))
                 .unwrap()
                 .unwrap()
@@ -148,7 +149,7 @@ mod tests {
     fn set_add_already_exists() {
         let (mut vm, ids_data) = init_vm_ids_data(None, None, Some(1), Some(3));
         assert_eq!(run_hint!(vm, ids_data, HINT_CODE), Ok(()));
-        check_memory![vm.memory, ((1, 0), 1), ((1, 1), 0)];
+        check_memory![vm.segments.memory, ((1, 0), 1), ((1, 1), 0)];
     }
 
     #[test]

--- a/src/hint_processor/builtin_hint_processor/sha256_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/sha256_utils.rs
@@ -117,6 +117,7 @@ pub fn sha256_finalize(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
     use crate::{
         hint_processor::hint_processor_definition::HintReference,
         types::relocatable::MaybeRelocatable,

--- a/src/hint_processor/builtin_hint_processor/sha256_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/sha256_utils.rs
@@ -130,30 +130,30 @@ mod tests {
     #[test]
     fn sha256_input_one() {
         let mut vm = vm_with_range_check!();
-        vm.memory = memory![((1, 1), 7)];
+        vm.segments = segments![((1, 1), 7)];
         vm.run_context.fp = 2;
         let ids_data = ids_data!["full_word", "n_bytes"];
         assert_eq!(sha256_input(&mut vm, &ids_data, &ApTracking::new()), Ok(()));
 
-        check_memory![&vm.memory, ((1, 0), 1)];
+        check_memory![vm.segments.memory, ((1, 0), 1)];
     }
 
     #[test]
     fn sha256_input_zero() {
         let mut vm = vm_with_range_check!();
-        vm.memory = memory![((1, 1), 3)];
+        vm.segments = segments![((1, 1), 3)];
         vm.run_context.fp = 2;
         let ids_data = ids_data!["full_word", "n_bytes"];
         assert_eq!(sha256_input(&mut vm, &ids_data, &ApTracking::new()), Ok(()));
 
-        check_memory![&vm.memory, ((1, 0), 0)];
+        check_memory![vm.segments.memory, ((1, 0), 0)];
     }
 
     #[test]
     fn sha256_ok() {
         let mut vm = vm_with_range_check!();
 
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 0), (2, 0)),
             ((1, 1), (3, 0)),
             ((2, 0), 22),
@@ -179,7 +179,7 @@ mod tests {
         assert_eq!(sha256_main(&mut vm, &ids_data, &ApTracking::new()), Ok(()));
 
         check_memory![
-            &vm.memory,
+            vm.segments.memory,
             ((3, 0), 3704205499_u32),
             ((3, 1), 2308112482_u32),
             ((3, 2), 3022351583_u32),

--- a/src/hint_processor/builtin_hint_processor/signature.rs
+++ b/src/hint_processor/builtin_hint_processor/signature.rs
@@ -31,6 +31,7 @@ pub fn verify_ecdsa_signature(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
     use crate::{
         any_box,
         hint_processor::{

--- a/src/hint_processor/builtin_hint_processor/signature.rs
+++ b/src/hint_processor/builtin_hint_processor/signature.rs
@@ -60,7 +60,7 @@ mod tests {
             "ecdsa".to_string(),
             SignatureBuiltinRunner::new(&EcdsaInstanceDef::default(), true).into(),
         )];
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 0), (2, 0)),
             (
                 (1, 1),

--- a/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
@@ -297,6 +297,7 @@ pub fn squash_dict(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
     use crate::{
         any_box,
         hint_processor::{

--- a/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
@@ -343,7 +343,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 1;
         //Insert ids into memory (range_check_ptr)
-        vm.memory = memory![((1, 0), (2, 0))];
+        vm.segments = segments![((1, 0), (2, 0))];
         add_segments!(vm, 1);
         //Create ids_data
         let ids_data = ids_data!["range_check_ptr"];
@@ -361,7 +361,7 @@ mod tests {
             ]
         );
         //Check that current_access_index is now at range_check_ptr
-        check_memory![vm.memory, ((2, 0), 3)];
+        check_memory![vm.segments.memory, ((2, 0), 3)];
     }
 
     #[test]
@@ -379,7 +379,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 1;
         //Insert ids into memory (range_check_ptr)
-        vm.memory = memory![((1, 0), (2, 0))];
+        vm.segments = segments![((1, 0), (2, 0))];
         //Create ids_data
         let ids_data = ids_data!["range_check_ptr"];
         //Execute the hint
@@ -398,7 +398,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 1;
         //Insert ids into memory (range_check_ptr)
-        vm.memory = memory![((1, 0), (2, 0))];
+        vm.segments = segments![((1, 0), (2, 0))];
         //Create ids_data
         let ids_data = ids_data!["range_check_ptr"];
         //Execute the hint
@@ -423,7 +423,7 @@ mod tests {
         //Execute the hint
         assert_eq!(run_hint!(vm, ids_data, hint_code, &mut exec_scopes), Ok(()));
         //Check the value of ids.should_skip_loop
-        check_memory![vm.memory, ((1, 0), 1)];
+        check_memory![vm.segments.memory, ((1, 0), 1)];
     }
 
     #[test]
@@ -441,7 +441,7 @@ mod tests {
         //Execute the hint
         assert_eq!(run_hint!(vm, ids_data, hint_code, &mut exec_scopes), Ok(()));
         //Check the value of ids.should_skip_loop
-        check_memory![vm.memory, ((1, 0), 0)];
+        check_memory![vm.segments.memory, ((1, 0), 0)];
     }
 
     #[test]
@@ -479,7 +479,7 @@ mod tests {
         //Check the value of loop_temps.index_delta_minus_1
         //new_index - current_index -1
         //5 - 1 - 1 = 3
-        check_memory![vm.memory, ((1, 0), 3)];
+        check_memory![vm.segments.memory, ((1, 0), 3)];
     }
 
     #[test]
@@ -495,7 +495,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 1;
         //Insert ids into memory (loop_temps)
-        vm.memory = memory![((1, 0), (2, 0))];
+        vm.segments = segments![((1, 0), (2, 0))];
         //Create ids_data
         let ids_data = ids_data!["loop_temps"];
         //Execute the hint
@@ -520,7 +520,7 @@ mod tests {
         //Execute the hint
         assert_eq!(run_hint!(vm, ids_data, hint_code, &mut exec_scopes), Ok(()));
         //Check the value of ids.loop_temps.should_continue (loop_temps + 3)
-        check_memory![vm.memory, ((1, 3), 1)];
+        check_memory![vm.segments.memory, ((1, 3), 1)];
     }
 
     #[test]
@@ -538,7 +538,7 @@ mod tests {
         //Execute the hint
         assert_eq!(run_hint!(vm, ids_data, hint_code, &mut exec_scopes), Ok(()));
         //Check the value of ids.loop_temps.should_continue (loop_temps + 3)
-        check_memory![vm.memory, ((1, 3), 0)];
+        check_memory![vm.segments.memory, ((1, 3), 0)];
     }
 
     #[test]
@@ -586,7 +586,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 1;
         //Insert ids into memory (n_used_accesses)
-        vm.memory = memory![((1, 0), 4)];
+        vm.segments = segments![((1, 0), 4)];
         //Create hint_data
         let ids_data = ids_data!["n_used_accesses"];
         //Execute the hint
@@ -609,7 +609,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 1;
         //Insert ids into memory (n_used_accesses)
-        vm.memory = memory![((1, 0), 5)];
+        vm.segments = segments![((1, 0), 5)];
         //Create hint_data
         let ids_data = ids_data!["n_used_accesses"];
         //Execute the hint
@@ -638,7 +638,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 1;
         //Insert ids into memory (n_used_accesses)
-        vm.memory = memory![((1, 0), (1, 2))];
+        vm.segments = segments![((1, 0), (1, 2))];
         //Create hint_data
         let ids_data = ids_data!["n_used_accesses"];
         //Execute the hint
@@ -705,7 +705,7 @@ mod tests {
         //Execute the hint
         assert_eq!(run_hint!(vm, ids_data, hint_code, &mut exec_scopes), Ok(()));
         //Check the value of ids.next_key
-        check_memory![vm.memory, ((1, 0), 3)];
+        check_memory![vm.segments.memory, ((1, 0), 3)];
         //Check local variables
         check_scope!(
             &exec_scopes,
@@ -740,7 +740,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 0), (2, 0)),
             ((1, 3), 6),
             ((1, 4), 2),
@@ -775,7 +775,7 @@ mod tests {
             ]
         );
         //Check ids variables
-        check_memory![vm.memory, ((1, 1), 0), ((1, 2), 1)];
+        check_memory![vm.segments.memory, ((1, 1), 0), ((1, 2), 1)];
     }
 
     #[test]
@@ -787,7 +787,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 0), (2, 0)),
             ((1, 3), 6),
             ((1, 4), 4),
@@ -833,7 +833,7 @@ mod tests {
         let keys = exec_scopes.get_list_ref::<Felt>("keys").unwrap();
         assert_eq!(*keys, vec![Felt::new(2)]);
         //Check ids variables
-        check_memory![vm.memory, ((1, 1), 0), ((1, 2), 1)];
+        check_memory![vm.segments.memory, ((1, 1), 0), ((1, 2), 1)];
     }
 
     #[test]
@@ -847,7 +847,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 0), (2, 0)),
             ((1, 3), 6),
             ((1, 4), 2),
@@ -881,7 +881,7 @@ mod tests {
             ]
         );
         //Check ids variables
-        check_memory![vm.memory, ((1, 1), 0), ((1, 2), 1)];
+        check_memory![vm.segments.memory, ((1, 1), 0), ((1, 2), 1)];
     }
 
     #[test]
@@ -895,7 +895,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 0), (2, 0)),
             ((1, 3), 6),
             ((1, 4), 2),
@@ -933,7 +933,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 0), (2, 0)),
             ((1, 3), 7),
             ((1, 4), 2),
@@ -967,7 +967,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 0), (2, 0)),
             ((1, 3), 6),
             (
@@ -1010,7 +1010,7 @@ mod tests {
         //Initialize fp
         vm.run_context.fp = 5;
         //Insert ids into memory
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 0), (2, 0)),
             ((1, 3), 6),
             ((1, 4), 2),
@@ -1051,7 +1051,7 @@ mod tests {
         )])), ("keys", Vec::<Felt>::new()), ("key", felt_str!("3618502761706184546546682988428055018603476541694452277432519575032261771265"))]);
         //Check ids variables
         check_memory![
-            vm.memory,
+            vm.segments.memory,
             ((1, 1), 1),
             (
                 (1, 2),

--- a/src/hint_processor/builtin_hint_processor/uint256_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/uint256_utils.rs
@@ -250,7 +250,7 @@ mod tests {
         //Create hint_data
         let ids_data =
             non_continuous_ids_data![("a", -6), ("b", -4), ("carry_high", 3), ("carry_low", 2)];
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 4), 2),
             ((1, 5), 3),
             ((1, 6), 4),
@@ -259,7 +259,7 @@ mod tests {
         //Execute the hint
         assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
         //Check hint memory inserts
-        check_memory![&vm.memory, ((1, 12), 0), ((1, 13), 1)];
+        check_memory![vm.segments.memory, ((1, 12), 0), ((1, 13), 1)];
     }
 
     #[test]
@@ -272,7 +272,7 @@ mod tests {
         let ids_data =
             non_continuous_ids_data![("a", -6), ("b", -4), ("carry_high", 3), ("carry_low", 2)];
         //Insert ids into memory
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 4), 2),
             ((1, 5), 3),
             ((1, 6), 4),
@@ -301,13 +301,13 @@ mod tests {
         //Create hint_data
         let ids_data = non_continuous_ids_data![("a", -3), ("high", 1), ("low", 0)];
         //Insert ids.a into memory
-        vm.memory = memory![((1, 7), ("850981239023189021389081239089023", 10))];
+        vm.segments = segments![((1, 7), ("850981239023189021389081239089023", 10))];
         //Execute the hint
         assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
         //Check hint memory inserts
         //ids.low, ids.high
         check_memory![
-            &vm.memory,
+            vm.segments.memory,
             ((1, 10), 7249717543555297151_u64),
             ((1, 11), 46131785404667_u64)
         ];
@@ -322,14 +322,14 @@ mod tests {
         //Create ids_data
         let ids_data = non_continuous_ids_data![("a", -3), ("high", 1), ("low", 0)];
         //Insert ids.a into memory
-        vm.memory = memory![((1, 7), ("400066369019890261321163226850167045262", 10))];
+        vm.segments = segments![((1, 7), ("400066369019890261321163226850167045262", 10))];
         //Execute the hint
         assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
 
         //Check hint memory inserts
         //ids.low, ids.high
         check_memory![
-            &vm.memory,
+            vm.segments.memory,
             ((1, 10), 2279400676465785998_u64),
             ((1, 11), 21687641321487626429_u128)
         ];
@@ -344,7 +344,7 @@ mod tests {
         //Create hint_data
         let ids_data = non_continuous_ids_data![("a", -3), ("high", 1), ("low", 0)];
         //Insert ids.a into memory
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 7), ("850981239023189021389081239089023", 10)),
             ((1, 10), 0)
         ];
@@ -369,12 +369,16 @@ mod tests {
         vm.run_context.fp = 5;
         //Create hint_data
         let ids_data = non_continuous_ids_data![("n", -5), ("root", 0)];
-        vm.memory = memory![((1, 0), 17), ((1, 1), 7)];
+        vm.segments = segments![((1, 0), 17), ((1, 1), 7)];
         //Execute the hint
         assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
         //Check hint memory inserts
         //ids.root.low, ids.root.high
-        check_memory![&vm.memory, ((1, 5), 48805497317890012913_u128), ((1, 6), 0)];
+        check_memory![
+            vm.segments.memory,
+            ((1, 5), 48805497317890012913_u128),
+            ((1, 6), 0)
+        ];
     }
 
     #[test]
@@ -385,7 +389,7 @@ mod tests {
         vm.run_context.fp = 5;
         //Create hint_data
         let ids_data = non_continuous_ids_data![("n", -5), ("root", 0)];
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 0), 0),
             ((1, 1), ("340282366920938463463374607431768211458", 10))
         ];
@@ -407,7 +411,7 @@ mod tests {
         //Create hint_data
         let ids_data = non_continuous_ids_data![("n", -5), ("root", 0)];
         //Insert  ids.n.low into memory
-        vm.memory = memory![((1, 0), 17), ((1, 1), 7), ((1, 5), 1)];
+        vm.segments = segments![((1, 0), 17), ((1, 1), 7), ((1, 5), 1)];
         //Execute the hint
         assert_eq!(
             run_hint!(vm, ids_data, hint_code),
@@ -430,7 +434,7 @@ mod tests {
         //Create hint_data
         let ids_data = non_continuous_ids_data![("a", -4)];
         //Insert ids.a.high into memory
-        vm.memory = memory![(
+        vm.segments = segments![(
             (1, 1),
             (
                 "3618502788666131213697322783095070105793248398792065931704779359851756126208",
@@ -441,7 +445,7 @@ mod tests {
         assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
         //Check hint memory insert
         //memory[ap] = 1 if 0 <= (ids.a.high % PRIME) < 2 ** 127 else 0
-        check_memory![&vm.memory, ((1, 5), 1)];
+        check_memory![vm.segments.memory, ((1, 5), 1)];
     }
 
     #[test]
@@ -453,7 +457,7 @@ mod tests {
         //Create hint_data
         let ids_data = non_continuous_ids_data![("a", -4)];
         //Insert ids.a.high into memory
-        vm.memory = memory![(
+        vm.segments = segments![(
             (1, 1),
             (
                 "3618502788666131213697322783095070105793248398792065931704779359851756126209",
@@ -464,7 +468,7 @@ mod tests {
         assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
         //Check hint memory insert
         //memory[ap] = 1 if 0 <= (ids.a.high % PRIME) < 2 ** 127 else 0
-        check_memory![&vm.memory, ((1, 5), 0)];
+        check_memory![vm.segments.memory, ((1, 5), 0)];
     }
 
     #[test]
@@ -475,7 +479,7 @@ mod tests {
         run_context!(vm, 0, 5, 4);
         //Create hint_data
         let ids_data = non_continuous_ids_data![("a", -4)];
-        vm.memory = memory![((1, 1), 1), ((1, 5), 55)];
+        vm.segments = segments![((1, 1), 1), ((1, 5), 55)];
         //Execute the hint
         assert_eq!(
             run_hint!(vm, ids_data, hint_code),
@@ -499,13 +503,13 @@ mod tests {
         let ids_data =
             non_continuous_ids_data![("a", -6), ("div", -4), ("quotient", 0), ("remainder", 2)];
         //Insert ids into memory
-        vm.memory = memory![((1, 4), 89), ((1, 5), 72), ((1, 6), 3), ((1, 7), 7)];
+        vm.segments = segments![((1, 4), 89), ((1, 5), 72), ((1, 6), 3), ((1, 7), 7)];
         //Execute the hint
         assert_eq!(run_hint!(vm, ids_data, hint_code), Ok(()));
         //Check hint memory inserts
         //ids.quotient.low, ids.quotient.high, ids.remainder.low, ids.remainder.high
         check_memory![
-            &vm.memory,
+            vm.segments.memory,
             ((1, 10), 10),
             ((1, 11), 0),
             ((1, 12), 59),
@@ -523,7 +527,7 @@ mod tests {
         let ids_data =
             non_continuous_ids_data![("a", -6), ("div", -4), ("quotient", 0), ("remainder", 2)];
         //Insert ids into memory
-        vm.memory = memory![
+        vm.segments = segments![
             ((1, 4), 89),
             ((1, 5), 72),
             ((1, 6), 3),

--- a/src/hint_processor/builtin_hint_processor/uint256_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/uint256_utils.rs
@@ -218,6 +218,7 @@ pub fn uint256_unsigned_div_rem(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
     use crate::{
         any_box,
         hint_processor::{

--- a/src/hint_processor/builtin_hint_processor/usort.rs
+++ b/src/hint_processor/builtin_hint_processor/usort.rs
@@ -135,6 +135,7 @@ pub fn verify_multiplicity_body(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
     use crate::{
         any_box,
         hint_processor::{

--- a/src/hint_processor/builtin_hint_processor/usort.rs
+++ b/src/hint_processor/builtin_hint_processor/usort.rs
@@ -163,7 +163,7 @@ mod tests {
         let mut vm = vm_with_range_check!();
         vm.run_context.fp = 2;
         add_segments!(vm, 1);
-        vm.memory = memory![((1, 0), (2, 1)), ((1, 1), 5)];
+        vm.segments = segments![((1, 0), (2, 1)), ((1, 1), 5)];
         //Create hint_data
         let ids_data = ids_data!["input", "input_len"];
         let mut exec_scopes = scope![("usort_max_size", 1_u64)];

--- a/src/hint_processor/hint_processor_utils.rs
+++ b/src/hint_processor/hint_processor_utils.rs
@@ -205,7 +205,7 @@ mod tests {
     #[test]
     fn get_integer_from_reference_with_immediate_value() {
         let mut vm = vm!();
-        vm.memory = memory![((1, 0), 0)];
+        vm.segments = segments![((1, 0), 0)];
         let mut hint_ref = HintReference::new(0, 0, false, true);
         hint_ref.offset1 = OffsetValue::Immediate(Felt::new(2));
 
@@ -220,7 +220,7 @@ mod tests {
     #[test]
     fn get_offset_value_reference_valid() {
         let mut vm = vm!();
-        vm.memory = memory![((1, 0), 0)];
+        vm.segments = segments![((1, 0), 0)];
         let mut hint_ref = HintReference::new(0, 0, false, true);
         hint_ref.offset1 = OffsetValue::Reference(Register::FP, 2_i32, false);
 
@@ -233,7 +233,7 @@ mod tests {
     #[test]
     fn get_offset_value_reference_invalid() {
         let mut vm = vm!();
-        vm.memory = memory![((1, 0), 0)];
+        vm.segments = segments![((1, 0), 0)];
         let mut hint_ref = HintReference::new(0, 0, false, true);
         hint_ref.offset1 = OffsetValue::Reference(Register::FP, -2_i32, false);
 
@@ -246,7 +246,7 @@ mod tests {
     #[test]
     fn get_ptr_from_reference_short_path() {
         let mut vm = vm!();
-        vm.memory = memory![((1, 0), (2, 0))];
+        vm.segments = segments![((1, 0), (2, 0))];
 
         assert_eq!(
             get_ptr_from_reference(
@@ -261,7 +261,7 @@ mod tests {
     #[test]
     fn get_ptr_from_reference_with_dereference() {
         let mut vm = vm!();
-        vm.memory = memory![((1, 0), (3, 0))];
+        vm.segments = segments![((1, 0), (3, 0))];
 
         assert_eq!(
             get_ptr_from_reference(
@@ -276,7 +276,7 @@ mod tests {
     #[test]
     fn get_ptr_from_reference_with_dereference_and_imm() {
         let mut vm = vm!();
-        vm.memory = memory![((1, 0), (4, 0))];
+        vm.segments = segments![((1, 0), (4, 0))];
         let mut hint_ref = HintReference::new(0, 0, true, false);
         hint_ref.offset2 = OffsetValue::Value(2);
 
@@ -289,7 +289,7 @@ mod tests {
     #[test]
     fn compute_addr_from_reference_no_regiter_in_reference() {
         let mut vm = vm!();
-        vm.memory = memory![((1, 0), (4, 0))];
+        vm.segments = segments![((1, 0), (4, 0))];
         let mut hint_reference = HintReference::new(0, 0, false, false);
         hint_reference.offset1 = OffsetValue::Immediate(Felt::new(2_i32));
 
@@ -302,7 +302,7 @@ mod tests {
     #[test]
     fn compute_addr_from_reference_failed_to_get_ids() {
         let mut vm = vm!();
-        vm.memory = memory![((1, 0), 4)];
+        vm.segments = segments![((1, 0), 4)];
         // vm.run_context.fp = -1;
         let mut hint_reference = HintReference::new(0, 0, false, false);
         hint_reference.offset1 = OffsetValue::Reference(Register::FP, -1, true);
@@ -342,7 +342,7 @@ mod tests {
     #[test]
     fn get_maybe_relocatable_from_reference_valid() {
         let mut vm = vm!();
-        vm.memory = memory![((1, 0), (0, 0))];
+        vm.segments = segments![((1, 0), (0, 0))];
         let hint_ref = HintReference::new_simple(0);
         assert_eq!(
             get_maybe_relocatable_from_reference(&vm, &hint_ref, &ApTracking::new()),
@@ -353,7 +353,7 @@ mod tests {
     #[test]
     fn get_maybe_relocatable_from_reference_invalid() {
         let mut vm = vm!();
-        vm.memory = Memory::new();
+        vm.segments.memory = Memory::new();
         let hint_ref = HintReference::new_simple(0);
         assert_eq!(
             get_maybe_relocatable_from_reference(&vm, &hint_ref, &ApTracking::new()),

--- a/src/hint_processor/hint_processor_utils.rs
+++ b/src/hint_processor/hint_processor_utils.rs
@@ -194,6 +194,7 @@ fn get_offset_value_reference(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
     use crate::{
         relocatable,
         utils::test_utils::*,
@@ -201,6 +202,7 @@ mod tests {
             errors::memory_errors::MemoryError, vm_core::VirtualMachine, vm_memory::memory::Memory,
         },
     };
+    use std::collections::HashMap;
 
     #[test]
     fn get_integer_from_reference_with_immediate_value() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -102,7 +102,7 @@ pub mod test_utils {
         }
     }
 
-    macro_rules!  segments {
+    macro_rules! segments {
         ($( (($si:expr, $off:expr), $val:tt) ),* ) => {
             {
                 let memory = memory!($( (($si, $off), $val) ),*);
@@ -396,7 +396,7 @@ pub mod test_utils {
     macro_rules! add_segments {
         ($vm:expr, $n:expr) => {
             for _ in 0..$n {
-                $vm.segments.add(&mut $vm.memory);
+                $vm.segments.add();
             }
         };
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -106,9 +106,10 @@ pub mod test_utils {
         ($( (($si:expr, $off:expr), $val:tt) ),* ) => {
             {
                 let memory = memory!($( (($si, $off), $val) ),*);
+                let mem_len = memory.data.len();
                 MemorySegmentManager {
                     memory,
-                    num_segments: memory.data.len(),
+                    num_segments: mem_len,
                     num_temp_segments: 0,
                     segment_sizes: HashMap::new(),
                     segment_used_sizes: None,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -106,11 +106,8 @@ pub mod test_utils {
         ($( (($si:expr, $off:expr), $val:tt) ),* ) => {
             {
                 let memory = memory!($( (($si, $off), $val) ),*);
-                let mem_len = memory.data.len();
                 MemorySegmentManager {
                     memory,
-                    num_segments: mem_len,
-                    num_temp_segments: 0,
                     segment_sizes: HashMap::new(),
                     segment_used_sizes: None,
                     public_memory_offsets: HashMap::new(),
@@ -706,7 +703,7 @@ mod test {
         add_segments!(vm, 1);
         assert_eq!(run_hint!(vm, HashMap::new(), hint_code), Ok(()));
         //A segment is added
-        assert_eq!(vm.segments.num_segments, 2);
+        assert_eq!(vm.segments.memory.data.len(), 2);
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -102,6 +102,25 @@ pub mod test_utils {
         }
     }
 
+    macro_rules!  segments {
+        ($( (($si:expr, $off:expr), $val:tt) ),* ) => {
+            {
+                let memory = memory!($( (($si, $off), $val) ),*);
+                MemorySegmentManager {
+                    memory,
+                    num_segments: memory.data.len(),
+                    num_temp_segments: 0,
+                    segment_sizes: HashMap::new(),
+                    segment_used_sizes: None,
+                    public_memory_offsets: HashMap::new(),
+                }
+
+            }
+
+        };
+    }
+    pub(crate) use segments;
+
     macro_rules! memory {
         ( $( (($si:expr, $off:expr), $val:tt) ),* ) => {
             {

--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -215,12 +215,14 @@ impl BitwiseBuiltinRunner {
 mod tests {
     use super::*;
     use crate::vm::errors::memory_errors::MemoryError;
+    use crate::vm::vm_memory::memory::Memory;
     use crate::vm::{runners::builtin_runner::BuiltinRunner, vm_core::VirtualMachine};
     use crate::{
         hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor,
         types::program::Program, utils::test_utils::*, vm::runners::cairo_runner::CairoRunner,
     };
     use felt::Felt;
+    use std::collections::HashMap;
 
     #[test]
     fn get_used_instances() {

--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -40,12 +40,8 @@ impl BitwiseBuiltinRunner {
         }
     }
 
-    pub fn initialize_segments(
-        &mut self,
-        segments: &mut MemorySegmentManager,
-        memory: &mut Memory,
-    ) {
-        self.base = segments.add(memory).segment_index
+    pub fn initialize_segments(&mut self, segments: &mut MemorySegmentManager) {
+        self.base = segments.add().segment_index
     }
 
     pub fn initial_stack(&self) -> Vec<MaybeRelocatable> {
@@ -176,11 +172,11 @@ impl BitwiseBuiltinRunner {
     pub fn final_stack(
         &mut self,
         segments: &MemorySegmentManager,
-        memory: &Memory,
         pointer: Relocatable,
     ) -> Result<Relocatable, RunnerError> {
         if self.included {
-            if let Ok(stop_pointer) = memory
+            if let Ok(stop_pointer) = segments
+                .memory
                 .get_relocatable(&(pointer.sub_usize(1)).map_err(|_| RunnerError::FinalStack)?)
             {
                 if self.base() != stop_pointer.segment_index {
@@ -232,7 +228,7 @@ mod tests {
 
         let mut vm = vm!();
 
-        vm.memory = memory![
+        vm.segments = segments![
             ((0, 0), (0, 0)),
             ((0, 1), (0, 1)),
             ((2, 0), (0, 0)),
@@ -250,7 +246,7 @@ mod tests {
 
         let mut vm = vm!();
 
-        vm.memory = memory![
+        vm.segments = segments![
             ((0, 0), (0, 0)),
             ((0, 1), (0, 1)),
             ((2, 0), (0, 0)),
@@ -262,9 +258,7 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin
-                .final_stack(&vm.segments, &vm.memory, pointer)
-                .unwrap(),
+            builtin.final_stack(&vm.segments, pointer).unwrap(),
             Relocatable::from((2, 1))
         );
     }
@@ -275,7 +269,7 @@ mod tests {
 
         let mut vm = vm!();
 
-        vm.memory = memory![
+        vm.segments = segments![
             ((0, 0), (0, 0)),
             ((0, 1), (0, 1)),
             ((2, 0), (0, 0)),
@@ -287,7 +281,7 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin.final_stack(&vm.segments, &vm.memory, pointer),
+            builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::InvalidStopPointer("bitwise".to_string()))
         );
     }
@@ -298,7 +292,7 @@ mod tests {
 
         let mut vm = vm!();
 
-        vm.memory = memory![
+        vm.segments = segments![
             ((0, 0), (0, 0)),
             ((0, 1), (0, 1)),
             ((2, 0), (0, 0)),
@@ -310,9 +304,7 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin
-                .final_stack(&vm.segments, &vm.memory, pointer)
-                .unwrap(),
+            builtin.final_stack(&vm.segments, pointer).unwrap(),
             Relocatable::from((2, 2))
         );
     }
@@ -323,7 +315,7 @@ mod tests {
 
         let mut vm = vm!();
 
-        vm.memory = memory![
+        vm.segments = segments![
             ((0, 0), (0, 0)),
             ((0, 1), (0, 1)),
             ((2, 0), (0, 0)),
@@ -335,7 +327,7 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin.final_stack(&vm.segments, &vm.memory, pointer),
+            builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::FinalStack)
         );
     }

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -317,12 +317,14 @@ mod tests {
     use crate::vm::errors::cairo_run_errors::CairoRunError;
     use crate::vm::errors::vm_errors::VirtualMachineError;
     use crate::vm::runners::cairo_runner::CairoRunner;
+    use crate::vm::vm_memory::memory::Memory;
     use crate::vm::{
         errors::{memory_errors::MemoryError, runner_errors::RunnerError},
         runners::builtin_runner::BuiltinRunner,
         vm_core::VirtualMachine,
     };
     use felt::felt_str;
+    use std::collections::HashMap;
     use std::path::Path;
     use EcOpBuiltinRunner;
 

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -106,12 +106,8 @@ impl EcOpBuiltinRunner {
         Ok(partial_sum_b)
     }
 
-    pub fn initialize_segments(
-        &mut self,
-        segments: &mut MemorySegmentManager,
-        memory: &mut Memory,
-    ) {
-        self.base = segments.add(memory).segment_index
+    pub fn initialize_segments(&mut self, segments: &mut MemorySegmentManager) {
+        self.base = segments.add().segment_index
     }
 
     pub fn initial_stack(&self) -> Vec<MaybeRelocatable> {
@@ -269,11 +265,11 @@ impl EcOpBuiltinRunner {
     pub fn final_stack(
         &mut self,
         segments: &MemorySegmentManager,
-        memory: &Memory,
         pointer: Relocatable,
     ) -> Result<Relocatable, RunnerError> {
         if self.included {
-            if let Ok(stop_pointer) = memory
+            if let Ok(stop_pointer) = segments
+                .memory
                 .get_relocatable(&(pointer.sub_usize(1)).map_err(|_| RunnerError::FinalStack)?)
             {
                 if self.base() != stop_pointer.segment_index {
@@ -346,7 +342,7 @@ mod tests {
 
         let mut vm = vm!();
 
-        vm.memory = memory![
+        vm.segments = segments![
             ((0, 0), (0, 0)),
             ((0, 1), (0, 1)),
             ((2, 0), (0, 0)),
@@ -358,9 +354,7 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin
-                .final_stack(&vm.segments, &vm.memory, pointer)
-                .unwrap(),
+            builtin.final_stack(&vm.segments, pointer).unwrap(),
             Relocatable::from((2, 1))
         );
     }
@@ -371,7 +365,7 @@ mod tests {
 
         let mut vm = vm!();
 
-        vm.memory = memory![
+        vm.segments = segments![
             ((0, 0), (0, 0)),
             ((0, 1), (0, 1)),
             ((2, 0), (0, 0)),
@@ -383,7 +377,7 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin.final_stack(&vm.segments, &vm.memory, pointer),
+            builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::InvalidStopPointer("ec_op".to_string()))
         );
     }
@@ -394,7 +388,7 @@ mod tests {
 
         let mut vm = vm!();
 
-        vm.memory = memory![
+        vm.segments = segments![
             ((0, 0), (0, 0)),
             ((0, 1), (0, 1)),
             ((2, 0), (0, 0)),
@@ -406,9 +400,7 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin
-                .final_stack(&vm.segments, &vm.memory, pointer)
-                .unwrap(),
+            builtin.final_stack(&vm.segments, pointer).unwrap(),
             Relocatable::from((2, 2))
         );
     }
@@ -419,7 +411,7 @@ mod tests {
 
         let mut vm = vm!();
 
-        vm.memory = memory![
+        vm.segments = segments![
             ((0, 0), (0, 0)),
             ((0, 1), (0, 1)),
             ((2, 0), (0, 0)),
@@ -431,7 +423,7 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin.final_stack(&vm.segments, &vm.memory, pointer),
+            builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::FinalStack)
         );
     }

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -205,11 +205,13 @@ mod tests {
     use crate::types::program::Program;
     use crate::utils::test_utils::*;
     use crate::vm::runners::cairo_runner::CairoRunner;
+    use crate::vm::vm_memory::memory::Memory;
     use crate::vm::{
         errors::memory_errors::MemoryError, runners::builtin_runner::BuiltinRunner,
         vm_core::VirtualMachine,
     };
     use felt::felt_str;
+    use std::collections::HashMap;
 
     #[test]
     fn get_used_instances() {

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -42,12 +42,8 @@ impl HashBuiltinRunner {
         }
     }
 
-    pub fn initialize_segments(
-        &mut self,
-        segments: &mut MemorySegmentManager,
-        memory: &mut Memory,
-    ) {
-        self.base = segments.add(memory).segment_index
+    pub fn initialize_segments(&mut self, segments: &mut MemorySegmentManager) {
+        self.base = segments.add().segment_index
     }
 
     pub fn initial_stack(&self) -> Vec<MaybeRelocatable> {
@@ -170,11 +166,11 @@ impl HashBuiltinRunner {
     pub fn final_stack(
         &mut self,
         segments: &MemorySegmentManager,
-        memory: &Memory,
         pointer: Relocatable,
     ) -> Result<Relocatable, RunnerError> {
         if self.included {
-            if let Ok(stop_pointer) = memory
+            if let Ok(stop_pointer) = segments
+                .memory
                 .get_relocatable(&(pointer.sub_usize(1)).map_err(|_| RunnerError::FinalStack)?)
             {
                 if self.base() != stop_pointer.segment_index {
@@ -231,7 +227,7 @@ mod tests {
 
         let mut vm = vm!();
 
-        vm.memory = memory![
+        vm.segments = segments![
             ((0, 0), (0, 0)),
             ((0, 1), (0, 1)),
             ((2, 0), (0, 0)),
@@ -243,9 +239,7 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin
-                .final_stack(&vm.segments, &vm.memory, pointer)
-                .unwrap(),
+            builtin.final_stack(&vm.segments, pointer).unwrap(),
             Relocatable::from((2, 1))
         );
     }
@@ -256,7 +250,7 @@ mod tests {
 
         let mut vm = vm!();
 
-        vm.memory = memory![
+        vm.segments = segments![
             ((0, 0), (0, 0)),
             ((0, 1), (0, 1)),
             ((2, 0), (0, 0)),
@@ -268,7 +262,7 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin.final_stack(&vm.segments, &vm.memory, pointer),
+            builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::InvalidStopPointer("pedersen".to_string()))
         );
     }
@@ -279,7 +273,7 @@ mod tests {
 
         let mut vm = vm!();
 
-        vm.memory = memory![
+        vm.segments = segments![
             ((0, 0), (0, 0)),
             ((0, 1), (0, 1)),
             ((2, 0), (0, 0)),
@@ -291,9 +285,7 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin
-                .final_stack(&vm.segments, &vm.memory, pointer)
-                .unwrap(),
+            builtin.final_stack(&vm.segments, pointer).unwrap(),
             Relocatable::from((2, 2))
         );
     }
@@ -304,7 +296,7 @@ mod tests {
 
         let mut vm = vm!();
 
-        vm.memory = memory![
+        vm.segments = segments![
             ((0, 0), (0, 0)),
             ((0, 1), (0, 1)),
             ((2, 0), (0, 0)),
@@ -316,7 +308,7 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin.final_stack(&vm.segments, &vm.memory, pointer),
+            builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::FinalStack)
         );
     }

--- a/src/vm/runners/builtin_runner/keccak.rs
+++ b/src/vm/runners/builtin_runner/keccak.rs
@@ -259,11 +259,13 @@ mod tests {
     use crate::types::program::Program;
     use crate::utils::test_utils::*;
     use crate::vm::runners::cairo_runner::CairoRunner;
+    use crate::vm::vm_memory::memory::Memory;
     use crate::vm::{
         errors::{memory_errors::MemoryError, runner_errors::RunnerError},
         runners::builtin_runner::BuiltinRunner,
         vm_core::VirtualMachine,
     };
+    use std::collections::HashMap;
     use std::path::Path;
 
     #[test]

--- a/src/vm/runners/builtin_runner/keccak.rs
+++ b/src/vm/runners/builtin_runner/keccak.rs
@@ -44,12 +44,8 @@ impl KeccakBuiltinRunner {
         }
     }
 
-    pub fn initialize_segments(
-        &mut self,
-        segments: &mut MemorySegmentManager,
-        memory: &mut Memory,
-    ) {
-        self.base = segments.add(memory).segment_index
+    pub fn initialize_segments(&mut self, segments: &mut MemorySegmentManager) {
+        self.base = segments.add().segment_index
     }
 
     pub fn initial_stack(&self) -> Vec<MaybeRelocatable> {
@@ -194,11 +190,11 @@ impl KeccakBuiltinRunner {
     pub fn final_stack(
         &mut self,
         segments: &MemorySegmentManager,
-        memory: &Memory,
         pointer: Relocatable,
     ) -> Result<Relocatable, RunnerError> {
         if self.included {
-            if let Ok(stop_pointer) = memory
+            if let Ok(stop_pointer) = segments
+                .memory
                 .get_relocatable(&(pointer.sub_usize(1)).map_err(|_| RunnerError::FinalStack)?)
             {
                 if self.base() != stop_pointer.segment_index {
@@ -287,7 +283,7 @@ mod tests {
 
         let mut vm = vm!();
 
-        vm.memory = memory![
+        vm.segments = segments![
             ((0, 0), (0, 0)),
             ((0, 1), (0, 1)),
             ((2, 0), (0, 0)),
@@ -299,9 +295,7 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin
-                .final_stack(&vm.segments, &vm.memory, pointer)
-                .unwrap(),
+            builtin.final_stack(&vm.segments, pointer).unwrap(),
             Relocatable::from((2, 1))
         );
     }
@@ -312,7 +306,7 @@ mod tests {
 
         let mut vm = vm!();
 
-        vm.memory = memory![
+        vm.segments = segments![
             ((0, 0), (0, 0)),
             ((0, 1), (0, 1)),
             ((2, 0), (0, 0)),
@@ -324,7 +318,7 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin.final_stack(&vm.segments, &vm.memory, pointer),
+            builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::InvalidStopPointer("keccak".to_string()))
         );
     }
@@ -336,7 +330,7 @@ mod tests {
 
         let mut vm = vm!();
 
-        vm.memory = memory![
+        vm.segments = segments![
             ((0, 0), (0, 0)),
             ((0, 1), (0, 1)),
             ((2, 0), (0, 0)),
@@ -348,9 +342,7 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin
-                .final_stack(&vm.segments, &vm.memory, pointer)
-                .unwrap(),
+            builtin.final_stack(&vm.segments, pointer).unwrap(),
             Relocatable::from((2, 2))
         );
     }
@@ -361,7 +353,7 @@ mod tests {
 
         let mut vm = vm!();
 
-        vm.memory = memory![
+        vm.segments = segments![
             ((0, 0), (0, 0)),
             ((0, 1), (0, 1)),
             ((2, 0), (0, 0)),
@@ -373,7 +365,7 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin.final_stack(&vm.segments, &vm.memory, pointer),
+            builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::FinalStack)
         );
     }

--- a/src/vm/runners/builtin_runner/output.rs
+++ b/src/vm/runners/builtin_runner/output.rs
@@ -125,6 +125,7 @@ impl Default for OutputBuiltinRunner {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vm::vm_memory::memory::Memory;
     use crate::{
         utils::test_utils::*,
         vm::{
@@ -132,6 +133,7 @@ mod tests {
             vm_core::VirtualMachine,
         },
     };
+    use std::collections::HashMap;
 
     #[test]
     fn get_used_instances() {
@@ -262,7 +264,6 @@ mod tests {
     fn initialize_segments_for_output() {
         let mut builtin = OutputBuiltinRunner::new(true);
         let mut segments = MemorySegmentManager::new();
-        let mut memory = Memory::new();
         builtin.initialize_segments(&mut segments);
         assert_eq!(builtin.base, 0);
     }

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -238,6 +238,7 @@ impl RangeCheckBuiltinRunner {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vm::vm_memory::memory::Memory;
     use crate::{
         hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor,
         types::program::Program,
@@ -247,6 +248,7 @@ mod tests {
             vm_core::VirtualMachine,
         },
     };
+    use std::collections::HashMap;
 
     #[test]
     fn get_used_instances() {
@@ -442,7 +444,6 @@ mod tests {
     fn initialize_segments_for_range_check() {
         let mut builtin = RangeCheckBuiltinRunner::new(8, 8, true);
         let mut segments = MemorySegmentManager::new();
-        let mut memory = Memory::new();
         builtin.initialize_segments(&mut segments);
         assert_eq!(builtin.base, 0);
     }

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -204,6 +204,7 @@ impl RangeCheckBuiltinRunner {
             if let Ok(stop_pointer) = memory
                 .get_relocatable(&(pointer.sub_usize(1)).map_err(|_| RunnerError::FinalStack)?)
             {
+                println!("base: {}, stop_ptr: {}", self.base(), stop_pointer);
                 if self.base() != stop_pointer.segment_index {
                     return Err(RunnerError::InvalidStopPointer("range_check".to_string()));
                 }

--- a/src/vm/runners/builtin_runner/signature.rs
+++ b/src/vm/runners/builtin_runner/signature.rs
@@ -283,7 +283,6 @@ mod tests {
     fn initialize_segments_for_ecdsa() {
         let mut builtin = SignatureBuiltinRunner::new(&EcdsaInstanceDef::default(), true);
         let mut segments = MemorySegmentManager::new();
-        let mut memory = Memory::new();
         builtin.initialize_segments(&mut segments);
         assert_eq!(builtin.base, 0);
     }

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -1295,7 +1295,7 @@ mod tests {
             segment_index: 5,
             offset: 9,
         });
-        vm.segments.num_segments = 6;
+        add_segments!(vm, 6);
         cairo_runner.initialize_builtins(&mut vm).unwrap();
         cairo_runner.initialize_segments(&mut vm, program_base);
         assert_eq!(
@@ -1315,7 +1315,7 @@ mod tests {
         assert_eq!(vm.builtin_runners[0].0, String::from("output"));
         assert_eq!(vm.builtin_runners[0].1.base(), 7);
 
-        assert_eq!(vm.segments.num_segments, 8);
+        assert_eq!(vm.segments.num_segments(), 8);
     }
 
     #[test]
@@ -1343,7 +1343,7 @@ mod tests {
         assert_eq!(vm.builtin_runners[0].0, String::from("output"));
         assert_eq!(vm.builtin_runners[0].1.base(), 2);
 
-        assert_eq!(vm.segments.num_segments, 3);
+        assert_eq!(vm.segments.num_segments(), 3);
     }
 
     #[test]
@@ -3923,7 +3923,7 @@ mod tests {
                 offset: 0,
             })
         );
-        assert_eq!(vm.segments.num_segments, 9);
+        assert_eq!(vm.segments.num_segments(), 9);
     }
 
     #[test]

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -303,11 +303,11 @@ impl CairoRunner {
     ) {
         self.program_base = match program_base {
             Some(base) => Some(base),
-            None => Some(vm.segments.add(&mut vm.memory)),
+            None => Some(vm.segments.add()),
         };
-        self.execution_base = Some(vm.segments.add(&mut vm.memory));
+        self.execution_base = Some(vm.segments.add());
         for (_key, builtin_runner) in vm.builtin_runners.iter_mut() {
-            builtin_runner.initialize_segments(&mut vm.segments, &mut vm.memory);
+            builtin_runner.initialize_segments(&mut vm.segments);
         }
     }
 
@@ -325,7 +325,6 @@ impl CairoRunner {
             self.initial_pc = Some(initial_pc);
             vm.segments
                 .load_data(
-                    &mut vm.memory,
                     &MaybeRelocatable::RelocatableValue(prog_base),
                     &self.program.data,
                 )
@@ -333,11 +332,7 @@ impl CairoRunner {
         }
         if let Some(exec_base) = self.execution_base {
             vm.segments
-                .load_data(
-                    &mut vm.memory,
-                    &MaybeRelocatable::RelocatableValue(exec_base),
-                    &stack,
-                )
+                .load_data(&MaybeRelocatable::RelocatableValue(exec_base), &stack)
                 .map_err(RunnerError::MemoryInitializationError)?;
         } else {
             return Err(RunnerError::NoProgBase);
@@ -352,7 +347,7 @@ impl CairoRunner {
         mut stack: Vec<MaybeRelocatable>,
         return_fp: MaybeRelocatable,
     ) -> Result<Relocatable, RunnerError> {
-        let end = vm.segments.add(&mut vm.memory);
+        let end = vm.segments.add();
         stack.append(&mut vec![
             return_fp,
             MaybeRelocatable::RelocatableValue(end),
@@ -411,7 +406,7 @@ impl CairoRunner {
             return Ok(self.program_base.as_ref().ok_or(RunnerError::NoProgBase)?
                 + self.program.end.ok_or(RunnerError::NoProgramEnd)?);
         }
-        let return_fp = vm.segments.add(&mut vm.memory);
+        let return_fp = vm.segments.add();
         if let Some(main) = &self.program.main {
             let main_clone = *main;
             Ok(self.initialize_function_entrypoint(
@@ -433,7 +428,7 @@ impl CairoRunner {
             self.program_base.as_ref().ok_or(RunnerError::NoProgBase)?,
         ));
         for (_, builtin) in vm.builtin_runners.iter() {
-            builtin.add_validation_rule(&mut vm.memory)?;
+            builtin.add_validation_rule(&mut vm.segments.memory)?;
         }
 
         // Mark all addresses from the program segment as accessed
@@ -449,7 +444,8 @@ impl CairoRunner {
 
         vm.accessed_addresses = Some(initial_accessed_addresses);
 
-        vm.memory
+        vm.segments
+            .memory
             .validate_existing_memory()
             .map_err(RunnerError::MemoryValidationError)
     }
@@ -590,16 +586,17 @@ impl CairoRunner {
             vm.trace.as_ref().ok_or(VirtualMachineError::TracerError(
                 TraceError::TraceNotEnabled,
             ))?,
-            &vm.memory,
+            &vm.segments.memory,
         )?;
 
         match limits {
             Some((mut rc_min, mut rc_max)) => {
                 for (_, runner) in &vm.builtin_runners {
-                    let (runner_min, runner_max) = match runner.get_range_check_usage(&vm.memory) {
-                        Some(x) => x,
-                        None => continue,
-                    };
+                    let (runner_min, runner_max) =
+                        match runner.get_range_check_usage(&vm.segments.memory) {
+                            Some(x) => x,
+                            None => continue,
+                        };
 
                     rc_min = rc_min.min(runner_min as isize);
                     rc_max = rc_max.max(runner_max as isize);
@@ -643,7 +640,7 @@ impl CairoRunner {
             .as_ref()
             .ok_or(MemoryError::MissingAccessedAddresses)?
             .iter()
-            .map(|addr| vm.memory.relocate_value(*addr));
+            .map(|addr| vm.segments.memory.relocate_value(*addr));
 
         let builtin_addresses = vm
             .builtin_runners
@@ -708,14 +705,14 @@ impl CairoRunner {
             return Err(RunnerError::RunAlreadyFinished.into());
         }
 
-        vm.memory.relocate_memory()?;
+        vm.segments.memory.relocate_memory()?;
         vm.end_run(&self.exec_scopes)?;
 
         if disable_finalize_all {
             return Ok(());
         }
 
-        vm.segments.compute_effective_sizes(&vm.memory);
+        vm.segments.compute_effective_sizes();
         if self.proof_mode && !disable_trace_padding {
             self.run_until_next_power_of_2(vm, hint_processor)?;
             loop {
@@ -751,7 +748,7 @@ impl CairoRunner {
         }
         //Relocated addresses start at 1
         self.relocated_memory.push(None);
-        for (index, segment) in vm.memory.data.iter().enumerate() {
+        for (index, segment) in vm.segments.memory.data.iter().enumerate() {
             for (seg_offset, element) in segment.iter().enumerate() {
                 match element {
                     Some(elem) => {
@@ -796,7 +793,7 @@ impl CairoRunner {
     }
 
     pub fn relocate(&mut self, vm: &mut VirtualMachine) -> Result<(), TraceError> {
-        vm.segments.compute_effective_sizes(&vm.memory);
+        vm.segments.compute_effective_sizes();
         // relocate_segments can fail if compute_effective_sizes is not called before.
         // The expect should be unreachable.
         let relocation_table = vm
@@ -883,7 +880,7 @@ impl CairoRunner {
             _ => return Ok(()),
         };
 
-        let segment_used_sizes = vm.segments.compute_effective_sizes(&vm.memory);
+        let segment_used_sizes = vm.segments.compute_effective_sizes();
         let base = builtin.base();
 
         let segment_index: usize = base
@@ -892,6 +889,7 @@ impl CairoRunner {
 
         for i in 0..segment_used_sizes[segment_index] {
             let value = vm
+                .segments
                 .memory
                 .get_integer(&(base, i).into())
                 .map_err(|_| RunnerError::MemoryGet((base, i).into()))?
@@ -963,7 +961,7 @@ impl CairoRunner {
     ) -> Result<(), CairoRunError> {
         let stack = args
             .iter()
-            .map(|arg| vm.segments.gen_cairo_arg(arg, &mut vm.memory))
+            .map(|arg| vm.segments.gen_cairo_arg(arg))
             .collect::<Result<Vec<MaybeRelocatable>, VirtualMachineError>>()?;
         let return_fp = MaybeRelocatable::from(0);
         let end = self.initialize_function_entrypoint(vm, entrypoint, stack, return_fp)?;
@@ -1067,7 +1065,7 @@ impl CairoRunner {
         }
         let mut pointer = vm.get_ap();
         for (_, builtin_runner) in vm.builtin_runners.iter_mut().rev() {
-            let new_pointer = builtin_runner.final_stack(&vm.segments, &vm.memory, pointer)?;
+            let new_pointer = builtin_runner.final_stack(&vm.segments, pointer)?;
             pointer = new_pointer;
         }
         if self.segments_finalized {
@@ -1098,7 +1096,7 @@ impl CairoRunner {
 
         // Create, initialize and insert the new custom hash runner.
         let mut builtin: BuiltinRunner = HashBuiltinRunner::new(32, true).into();
-        builtin.initialize_segments(&mut vm.segments, &mut vm.memory);
+        builtin.initialize_segments(&mut vm.segments);
         let segment_index = builtin.base();
         vm.builtin_runners
             .push(("hash_builtin".to_string(), builtin));
@@ -1125,7 +1123,7 @@ impl CairoRunner {
                     self.get_program_builtins().contains(builtin_name)
                 })
         {
-            stack_ptr = runner.final_stack(&vm.segments, &vm.memory, stack_ptr)?
+            stack_ptr = runner.final_stack(&vm.segments, stack_ptr)?
         }
         Ok(stack_ptr)
     }
@@ -1220,6 +1218,7 @@ impl Sub for ExecutionResources {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
     use crate::{
         hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor,
         relocatable,
@@ -1256,7 +1255,7 @@ mod tests {
         vm.accessed_addresses = Some(vec![(1, 0).into(), (1, 3).into()]);
         vm.builtin_runners = vec![{
             let mut builtin_runner: BuiltinRunner = OutputBuiltinRunner::new(true).into();
-            builtin_runner.initialize_segments(&mut vm.segments, &mut vm.memory);
+            builtin_runner.initialize_segments(&mut vm.segments);
 
             ("output".to_string(), builtin_runner)
         }];
@@ -1377,7 +1376,7 @@ mod tests {
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         for _ in 0..2 {
-            vm.segments.add(&mut vm.memory);
+            vm.segments.add();
         }
         cairo_runner.program_base = Some(Relocatable {
             segment_index: 1,
@@ -1386,7 +1385,7 @@ mod tests {
         cairo_runner.execution_base = Some(relocatable!(2, 0));
         let stack = Vec::new();
         cairo_runner.initialize_state(&mut vm, 1, stack).unwrap();
-        check_memory!(vm.memory, ((1, 0), 4), ((1, 1), 6));
+        check_memory!(vm.segments.memory, ((1, 0), 4), ((1, 1), 6));
     }
 
     #[test]
@@ -1396,13 +1395,13 @@ mod tests {
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         for _ in 0..3 {
-            vm.segments.add(&mut vm.memory);
+            vm.segments.add();
         }
         cairo_runner.program_base = Some(relocatable!(1, 0));
         cairo_runner.execution_base = Some(relocatable!(2, 0));
         let stack = vec![mayberelocatable!(4), mayberelocatable!(6)];
         cairo_runner.initialize_state(&mut vm, 1, stack).unwrap();
-        check_memory!(vm.memory, ((2, 0), 4), ((2, 1), 6));
+        check_memory!(vm.segments.memory, ((2, 0), 4), ((2, 1), 6));
     }
 
     #[test]
@@ -1412,7 +1411,7 @@ mod tests {
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         for _ in 0..2 {
-            vm.segments.add(&mut vm.memory);
+            vm.segments.add();
         }
         cairo_runner.execution_base = Some(Relocatable {
             segment_index: 2,
@@ -1433,7 +1432,7 @@ mod tests {
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         for _ in 0..2 {
-            vm.segments.add(&mut vm.memory);
+            vm.segments.add();
         }
         cairo_runner.program_base = Some(relocatable!(1, 0));
         let stack = vec![
@@ -1450,7 +1449,7 @@ mod tests {
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         for _ in 0..2 {
-            vm.segments.add(&mut vm.memory);
+            vm.segments.add();
         }
         cairo_runner.program_base = Some(relocatable!(0, 0));
         cairo_runner.execution_base = Some(relocatable!(1, 0));
@@ -1461,7 +1460,7 @@ mod tests {
             .unwrap();
         assert_eq!(cairo_runner.initial_fp, cairo_runner.initial_ap);
         assert_eq!(cairo_runner.initial_fp, Some(relocatable!(1, 2)));
-        check_memory!(vm.memory, ((1, 0), 9), ((1, 1), (2, 0)));
+        check_memory!(vm.segments.memory, ((1, 0), 9), ((1, 1), (2, 0)));
     }
 
     #[test]
@@ -1471,7 +1470,7 @@ mod tests {
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         for _ in 0..2 {
-            vm.segments.add(&mut vm.memory);
+            vm.segments.add();
         }
         cairo_runner.program_base = Some(relocatable!(0, 0));
         cairo_runner.execution_base = Some(relocatable!(1, 0));
@@ -1482,7 +1481,12 @@ mod tests {
             .unwrap();
         assert_eq!(cairo_runner.initial_fp, cairo_runner.initial_ap);
         assert_eq!(cairo_runner.initial_fp, Some(relocatable!(1, 3)));
-        check_memory!(vm.memory, ((1, 0), 7), ((1, 1), 9), ((1, 2), (2, 0)));
+        check_memory!(
+            vm.segments.memory,
+            ((1, 0), 7),
+            ((1, 1), 9),
+            ((1, 2), (2, 0))
+        );
     }
 
     #[test]
@@ -1538,7 +1542,7 @@ mod tests {
         let mut vm = vm!();
 
         // Add some arbitrary values to the VM's memory to check they are not being accessed
-        vm.memory = memory![((1, 0), 1)];
+        vm.segments = segments![((1, 0), 1)];
 
         let expected_accessed_addresses: Vec<Relocatable> = (0..24)
             .map(|offset| Relocatable::from((0, offset)))
@@ -1584,19 +1588,21 @@ mod tests {
         cairo_runner.initial_fp = Some(relocatable!(1, 2));
         cairo_runner.initialize_builtins(&mut vm).unwrap();
         cairo_runner.initialize_segments(&mut vm, None);
-        vm.memory = memory![((2, 0), 23), ((2, 1), 233)];
+        vm.segments = segments![((2, 0), 23), ((2, 1), 233)];
         assert_eq!(vm.builtin_runners[0].0, String::from("range_check"));
         assert_eq!(vm.builtin_runners[0].1.base(), 2);
         cairo_runner.initialize_vm(&mut vm).unwrap();
         assert!(vm
+            .segments
             .memory
             .validated_addresses
             .contains(&Relocatable::from((2, 0))));
         assert!(vm
+            .segments
             .memory
             .validated_addresses
             .contains(&Relocatable::from((2, 1))));
-        assert_eq!(vm.memory.validated_addresses.len(), 2);
+        assert_eq!(vm.segments.memory.validated_addresses.len(), 2);
     }
 
     #[test]
@@ -1610,7 +1616,7 @@ mod tests {
         cairo_runner.initial_fp = Some(relocatable!(1, 2));
         cairo_runner.initialize_builtins(&mut vm).unwrap();
         cairo_runner.initialize_segments(&mut vm, None);
-        vm.memory = memory![((2, 1), 23), ((2, 4), (-1))];
+        vm.segments = segments![((2, 1), 23), ((2, 4), (-1))];
 
         assert_eq!(
             cairo_runner.initialize_vm(&mut vm),
@@ -1670,7 +1676,7 @@ mod tests {
         assert_eq!(vm.run_context.fp, 2);
         //Memory
         check_memory!(
-            vm.memory,
+            vm.segments.memory,
             ((0, 0), 5207990763031199744_u64),
             ((0, 1), 2),
             ((0, 2), 2345108766317314046_u64),
@@ -1744,7 +1750,7 @@ mod tests {
         assert_eq!(vm.run_context.fp, 3);
         //Memory
         check_memory!(
-            vm.memory,
+            vm.segments.memory,
             ((0, 0), 4612671182993129469_u64),
             ((0, 1), 5198983563776393216_u64),
             ((0, 2), 1),
@@ -1832,7 +1838,7 @@ mod tests {
         assert_eq!(vm.run_context.fp, 3);
         //Memory
         check_memory!(
-            vm.memory,
+            vm.segments.memory,
             ((0, 0), 4612671182993129469_u64),
             ((0, 1), 5189976364521848832_u64),
             ((0, 2), 18446744073709551615_u128),
@@ -2018,8 +2024,15 @@ mod tests {
         assert_eq!(vm.builtin_runners[0].0, String::from("range_check"));
         assert_eq!(vm.builtin_runners[0].1.base(), 2);
 
-        check_memory!(vm.memory, ((2, 0), 7), ((2, 1), 18446744073709551608_i128));
-        assert_eq!(vm.memory.get(&MaybeRelocatable::from((2, 2))), Ok(None));
+        check_memory!(
+            vm.segments.memory,
+            ((2, 0), 7),
+            ((2, 1), 18446744073709551608_i128)
+        );
+        assert_eq!(
+            vm.segments.memory.get(&MaybeRelocatable::from((2, 2))),
+            Ok(None)
+        );
     }
 
     #[test]
@@ -2126,8 +2139,11 @@ mod tests {
         //Check that the output to be printed is correct
         assert_eq!(vm.builtin_runners[0].0, String::from("output"));
         assert_eq!(vm.builtin_runners[0].1.base(), 2);
-        check_memory!(vm.memory, ((2, 0), 1), ((2, 1), 17));
-        assert_eq!(vm.memory.get(&MaybeRelocatable::from((2, 2))), Ok(None));
+        check_memory!(vm.segments.memory, ((2, 0), 1), ((2, 1), 17));
+        assert_eq!(
+            vm.segments.memory.get(&MaybeRelocatable::from((2, 2))),
+            Ok(None)
+        );
     }
 
     #[test]
@@ -2266,9 +2282,16 @@ mod tests {
         assert_eq!(vm.builtin_runners[1].0, String::from("range_check"));
         assert_eq!(vm.builtin_runners[1].1.base(), 3);
 
-        check_memory!(vm.memory, ((3, 0), 7), ((3, 1), 18446744073709551608_i128));
+        check_memory!(
+            vm.segments.memory,
+            ((3, 0), 7),
+            ((3, 1), 18446744073709551608_i128)
+        );
         assert_eq!(
-            vm.memory.get(&MaybeRelocatable::from((2, 2))).unwrap(),
+            vm.segments
+                .memory
+                .get(&MaybeRelocatable::from((2, 2)))
+                .unwrap(),
             None
         );
 
@@ -2276,9 +2299,12 @@ mod tests {
         assert_eq!(vm.builtin_runners[0].0, String::from("output"));
         assert_eq!(vm.builtin_runners[0].1.base(), 2);
 
-        check_memory!(vm.memory, ((2, 0), 7));
+        check_memory!(vm.segments.memory, ((2, 0), 7));
         assert_eq!(
-            vm.memory.get(&(MaybeRelocatable::from((2, 1)))).unwrap(),
+            vm.segments
+                .memory
+                .get(&(MaybeRelocatable::from((2, 1))))
+                .unwrap(),
             None
         );
     }
@@ -2313,46 +2339,52 @@ mod tests {
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!(true);
         for _ in 0..4 {
-            vm.segments.add(&mut vm.memory);
+            vm.segments.add();
         }
         // Memory initialization without macro
-        vm.memory
+        vm.segments
+            .memory
             .insert(
                 &MaybeRelocatable::from((0, 0)),
                 &MaybeRelocatable::from(Felt::new(4613515612218425347_i64)),
             )
             .unwrap();
-        vm.memory
+        vm.segments
+            .memory
             .insert(
                 &MaybeRelocatable::from((0, 1)),
                 &MaybeRelocatable::from(Felt::new(5)),
             )
             .unwrap();
-        vm.memory
+        vm.segments
+            .memory
             .insert(
                 &MaybeRelocatable::from((0, 2)),
                 &MaybeRelocatable::from(Felt::new(2345108766317314046_i64)),
             )
             .unwrap();
-        vm.memory
+        vm.segments
+            .memory
             .insert(
                 &MaybeRelocatable::from((1, 0)),
                 &MaybeRelocatable::from((2, 0)),
             )
             .unwrap();
-        vm.memory
+        vm.segments
+            .memory
             .insert(
                 &MaybeRelocatable::from((1, 1)),
                 &MaybeRelocatable::from((3, 0)),
             )
             .unwrap();
-        vm.memory
+        vm.segments
+            .memory
             .insert(
                 &MaybeRelocatable::from((1, 5)),
                 &MaybeRelocatable::from(Felt::new(5)),
             )
             .unwrap();
-        vm.segments.compute_effective_sizes(&vm.memory);
+        vm.segments.compute_effective_sizes();
         let rel_table = vm
             .segments
             .relocate_segments()
@@ -2457,7 +2489,7 @@ mod tests {
             cairo_runner.run_until_pc(end, &mut vm, &mut hint_processor),
             Ok(())
         );
-        vm.segments.compute_effective_sizes(&vm.memory);
+        vm.segments.compute_effective_sizes();
         let rel_table = vm
             .segments
             .relocate_segments()
@@ -2592,7 +2624,7 @@ mod tests {
             cairo_runner.run_until_pc(end, &mut vm, &mut hint_processor),
             Ok(())
         );
-        vm.segments.compute_effective_sizes(&vm.memory);
+        vm.segments.compute_effective_sizes();
         let rel_table = vm
             .segments
             .relocate_segments()
@@ -2708,7 +2740,7 @@ mod tests {
         assert_eq!(vm.builtin_runners[0].0, String::from("output"));
         assert_eq!(vm.builtin_runners[0].1.base(), 2);
 
-        vm.memory = memory![((2, 0), 1), ((2, 1), 2)];
+        vm.segments = segments![((2, 0), 1), ((2, 1), 2)];
         vm.segments.segment_used_sizes = Some(vec![0, 0, 2]);
         let mut stdout = Vec::<u8>::new();
         cairo_runner.write_output(&mut vm, &mut stdout).unwrap();
@@ -2781,7 +2813,7 @@ mod tests {
         cairo_runner.initialize_segments(&mut vm, None);
         assert_eq!(vm.builtin_runners[0].0, String::from("output"));
         assert_eq!(vm.builtin_runners[0].1.base(), 2);
-        vm.memory = memory![(
+        vm.segments = segments![(
             (2, 0),
             (
                 "800000000000011000000000000000000000000000000000000000000000000",
@@ -3188,7 +3220,7 @@ mod tests {
 
         vm.builtin_runners = vec![{
             let mut builtin_runner: BuiltinRunner = OutputBuiltinRunner::new(true).into();
-            builtin_runner.initialize_segments(&mut vm.segments, &mut vm.memory);
+            builtin_runner.initialize_segments(&mut vm.segments);
 
             ("output".to_string(), builtin_runner)
         }];
@@ -3206,7 +3238,7 @@ mod tests {
         vm.accessed_addresses = Some(vec![(1, 0).into(), (1, 2).into()]);
         vm.builtin_runners = vec![{
             let mut builtin_runner: BuiltinRunner = OutputBuiltinRunner::new(true).into();
-            builtin_runner.initialize_segments(&mut vm.segments, &mut vm.memory);
+            builtin_runner.initialize_segments(&mut vm.segments);
 
             ("output".to_string(), builtin_runner)
         }];
@@ -3409,7 +3441,7 @@ mod tests {
         vm.segments.segment_used_sizes = Some(vec![4]);
         vm.builtin_runners = vec![{
             let mut builtin = OutputBuiltinRunner::new(true);
-            builtin.initialize_segments(&mut vm.segments, &mut vm.memory);
+            builtin.initialize_segments(&mut vm.segments);
 
             ("output".to_string(), BuiltinRunner::Output(builtin))
         }];
@@ -3611,7 +3643,7 @@ mod tests {
                 fp: (0, 0).into(),
             },
         ]);
-        vm.memory.data = vec![vec![
+        vm.segments.memory.data = vec![vec![
             Some(Felt::new(0x80FF_8000_0530u64).into()),
             Some(Felt::new(0xBFFF_8000_0620u64).into()),
             Some(Felt::new(0x8FFF_8000_0750u64).into()),
@@ -3637,7 +3669,7 @@ mod tests {
             ap: (0, 0).into(),
             fp: (0, 0).into(),
         }]);
-        vm.memory.data = vec![vec![mayberelocatable!(0x80FF_8000_0530u64).into()]];
+        vm.segments.memory.data = vec![vec![mayberelocatable!(0x80FF_8000_0530u64).into()]];
         vm.builtin_runners = vec![(
             "range_check".to_string(),
             RangeCheckBuiltinRunner::new(12, 5, true).into(),
@@ -3672,7 +3704,7 @@ mod tests {
         let mut vm = vm!();
         vm.builtin_runners = vec![];
         vm.current_step = 10000;
-        vm.memory.data = vec![vec![Some(mayberelocatable!(0x80FF_8000_0530u64))]];
+        vm.segments.memory.data = vec![vec![Some(mayberelocatable!(0x80FF_8000_0530u64))]];
         vm.trace = Some(vec![TraceEntry {
             pc: (0, 0).into(),
             ap: (0, 0).into(),
@@ -3694,7 +3726,7 @@ mod tests {
             "range_check".to_string(),
             RangeCheckBuiltinRunner::new(8, 8, true).into(),
         )];
-        vm.memory.data = vec![vec![Some(mayberelocatable!(0x80FF_8000_0530u64))]];
+        vm.segments.memory.data = vec![vec![Some(mayberelocatable!(0x80FF_8000_0530u64))]];
         vm.trace = Some(vec![TraceEntry {
             pc: (0, 0).into(),
             ap: (0, 0).into(),
@@ -3723,7 +3755,7 @@ mod tests {
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         for _ in 0..2 {
-            vm.segments.add(&mut vm.memory);
+            vm.segments.add();
         }
         cairo_runner.program_base = Some(relocatable!(0, 0));
         cairo_runner.execution_base = Some(relocatable!(1, 0));
@@ -3756,7 +3788,7 @@ mod tests {
             "range_check".to_string(),
             RangeCheckBuiltinRunner::new(8, 8, true).into(),
         )];
-        vm.memory.data = vec![vec![Some(mayberelocatable!(0x80FF_8000_0530u64))]];
+        vm.segments.memory.data = vec![vec![Some(mayberelocatable!(0x80FF_8000_0530u64))]];
         vm.trace = Some(vec![TraceEntry {
             pc: (0, 0).into(),
             ap: (0, 0).into(),
@@ -3781,7 +3813,7 @@ mod tests {
         vm.accessed_addresses = Some(vec![(1, 0).into(), (1, 3).into()]);
         vm.builtin_runners = vec![{
             let mut builtin_runner: BuiltinRunner = OutputBuiltinRunner::new(true).into();
-            builtin_runner.initialize_segments(&mut vm.segments, &mut vm.memory);
+            builtin_runner.initialize_segments(&mut vm.segments);
 
             ("output".to_string(), builtin_runner)
         }];
@@ -4151,7 +4183,7 @@ mod tests {
         let output_builtin = OutputBuiltinRunner::new(true);
         vm.builtin_runners
             .push((String::from("output"), output_builtin.into()));
-        vm.memory.data = vec![vec![], vec![Some(MaybeRelocatable::from((0, 0)))], vec![]];
+        vm.segments.memory.data = vec![vec![], vec![Some(MaybeRelocatable::from((0, 0)))], vec![]];
         vm.set_ap(1);
         vm.segments.segment_used_sizes = Some(vec![0, 1, 0]);
         //Check values written by first call to segments.finalize()
@@ -4177,7 +4209,7 @@ mod tests {
         let output_builtin = OutputBuiltinRunner::new(true);
         vm.builtin_runners
             .push((String::from("output"), output_builtin.into()));
-        vm.memory.data = vec![
+        vm.segments.memory.data = vec![
             vec![Some(MaybeRelocatable::from((0, 0)))],
             vec![Some(MaybeRelocatable::from((0, 1)))],
             vec![],
@@ -4211,7 +4243,7 @@ mod tests {
         vm.builtin_runners
             .push((String::from("bitwise"), bitwise_builtin.into()));
         cairo_runner.initialize_segments(&mut vm, None);
-        vm.memory.data = vec![
+        vm.segments.memory.data = vec![
             vec![Some(MaybeRelocatable::from((0, 0)))],
             vec![
                 Some(MaybeRelocatable::from((2, 0))),
@@ -4481,7 +4513,7 @@ mod tests {
         runner
             .run_until_pc(end, &mut vm, &mut BuiltinHintProcessor::new_empty())
             .unwrap();
-        vm.segments.compute_effective_sizes(&vm.memory);
+        vm.segments.compute_effective_sizes();
         let initial_pointer = vm.get_ap();
         let expected_pointer = vm.get_ap().sub_usize(1).unwrap();
         assert_eq!(
@@ -4500,7 +4532,7 @@ mod tests {
         runner
             .run_until_pc(end, &mut vm, &mut BuiltinHintProcessor::new_empty())
             .unwrap();
-        vm.segments.compute_effective_sizes(&vm.memory);
+        vm.segments.compute_effective_sizes();
         let initial_pointer = vm.get_ap();
         let expected_pointer = vm.get_ap().sub_usize(4).unwrap();
         assert_eq!(
@@ -4519,7 +4551,7 @@ mod tests {
         runner
             .run_until_pc(end, &mut vm, &mut BuiltinHintProcessor::new_empty())
             .unwrap();
-        vm.segments.compute_effective_sizes(&vm.memory);
+        vm.segments.compute_effective_sizes();
         let initial_pointer = vm.get_ap();
         let expected_pointer = vm.get_ap();
         assert_eq!(
@@ -4539,7 +4571,7 @@ mod tests {
         runner
             .run_until_pc(end, &mut vm, &mut BuiltinHintProcessor::new_empty())
             .unwrap();
-        vm.segments.compute_effective_sizes(&vm.memory);
+        vm.segments.compute_effective_sizes();
         let mut exec = runner.get_execution_resources(&vm).unwrap();
         exec.builtin_instance_counter
             .insert("output_builtin".to_string(), 0);

--- a/src/vm/security.rs
+++ b/src/vm/security.rs
@@ -29,7 +29,12 @@ pub fn verify_secure_runner(
     };
     // Check builtin segment out of bounds.
     for (index, stop_ptr) in builtins_segment_info {
-        let current_size = vm.memory.data.get(index).map(|segment| segment.len());
+        let current_size = vm
+            .segments
+            .memory
+            .data
+            .get(index)
+            .map(|segment| segment.len());
         // + 1 here accounts for maximum segment offset being segment.len() -1
         if current_size >= Some(stop_ptr + 1) {
             return Err(VirtualMachineError::OutOfBoundsBuiltinSegmentAccess);
@@ -41,6 +46,7 @@ pub fn verify_secure_runner(
         .and_then(|rel| rel.segment_index.to_usize())
         .ok_or(RunnerError::NoProgBase)?;
     let program_segment_size = vm
+        .segments
         .memory
         .data
         .get(program_segment_index)
@@ -52,8 +58,8 @@ pub fn verify_secure_runner(
     // Check that the addresses in memory are valid
     // This means that every temporary address has been properly relocated to a real address
     // Asumption: If temporary memory is empty, this means no temporary memory addresses were generated and all addresses in memory are real
-    if !vm.memory.temp_data.is_empty() {
-        for value in vm.memory.data.iter().flatten() {
+    if !vm.segments.memory.temp_data.is_empty() {
+        for value in vm.segments.memory.data.iter().flatten() {
             match value {
                 Some(MaybeRelocatable::RelocatableValue(addr)) if addr.segment_index < 0 => {
                     return Err(VirtualMachineError::InvalidMemoryValueTemporaryAddress(
@@ -104,7 +110,7 @@ mod test {
         let mut vm = vm!();
 
         runner.initialize(&mut vm).unwrap();
-        vm.segments.compute_effective_sizes(&vm.memory);
+        vm.segments.compute_effective_sizes();
         assert_eq!(verify_secure_runner(&runner, true, &mut vm), Ok(()));
     }
 
@@ -117,7 +123,7 @@ mod test {
 
         runner.initialize(&mut vm).unwrap();
 
-        vm.memory = memory![((0, 0), 100)];
+        vm.segments = segments![((0, 0), 100)];
         vm.segments.segment_used_sizes = Some(vec![1]);
 
         assert_eq!(
@@ -135,7 +141,7 @@ mod test {
         runner.initialize(&mut vm).unwrap();
         vm.builtin_runners[0].1.set_stop_ptr(0);
 
-        vm.memory.data = vec![vec![], vec![], vec![Some(mayberelocatable!(1))]];
+        vm.segments.memory.data = vec![vec![], vec![], vec![Some(mayberelocatable!(1))]];
         vm.segments.segment_used_sizes = Some(vec![0, 0, 0, 0]);
 
         assert_eq!(
@@ -157,7 +163,7 @@ mod test {
             .unwrap();
         vm.builtin_runners[0].1.set_stop_ptr(1);
 
-        vm.memory.data = vec![vec![], vec![], vec![Some(mayberelocatable!(1))]];
+        vm.segments.memory.data = vec![vec![], vec![], vec![Some(mayberelocatable!(1))]];
         vm.segments.segment_used_sizes = Some(vec![0, 0, 1, 0]);
 
         assert_eq!(verify_secure_runner(&runner, true, &mut vm), Ok(()));
@@ -180,7 +186,7 @@ mod test {
 
         runner.initialize(&mut vm).unwrap();
 
-        vm.memory.data = vec![vec![
+        vm.segments.memory.data = vec![vec![
             Some(relocatable!(1, 0).into()),
             Some(relocatable!(2, 1).into()),
             Some(relocatable!(3, 2).into()),
@@ -208,13 +214,13 @@ mod test {
 
         runner.initialize(&mut vm).unwrap();
 
-        vm.memory.data = vec![vec![
+        vm.segments.memory.data = vec![vec![
             Some(relocatable!(1, 0).into()),
             Some(relocatable!(2, 1).into()),
             Some(relocatable!(3, 2).into()),
             Some(relocatable!(4, 3).into()),
         ]];
-        vm.memory.temp_data = vec![vec![Some(relocatable!(1, 2).into())]];
+        vm.segments.memory.temp_data = vec![vec![Some(relocatable!(1, 2).into())]];
         vm.segments.segment_used_sizes = Some(vec![5, 1, 2, 3, 4]);
 
         assert_eq!(verify_secure_runner(&runner, true, &mut vm), Ok(()));
@@ -237,13 +243,13 @@ mod test {
 
         runner.initialize(&mut vm).unwrap();
 
-        vm.memory.data = vec![vec![
+        vm.segments.memory.data = vec![vec![
             Some(relocatable!(1, 0).into()),
             Some(relocatable!(2, 1).into()),
             Some(relocatable!(-3, 2).into()),
             Some(relocatable!(4, 3).into()),
         ]];
-        vm.memory.temp_data = vec![vec![Some(relocatable!(1, 2).into())]];
+        vm.segments.memory.temp_data = vec![vec![Some(relocatable!(1, 2).into())]];
         vm.segments.segment_used_sizes = Some(vec![5, 1, 2, 3, 4]);
 
         assert_eq!(

--- a/src/vm/security.rs
+++ b/src/vm/security.rs
@@ -85,9 +85,11 @@ mod test {
     use crate::types::relocatable::Relocatable;
     use crate::vm::errors::memory_errors::MemoryError;
     use crate::vm::vm_memory::memory::Memory;
+    use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
     use crate::{relocatable, types::program::Program, utils::test_utils::*};
     use felt::Felt;
     use num_traits::Zero;
+    use std::collections::HashMap;
 
     #[test]
     fn verify_secure_runner_without_program_base() {

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -200,8 +200,7 @@ impl VirtualMachine {
                 Some(res) => match res {
                     MaybeRelocatable::Int(num_res) => self.run_context.pc.add_int(&num_res)?,
 
-                    _ => {println!("Invalid JumpRel");
-                        return Err(VirtualMachineError::PureValue)},
+                    _ => return Err(VirtualMachineError::PureValue),
                 },
                 None => return Err(VirtualMachineError::UnconstrainedResJumpRel),
             },

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -1008,6 +1008,7 @@ impl VirtualMachine {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vm::vm_memory::memory::Memory;
     use crate::{
         any_box,
         hint_processor::builtin_hint_processor::builtin_hint_processor_definition::{
@@ -1031,6 +1032,7 @@ mod tests {
             },
         },
     };
+    use std::collections::HashMap;
 
     use felt::felt_str;
     use std::{collections::HashSet, path::Path};

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -17,7 +17,7 @@ use crate::{
         },
         runners::builtin_runner::{BuiltinRunner, RangeCheckBuiltinRunner, SignatureBuiltinRunner},
         trace::trace_entry::TraceEntry,
-        vm_memory::{memory::Memory, memory_segments::MemorySegmentManager},
+        vm_memory::memory_segments::MemorySegmentManager,
     },
 };
 use felt::Felt;
@@ -79,7 +79,6 @@ pub struct VirtualMachine {
     pub(crate) builtin_runners: Vec<(String, BuiltinRunner)>,
     pub(crate) segments: MemorySegmentManager,
     pub(crate) _program_base: Option<MaybeRelocatable>,
-    pub(crate) memory: Memory,
     pub(crate) accessed_addresses: Option<Vec<Relocatable>>,
     pub(crate) trace: Option<Vec<TraceEntry>>,
     pub(crate) current_step: usize,
@@ -119,7 +118,6 @@ impl VirtualMachine {
             run_context,
             builtin_runners: Vec::new(),
             _program_base: None,
-            memory: Memory::new(),
             // We had to change this from None to this Some because when calling run_from_entrypoint from cairo-rs-py
             // we could not change this value and faced an Error. This is the behaviour that the original VM implements also.
             accessed_addresses: Some(Vec::new()),
@@ -135,7 +133,7 @@ impl VirtualMachine {
     fn get_instruction_encoding(
         &self,
     ) -> Result<(Cow<Felt>, Option<Cow<MaybeRelocatable>>), VirtualMachineError> {
-        let encoding_ref = match self.memory.get(&self.run_context.pc) {
+        let encoding_ref = match self.segments.memory.get(&self.run_context.pc) {
             Ok(Some(Cow::Owned(MaybeRelocatable::Int(encoding)))) => Cow::Owned(encoding),
             Ok(Some(Cow::Borrowed(MaybeRelocatable::Int(encoding)))) => Cow::Borrowed(encoding),
             _ => return Err(VirtualMachineError::InvalidInstructionEncoding),
@@ -143,7 +141,7 @@ impl VirtualMachine {
 
         let imm_addr = &self.run_context.pc + 1_i32;
 
-        if let Ok(optional_imm) = self.memory.get(&imm_addr) {
+        if let Ok(optional_imm) = self.segments.memory.get(&imm_addr) {
             Ok((encoding_ref, optional_imm))
         } else {
             Err(VirtualMachineError::InvalidInstructionEncoding)
@@ -202,7 +200,8 @@ impl VirtualMachine {
                 Some(res) => match res {
                     MaybeRelocatable::Int(num_res) => self.run_context.pc.add_int(&num_res)?,
 
-                    _ => return Err(VirtualMachineError::PureValue),
+                    _ => {println!("Invalid JumpRel");
+                        return Err(VirtualMachineError::PureValue)},
                 },
                 None => return Err(VirtualMachineError::UnconstrainedResJumpRel),
             },
@@ -333,7 +332,7 @@ impl VirtualMachine {
     ) -> Result<Option<MaybeRelocatable>, VirtualMachineError> {
         for (_, builtin) in self.builtin_runners.iter() {
             if builtin.base() == address.segment_index {
-                match builtin.deduce_memory_cell(address, &self.memory) {
+                match builtin.deduce_memory_cell(address, &self.segments.memory) {
                     Ok(maybe_reloc) => return Ok(maybe_reloc),
                     Err(error) => return Err(VirtualMachineError::RunnerError(error)),
                 };
@@ -428,17 +427,20 @@ impl VirtualMachine {
         operands_addresses: &OperandsAddresses,
     ) -> Result<(), VirtualMachineError> {
         if deduced_operands.was_op0_deducted() {
-            self.memory
+            self.segments
+                .memory
                 .insert(&operands_addresses.op0_addr, &operands.op0)
                 .map_err(VirtualMachineError::MemoryError)?;
         }
         if deduced_operands.was_op1_deducted() {
-            self.memory
+            self.segments
+                .memory
                 .insert(&operands_addresses.op1_addr, &operands.op1)
                 .map_err(VirtualMachineError::MemoryError)?;
         }
         if deduced_operands.was_dest_deducted() {
-            self.memory
+            self.segments
+                .memory
                 .insert(&operands_addresses.dst_addr, &operands.dst)
                 .map_err(VirtualMachineError::MemoryError)?;
         }
@@ -597,6 +599,7 @@ impl VirtualMachine {
         //Get operands from memory
         let dst_addr = self.run_context.compute_dst_addr(instruction)?;
         let dst_op = self
+            .segments
             .memory
             .get(&dst_addr)
             .map_err(VirtualMachineError::MemoryError)?
@@ -604,6 +607,7 @@ impl VirtualMachine {
 
         let op0_addr = self.run_context.compute_op0_addr(instruction)?;
         let op0_op = self
+            .segments
             .memory
             .get(&op0_addr)
             .map_err(VirtualMachineError::MemoryError)?
@@ -613,6 +617,7 @@ impl VirtualMachine {
             .run_context
             .compute_op1_addr(instruction, op0_op.as_ref())?;
         let op1_op = self
+            .segments
             .memory
             .get(&op1_addr)
             .map_err(VirtualMachineError::MemoryError)?
@@ -672,9 +677,12 @@ impl VirtualMachine {
                 .base()
                 .try_into()
                 .map_err(|_| MemoryError::AddressInTemporarySegment(builtin.base()))?;
-            for (offset, value) in self.memory.data[index].iter().enumerate() {
+            for (offset, value) in self.segments.memory.data[index].iter().enumerate() {
                 if let Some(deduced_memory_cell) = builtin
-                    .deduce_memory_cell(&Relocatable::from((index as isize, offset)), &self.memory)
+                    .deduce_memory_cell(
+                        &Relocatable::from((index as isize, offset)),
+                        &self.segments.memory,
+                    )
                     .map_err(VirtualMachineError::RunnerError)?
                 {
                     if Some(&deduced_memory_cell) != value.as_ref() && value.is_some() {
@@ -696,11 +704,11 @@ impl VirtualMachine {
         addr: &Relocatable,
         builtin: &BuiltinRunner,
     ) -> Result<(), VirtualMachineError> {
-        let value = match builtin.deduce_memory_cell(addr, &self.memory)? {
+        let value = match builtin.deduce_memory_cell(addr, &self.segments.memory)? {
             Some(value) => value,
             None => return Ok(()),
         };
-        let current_value = match self.memory.get(addr)? {
+        let current_value = match self.segments.memory.get(addr)? {
             Some(value) => value.into_owned(),
             None => return Ok(()),
         };
@@ -749,7 +757,7 @@ impl VirtualMachine {
             let ret_pc = match fp
                 .sub_usize(1)
                 .ok()
-                .map(|ref r| self.memory.get_relocatable(r))
+                .map(|ref r| self.segments.memory.get_relocatable(r))
             {
                 Some(Ok(opt_pc)) => opt_pc,
                 _ => break,
@@ -758,7 +766,7 @@ impl VirtualMachine {
             match fp
                 .sub_usize(2)
                 .ok()
-                .map(|ref r| self.memory.get_relocatable(r))
+                .map(|ref r| self.segments.memory.get_relocatable(r))
             {
                 Some(Ok(opt_fp)) if opt_fp != fp => fp = opt_fp,
                 _ => break,
@@ -768,7 +776,7 @@ impl VirtualMachine {
             let call_pc = match ret_pc
                 .sub_usize(1)
                 .ok()
-                .map(|ref r| self.memory.get_integer(r))
+                .map(|ref r| self.segments.memory.get_integer(r))
             {
                 Some(Ok(instruction1)) => {
                     match is_call_instruction(&instruction1, None) {
@@ -777,7 +785,7 @@ impl VirtualMachine {
                             match ret_pc
                                 .sub_usize(2)
                                 .ok()
-                                .map(|ref r| self.memory.get_integer(r))
+                                .map(|ref r| self.segments.memory.get_integer(r))
                             {
                                 Some(Ok(instruction0)) => {
                                     match is_call_instruction(&instruction0, Some(&instruction1)) {
@@ -801,7 +809,7 @@ impl VirtualMachine {
 
     ///Adds a new segment and to the VirtualMachine.memory returns its starting location as a RelocatableValue.
     pub fn add_memory_segment(&mut self) -> Relocatable {
-        self.segments.add(&mut self.memory)
+        self.segments.add(&mut self.segments.memory)
     }
 
     pub fn get_ap(&self) -> Relocatable {
@@ -818,12 +826,12 @@ impl VirtualMachine {
 
     ///Gets the integer value corresponding to the Relocatable address
     pub fn get_integer(&self, key: &Relocatable) -> Result<Cow<Felt>, VirtualMachineError> {
-        self.memory.get_integer(key)
+        self.segments.memory.get_integer(key)
     }
 
     ///Gets the relocatable value corresponding to the Relocatable address
     pub fn get_relocatable(&self, key: &Relocatable) -> Result<Relocatable, VirtualMachineError> {
-        self.memory.get_relocatable(key)
+        self.segments.memory.get_relocatable(key)
     }
 
     ///Gets a MaybeRelocatable value from memory indicated by a generic address
@@ -834,7 +842,7 @@ impl VirtualMachine {
     where
         Relocatable: TryFrom<&'a K>,
     {
-        match self.memory.get(key) {
+        match self.segments.memory.get(key) {
             Ok(Some(cow)) => Ok(Some(cow.into_owned())),
             Ok(None) => Ok(None),
             Err(error) => Err(error),
@@ -856,7 +864,7 @@ impl VirtualMachine {
         key: &Relocatable,
         val: T,
     ) -> Result<(), VirtualMachineError> {
-        self.memory.insert_value(key, val)
+        self.segments.memory.insert_value(key, val)
     }
 
     ///Writes data into the memory at address ptr and returns the first address after the data.
@@ -865,7 +873,8 @@ impl VirtualMachine {
         ptr: &MaybeRelocatable,
         data: &Vec<MaybeRelocatable>,
     ) -> Result<MaybeRelocatable, MemoryError> {
-        self.segments.load_data(&mut self.memory, ptr, data)
+        self.segments
+            .load_data(&mut self.segments.memory, ptr, data)
     }
 
     /// Writes args into the memory at address ptr and returns the first address after the data.
@@ -875,7 +884,7 @@ impl VirtualMachine {
         ptr: &Relocatable,
         arg: &dyn Any,
     ) -> Result<MaybeRelocatable, MemoryError> {
-        self.segments.write_arg(&mut self.memory, ptr, arg)
+        self.segments.write_arg(&mut self.segments.memory, ptr, arg)
     }
 
     ///Gets `n_ret` return values from memory
@@ -885,7 +894,9 @@ impl VirtualMachine {
             .get_ap()
             .sub_usize(n_ret)
             .map_err(|_| MemoryError::NumOutOfBounds)?;
-        self.memory.get_continuous_range(&addr.into(), n_ret)
+        self.segments
+            .memory
+            .get_continuous_range(&addr.into(), n_ret)
     }
 
     ///Gets n elements from memory starting from addr (n being size)
@@ -894,7 +905,7 @@ impl VirtualMachine {
         addr: &MaybeRelocatable,
         size: usize,
     ) -> Result<Vec<Option<Cow<MaybeRelocatable>>>, MemoryError> {
-        self.memory.get_range(addr, size)
+        self.segments.memory.get_range(addr, size)
     }
 
     ///Gets n elements from memory starting from addr (n being size)
@@ -903,7 +914,7 @@ impl VirtualMachine {
         addr: &MaybeRelocatable,
         size: usize,
     ) -> Result<Vec<MaybeRelocatable>, MemoryError> {
-        self.memory.get_continuous_range(addr, size)
+        self.segments.memory.get_continuous_range(addr, size)
     }
 
     ///Gets n integer values from memory starting from addr (n being size),
@@ -912,7 +923,7 @@ impl VirtualMachine {
         addr: &Relocatable,
         size: usize,
     ) -> Result<Vec<Cow<Felt>>, VirtualMachineError> {
-        self.memory.get_integer_range(addr, size)
+        self.segments.memory.get_integer_range(addr, size)
     }
 
     pub fn get_range_check_builtin(&self) -> Result<&RangeCheckBuiltinRunner, VirtualMachineError> {
@@ -968,7 +979,8 @@ impl VirtualMachine {
     }
 
     pub fn add_temporary_segment(&mut self) -> Relocatable {
-        self.segments.add_temporary_segment(&mut self.memory)
+        self.segments
+            .add_temporary_segment(&mut self.segments.memory)
     }
 
     /// Add a new relocation rule.
@@ -982,17 +994,17 @@ impl VirtualMachine {
         src_ptr: Relocatable,
         dst_ptr: Relocatable,
     ) -> Result<(), MemoryError> {
-        self.memory.add_relocation_rule(src_ptr, dst_ptr)
+        self.segments.memory.add_relocation_rule(src_ptr, dst_ptr)
     }
 
     pub fn gen_arg(&mut self, arg: &dyn Any) -> Result<MaybeRelocatable, VirtualMachineError> {
-        self.segments.gen_arg(arg, &mut self.memory)
+        self.segments.gen_arg(arg, &mut self.segments.memory)
     }
 
     /// Proxy to MemorySegmentManager::compute_effective_sizes() to make it accessible from outside
     /// cairo-rs.
     pub fn compute_effective_sizes(&mut self) -> &Vec<usize> {
-        self.segments.compute_effective_sizes(&self.memory)
+        self.segments.compute_effective_sizes(&self.segments.memory)
     }
 }
 
@@ -1029,7 +1041,7 @@ mod tests {
     #[test]
     fn get_instruction_encoding_successful_without_imm() {
         let mut vm = vm!();
-        vm.memory = memory![((0, 0), 5)];
+        vm.segments = segments![((0, 0), 5)];
         assert_eq!((Felt::new(5), None), {
             let value = vm.get_instruction_encoding().unwrap();
             (value.0.into_owned(), value.1)
@@ -1040,7 +1052,7 @@ mod tests {
     fn get_instruction_encoding_successful_with_imm() {
         let mut vm = vm!();
 
-        vm.memory = memory![((0, 0), 5), ((0, 1), 6)];
+        vm.segments = segments![((0, 0), 5), ((0, 1), 6)];
 
         let (num, imm) = vm
             .get_instruction_encoding()
@@ -2442,7 +2454,7 @@ mod tests {
 
         let mut vm = vm!();
         vm.accessed_addresses = Some(Vec::new());
-        vm.memory = memory![
+        vm.segments = segments![
             ((0, 0), 0x206800180018001_i64),
             ((1, 1), 0x4),
             ((0, 1), 0x4)
@@ -2496,7 +2508,7 @@ mod tests {
 
         let mut vm = vm!();
 
-        vm.memory = memory!(((1, 0), 145944781867024385_i64));
+        vm.segments = segments!(((1, 0), 145944781867024385_i64));
 
         let error = vm.compute_operands(&instruction).unwrap_err();
         assert_eq!(error, VirtualMachineError::NoDst);
@@ -2698,7 +2710,7 @@ mod tests {
 
         run_context!(vm, 0, 2, 2);
 
-        vm.memory = memory![
+        vm.segments = segments![
             ((0, 0), 2345108766317314046_u64),
             ((1, 0), (2, 0)),
             ((1, 1), (3, 0))
@@ -2859,7 +2871,7 @@ mod tests {
     /// RelocatableValue(segment_index=1, offset=4): '0x14'
     fn multiplication_and_different_ap_increase() {
         let mut vm = vm!();
-        vm.memory = memory![
+        vm.segments = segments![
             ((0, 0), 0x400680017fff8000_i64),
             ((0, 1), 0x4),
             ((0, 2), 0x40780017fff7fff_i64),
@@ -2957,7 +2969,7 @@ mod tests {
         let builtin = HashBuiltinRunner::new(8, true);
         vm.builtin_runners
             .push((String::from("pedersen"), builtin.into()));
-        vm.memory = memory![((0, 3), 32), ((0, 4), 72), ((0, 5), 0)];
+        vm.segments = segments![((0, 3), 32), ((0, 4), 72), ((0, 5), 0)];
         assert_eq!(
             vm.deduce_memory_cell(&Relocatable::from((0, 5))),
             Ok(Some(MaybeRelocatable::from(felt::felt_str!(
@@ -3014,7 +3026,7 @@ mod tests {
         run_context!(vm, 0, 13, 12);
 
         //Insert values into memory (excluding those from the program segment (instructions))
-        vm.memory = memory![
+        vm.segments = segments![
             ((3, 0), 32),
             ((3, 1), 72),
             ((1, 0), (2, 0)),
@@ -3060,7 +3072,7 @@ mod tests {
         let builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default(), true);
         vm.builtin_runners
             .push((String::from("bitwise"), builtin.into()));
-        vm.memory = memory![((0, 5), 10), ((0, 6), 12), ((0, 7), 0)];
+        vm.segments = segments![((0, 5), 10), ((0, 6), 12), ((0, 7), 0)];
         assert_eq!(
             vm.deduce_memory_cell(&Relocatable::from((0, 7))),
             Ok(Some(MaybeRelocatable::from(Felt::new(8_i32))))
@@ -3106,7 +3118,7 @@ mod tests {
         run_context!(vm, 0, 9, 8);
 
         //Insert values into memory (excluding those from the program segment (instructions))
-        vm.memory = memory![
+        vm.segments = segments![
             ((2, 0), 12),
             ((2, 1), 10),
             ((1, 0), (2, 0)),
@@ -3142,7 +3154,7 @@ mod tests {
         vm.builtin_runners
             .push((String::from("ec_op"), builtin.into()));
 
-        vm.memory = memory![
+        vm.segments = segments![
             (
                 (0, 0),
                 (
@@ -3213,7 +3225,7 @@ mod tests {
         let mut vm = vm!();
         vm.builtin_runners
             .push((String::from("ec_op"), builtin.into()));
-        vm.memory = memory![
+        vm.segments = segments![
             (
                 (3, 0),
                 (
@@ -3261,7 +3273,7 @@ mod tests {
         let mut vm = vm!();
         vm.builtin_runners
             .push((String::from("ec_op"), builtin.into()));
-        vm.memory = memory![
+        vm.segments = segments![
             (
                 (3, 0),
                 (
@@ -3334,7 +3346,7 @@ mod tests {
         let mut vm = vm!();
         vm.builtin_runners
             .push((String::from("bitwise"), builtin.into()));
-        vm.memory = memory![((2, 0), 12), ((2, 1), 10)];
+        vm.segments = segments![((2, 0), 12), ((2, 1), 10)];
         assert_eq!(vm.verify_auto_deductions(), Ok(()));
     }
 
@@ -3356,7 +3368,7 @@ mod tests {
         builtin.base = 2;
         let builtin: BuiltinRunner = builtin.into();
         let mut vm = vm!();
-        vm.memory = memory![((2, 0), 12), ((2, 1), 10)];
+        vm.segments = segments![((2, 0), 12), ((2, 1), 10)];
         assert_eq!(
             vm.verify_auto_deductions_for_addr(&relocatable!(2, 0), &builtin),
             Ok(())
@@ -3397,7 +3409,7 @@ mod tests {
         let mut vm = vm!();
         vm.builtin_runners
             .push((String::from("pedersen"), builtin.into()));
-        vm.memory = memory![((3, 0), 32), ((3, 1), 72)];
+        vm.segments = segments![((3, 0), 32), ((3, 1), 72)];
         assert_eq!(vm.verify_auto_deductions(), Ok(()));
     }
 
@@ -3405,7 +3417,7 @@ mod tests {
     fn can_get_return_values() {
         let mut vm = vm!();
         vm.set_ap(4);
-        vm.memory = memory![((1, 0), 1), ((1, 1), 2), ((1, 2), 3), ((1, 3), 4)];
+        vm.segments = segments![((1, 0), 1), ((1, 1), 2), ((1, 2), 3), ((1, 3), 4)];
         let expected = vec![
             MaybeRelocatable::Int(Felt::new(1_i32)),
             MaybeRelocatable::Int(Felt::new(2_i32)),
@@ -3418,7 +3430,7 @@ mod tests {
     #[test]
     fn get_return_values_fails_when_ap_is_0() {
         let mut vm = vm!();
-        vm.memory = memory![((1, 0), 1), ((1, 1), 2), ((1, 2), 3), ((1, 3), 4)];
+        vm.segments = segments![((1, 0), 1), ((1, 1), 2), ((1, 2), 3), ((1, 3), 4)];
         assert!(matches!(
             vm.get_return_values(3),
             Err(MemoryError::NumOutOfBounds)
@@ -3468,7 +3480,7 @@ mod tests {
 
         let mut hint_processor = BuiltinHintProcessor::new_empty();
 
-        vm.memory = memory![
+        vm.segments = segments![
             ((0, 0), 290341444919459839_i64),
             ((0, 1), 1),
             ((0, 2), 2345108766317314046_i64),
@@ -3554,7 +3566,7 @@ mod tests {
     #[test]
     fn get_range_for_continuous_memory() {
         let mut vm = vm!();
-        vm.memory = memory![((1, 0), 2), ((1, 1), 3), ((1, 2), 4)];
+        vm.segments = segments![((1, 0), 2), ((1, 1), 3), ((1, 2), 4)];
 
         let value1 = MaybeRelocatable::from(Felt::new(2_i32));
         let value2 = MaybeRelocatable::from(Felt::new(3_i32));
@@ -3574,7 +3586,7 @@ mod tests {
     #[test]
     fn get_range_for_non_continuous_memory() {
         let mut vm = vm!();
-        vm.memory = memory![((1, 0), 2), ((1, 1), 3), ((1, 3), 4)];
+        vm.segments = segments![((1, 0), 2), ((1, 1), 3), ((1, 3), 4)];
 
         let value1 = MaybeRelocatable::from(Felt::new(2_i32));
         let value2 = MaybeRelocatable::from(Felt::new(3_i32));
@@ -3595,7 +3607,7 @@ mod tests {
     #[test]
     fn get_continuous_range_for_continuous_memory() {
         let mut vm = vm!();
-        vm.memory = memory![((1, 0), 2), ((1, 1), 3), ((1, 2), 4)];
+        vm.segments = segments![((1, 0), 2), ((1, 1), 3), ((1, 2), 4)];
 
         let value1 = MaybeRelocatable::from(Felt::new(2_i32));
         let value2 = MaybeRelocatable::from(Felt::new(3_i32));
@@ -3611,7 +3623,7 @@ mod tests {
     #[test]
     fn get_continuous_range_for_non_continuous_memory() {
         let mut vm = vm!();
-        vm.memory = memory![((1, 0), 2), ((1, 1), 3), ((1, 3), 4)];
+        vm.segments = segments![((1, 0), 2), ((1, 1), 3), ((1, 3), 4)];
 
         assert_eq!(
             vm.get_continuous_range(&MaybeRelocatable::from((1, 0)), 3),
@@ -3622,7 +3634,7 @@ mod tests {
     #[test]
     fn get_segment_used_size_after_computing_used() {
         let mut vm = vm!();
-        vm.memory = memory![
+        vm.segments = segments![
             ((0, 2), 1),
             ((0, 5), 1),
             ((0, 7), 1),
@@ -3729,7 +3741,7 @@ mod tests {
     #[test]
     fn decode_current_instruction_invalid_encoding() {
         let mut vm = vm!();
-        vm.memory = memory![((0, 0), ("112233445566778899", 16))];
+        vm.segments = segments![((0, 0), ("112233445566778899", 16))];
         assert_eq!(
             vm.decode_current_instruction(),
             Err(VirtualMachineError::InvalidInstructionEncoding)

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -556,10 +556,10 @@ mod memory_tests {
         let mut builtin = RangeCheckBuiltinRunner::new(8, 8, true);
         let mut segments = MemorySegmentManager::new();
         let mut memory = Memory::new();
-        builtin.initialize_segments(&mut segments, &mut memory);
+        builtin.initialize_segments(&mut segments);
         assert_eq!(builtin.add_validation_rule(&mut memory), Ok(()));
         for _ in 0..3 {
-            segments.add(&mut memory);
+            segments.add();
         }
 
         memory
@@ -579,8 +579,8 @@ mod memory_tests {
         let mut builtin = RangeCheckBuiltinRunner::new(8, 8, true);
         let mut segments = MemorySegmentManager::new();
         let mut memory = Memory::new();
-        segments.add(&mut memory);
-        builtin.initialize_segments(&mut segments, &mut memory);
+        segments.add();
+        builtin.initialize_segments(&mut segments);
         memory
             .insert(
                 &MaybeRelocatable::from((1, 0)),
@@ -616,8 +616,8 @@ mod memory_tests {
                 )
             )
         ];
-        segments.add(&mut memory);
-        builtin.initialize_segments(&mut segments, &mut memory);
+        segments.add();
+        builtin.initialize_segments(&mut segments);
         builtin.add_validation_rule(&mut memory).unwrap();
         let error = memory.validate_existing_memory();
         assert_eq!(error, Err(MemoryError::SignatureNotFound((1, 0).into())));
@@ -651,7 +651,7 @@ mod memory_tests {
             ((1, 1), 2)
         ];
 
-        builtin.initialize_segments(&mut segments, &mut memory);
+        builtin.initialize_segments(&mut segments);
 
         builtin.add_validation_rule(&mut memory).unwrap();
 
@@ -665,8 +665,8 @@ mod memory_tests {
         let mut builtin = RangeCheckBuiltinRunner::new(8, 8, true);
         let mut segments = MemorySegmentManager::new();
         let mut memory = memory![((1, 7), (1, 4))];
-        segments.add(&mut memory);
-        builtin.initialize_segments(&mut segments, &mut memory);
+        segments.add();
+        builtin.initialize_segments(&mut segments);
         assert_eq!(builtin.add_validation_rule(&mut memory), Ok(()));
         dbg!(builtin._bound);
         dbg!(&memory.data);
@@ -683,8 +683,8 @@ mod memory_tests {
         let mut builtin = RangeCheckBuiltinRunner::new(8, 8, true);
         let mut segments = MemorySegmentManager::new();
         let mut memory = Memory::new();
-        segments.add(&mut memory);
-        builtin.initialize_segments(&mut segments, &mut memory);
+        segments.add();
+        builtin.initialize_segments(&mut segments);
         memory
             .insert(
                 &MaybeRelocatable::from((0, 0)),
@@ -711,7 +711,7 @@ mod memory_tests {
     fn get_integer_invalid_expected_integer() {
         let mut segments = MemorySegmentManager::new();
         let mut memory = Memory::new();
-        segments.add(&mut memory);
+        segments.add();
         memory
             .insert(
                 &MaybeRelocatable::from((0, 0)),

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -601,27 +601,26 @@ mod memory_tests {
     fn validate_existing_memory_for_invalid_signature() {
         let mut builtin = SignatureBuiltinRunner::new(&EcdsaInstanceDef::default(), true);
         let mut segments = MemorySegmentManager::new();
+        builtin.initialize_segments(&mut segments);
         segments.memory = memory![
             (
-                (1, 0),
+                (0, 0),
                 (
                     "874739451078007766457464989774322083649278607533249481151382481072868806602",
                     10
                 )
             ),
             (
-                (1, 1),
+                (0, 1),
                 (
                     "-1472574760335685482768423018116732869320670550222259018541069375211356613248",
                     10
                 )
             )
         ];
-        segments.add();
-        builtin.initialize_segments(&mut segments);
         builtin.add_validation_rule(&mut segments.memory).unwrap();
         let error = segments.memory.validate_existing_memory();
-        assert_eq!(error, Err(MemoryError::SignatureNotFound((1, 0).into())));
+        assert_eq!(error, Err(MemoryError::SignatureNotFound((0, 0).into())));
     }
 
     #[test]
@@ -665,12 +664,9 @@ mod memory_tests {
     fn validate_existing_memory_for_range_check_relocatable_value() {
         let mut builtin = RangeCheckBuiltinRunner::new(8, 8, true);
         let mut segments = MemorySegmentManager::new();
-        segments.memory = memory![((1, 7), (1, 4))];
-        segments.add();
         builtin.initialize_segments(&mut segments);
+        segments.memory = memory![((0, 7), (0, 4))];
         assert_eq!(builtin.add_validation_rule(&mut segments.memory), Ok(()));
-        dbg!(builtin._bound);
-        dbg!(&segments.memory.data);
         let error = segments.memory.validate_existing_memory();
         assert_eq!(error, Err(MemoryError::FoundNonInt));
         assert_eq!(

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -555,21 +555,22 @@ mod memory_tests {
     fn validate_existing_memory_for_range_check_within_bounds() {
         let mut builtin = RangeCheckBuiltinRunner::new(8, 8, true);
         let mut segments = MemorySegmentManager::new();
-        let mut memory = Memory::new();
         builtin.initialize_segments(&mut segments);
-        assert_eq!(builtin.add_validation_rule(&mut memory), Ok(()));
+        assert_eq!(builtin.add_validation_rule(&mut segments.memory), Ok(()));
         for _ in 0..3 {
             segments.add();
         }
 
-        memory
+        segments
+            .memory
             .insert(
                 &MaybeRelocatable::from((0, 0)),
                 &MaybeRelocatable::from(Felt::new(45)),
             )
             .unwrap();
-        memory.validate_existing_memory().unwrap();
-        assert!(memory
+        segments.memory.validate_existing_memory().unwrap();
+        assert!(segments
+            .memory
             .validated_addresses
             .contains(&Relocatable::from((0, 0))));
     }

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -9,7 +9,6 @@ use std::{
     collections::{HashMap, HashSet},
     mem::swap,
 };
-
 pub struct ValidationRule(
     #[allow(clippy::type_complexity)]
     pub  Box<dyn Fn(&Memory, &Relocatable) -> Result<Vec<Relocatable>, MemoryError>>,

--- a/src/vm/vm_memory/memory_segments.rs
+++ b/src/vm/vm_memory/memory_segments.rs
@@ -259,7 +259,6 @@ impl Default for MemorySegmentManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::vm::vm_core::VirtualMachine;
     use crate::{relocatable, utils::test_utils::*};
     use assert_matches::assert_matches;
     use felt::Felt;
@@ -300,10 +299,10 @@ mod tests {
     #[test]
     fn add_two_temporary_segments() {
         let mut segments = MemorySegmentManager::new();
-        let mut _base = segments.add_temporary_segment();
-        _base = segments.add_temporary_segment();
+        segments.add_temporary_segment();
+        let base = segments.add_temporary_segment();
         assert_eq!(
-            _base,
+            base,
             Relocatable {
                 segment_index: -2,
                 offset: 0
@@ -725,7 +724,6 @@ mod tests {
     #[test]
     fn gen_arg_relocatable() {
         let mut memory_segment_manager = MemorySegmentManager::new();
-        let mut vm = vm!();
 
         assert_matches!(
             memory_segment_manager.gen_arg(&mayberelocatable!(0, 0)),
@@ -738,7 +736,6 @@ mod tests {
     #[test]
     fn gen_arg_bigint() {
         let mut memory_segment_manager = MemorySegmentManager::new();
-        let mut vm = vm!();
 
         assert_matches!(
             memory_segment_manager.gen_arg(&mayberelocatable!(1234)),
@@ -751,7 +748,6 @@ mod tests {
     #[test]
     fn gen_arg_vec() {
         let mut memory_segment_manager = MemorySegmentManager::new();
-        let mut vm = vm!();
 
         assert_matches!(
             memory_segment_manager.gen_arg(
@@ -775,7 +771,6 @@ mod tests {
     #[test]
     fn gen_arg_vec_relocatable() {
         let mut memory_segment_manager = MemorySegmentManager::new();
-        let mut vm = vm!();
 
         assert_matches!(
             memory_segment_manager.gen_arg(
@@ -795,7 +790,6 @@ mod tests {
     #[test]
     fn gen_arg_not_implemented() {
         let mut memory_segment_manager = MemorySegmentManager::new();
-        let mut vm = vm!();
 
         assert_matches!(
             memory_segment_manager.gen_arg(&""),
@@ -857,7 +851,6 @@ mod tests {
     #[test]
     fn gen_cairo_arg_array() {
         let mut memory_segment_manager = MemorySegmentManager::new();
-        let mut vm = vm!();
 
         assert_matches!(
             memory_segment_manager.gen_cairo_arg(

--- a/src/vm/vm_memory/memory_segments.rs
+++ b/src/vm/vm_memory/memory_segments.rs
@@ -255,7 +255,6 @@ impl Default for MemorySegmentManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::vm::vm_core::VirtualMachine;
     use crate::{relocatable, utils::test_utils::*};
     use felt::Felt;
     use num_traits::Num;
@@ -368,8 +367,7 @@ mod tests {
     }
     #[test]
     fn compute_effective_sizes_for_one_segment_memory() {
-        let mut segments = MemorySegmentManager::new();
-        let memory = memory![((0, 0), 1), ((0, 1), 1), ((0, 2), 1)];
+        let mut segments = segments![((0, 0), 1), ((0, 1), 1), ((0, 2), 1)];
         segments.compute_effective_sizes();
         assert_eq!(Some(vec![3]), segments.segment_used_sizes);
     }
@@ -391,16 +389,14 @@ mod tests {
 
     #[test]
     fn compute_effective_sizes_for_one_segment_memory_with_gaps() {
-        let mut segments = MemorySegmentManager::new();
-        let memory = memory![((0, 3), 1), ((0, 4), 1), ((0, 7), 1), ((0, 9), 1)];
+        let mut segments = segments![((0, 3), 1), ((0, 4), 1), ((0, 7), 1), ((0, 9), 1)];
         segments.compute_effective_sizes();
         assert_eq!(Some(vec![10]), segments.segment_used_sizes);
     }
 
     #[test]
     fn compute_effective_sizes_for_three_segment_memory() {
-        let mut segments = MemorySegmentManager::new();
-        let memory = memory![
+        let mut segments = segments![
             ((0, 0), 1),
             ((0, 1), 1),
             ((0, 2), 1),
@@ -417,8 +413,7 @@ mod tests {
 
     #[test]
     fn compute_effective_sizes_for_three_segment_memory_with_gaps() {
-        let mut segments = MemorySegmentManager::new();
-        let memory = memory![
+        let mut segments = segments![
             ((0, 2), 1),
             ((0, 5), 1),
             ((0, 7), 1),
@@ -433,8 +428,7 @@ mod tests {
 
     #[test]
     fn get_segment_used_size_after_computing_used() {
-        let mut segments = MemorySegmentManager::new();
-        let memory = memory![
+        let mut segments = segments![
             ((0, 2), 1),
             ((0, 5), 1),
             ((0, 7), 1),
@@ -722,8 +716,6 @@ mod tests {
     #[test]
     fn gen_arg_relocatable() {
         let mut memory_segment_manager = MemorySegmentManager::new();
-        let mut vm = vm!();
-
         assert_eq!(
             memory_segment_manager.gen_arg(&mayberelocatable!(0, 0)),
             Ok(mayberelocatable!(0, 0)),
@@ -735,8 +727,6 @@ mod tests {
     #[test]
     fn gen_arg_bigint() {
         let mut memory_segment_manager = MemorySegmentManager::new();
-        let mut vm = vm!();
-
         assert_eq!(
             memory_segment_manager.gen_arg(&mayberelocatable!(1234)),
             Ok(mayberelocatable!(1234)),
@@ -748,8 +738,6 @@ mod tests {
     #[test]
     fn gen_arg_vec() {
         let mut memory_segment_manager = MemorySegmentManager::new();
-        let mut vm = vm!();
-
         assert_eq!(
             memory_segment_manager.gen_arg(&vec![
                 mayberelocatable!(0),
@@ -770,8 +758,6 @@ mod tests {
     #[test]
     fn gen_arg_vec_relocatable() {
         let mut memory_segment_manager = MemorySegmentManager::new();
-        let mut vm = vm!();
-
         assert_eq!(
             memory_segment_manager.gen_arg(&vec![
                 MaybeRelocatable::from((0, 0)),
@@ -788,8 +774,6 @@ mod tests {
     #[test]
     fn gen_arg_not_implemented() {
         let mut memory_segment_manager = MemorySegmentManager::new();
-        let mut vm = vm!();
-
         assert_eq!(
             memory_segment_manager.gen_arg(&""),
             Err(VirtualMachineError::NotImplemented),
@@ -840,7 +824,6 @@ mod tests {
     #[test]
     fn gen_cairo_arg_single() {
         let mut memory_segment_manager = MemorySegmentManager::new();
-        let mut vm = vm!();
 
         assert_eq!(
             memory_segment_manager.gen_cairo_arg(&mayberelocatable!(1234).into()),
@@ -851,8 +834,6 @@ mod tests {
     #[test]
     fn gen_cairo_arg_array() {
         let mut memory_segment_manager = MemorySegmentManager::new();
-        let mut vm = vm!();
-
         assert_eq!(
             memory_segment_manager.gen_cairo_arg(
                 &vec![
@@ -874,7 +855,6 @@ mod tests {
     #[test]
     fn gen_cairo_arg_composed() {
         let mut memory_segment_manager = MemorySegmentManager::new();
-        let mut vm = vm!();
         let cairo_args = CairoArg::Composed(vec![
             CairoArg::Array(vec![
                 mayberelocatable!(0),

--- a/src/vm/vm_memory/memory_segments.rs
+++ b/src/vm/vm_memory/memory_segments.rs
@@ -18,7 +18,7 @@ pub struct MemorySegmentManager {
     pub num_temp_segments: usize,
     pub segment_sizes: HashMap<usize, usize>,
     pub segment_used_sizes: Option<Vec<usize>>,
-    pub memory: Memory,
+    pub(crate) memory: Memory,
     // A map from segment index to a list of pairs (offset, page_id) that constitute the
     // public memory. Note that the offset is absolute (not based on the page_id).
     pub public_memory_offsets: HashMap<usize, Vec<(usize, usize)>>,

--- a/src/vm/vm_memory/memory_segments.rs
+++ b/src/vm/vm_memory/memory_segments.rs
@@ -74,7 +74,7 @@ impl MemorySegmentManager {
         }
     }
 
-    /// Calculates the size (number of non-none elements) of each memory segment.
+    /// Calculates the size of each memory segment.
     pub fn compute_effective_sizes(&mut self) -> &Vec<usize> {
         self.segment_used_sizes
             .get_or_insert_with(|| self.memory.data.iter().map(Vec::len).collect())


### PR DESCRIPTION
This PR aims to reduce the complexity of the VM's memory. and also enforce proper usage (as the memory and its segment manager are now a "unified" entity)
- Remove `memory` field from `VirtualMachine`
- Add `memory` field to `MemorySegmentManager`
- Remove `Memory` argument from methods where `MemorySegmentManager` is also an argument
- Add test macro `segments` (an extension of the `memory` macro
