### PR TITLE
tests(felt): add tests for num_trait::Zero trait

### DIFF
--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -1071,7 +1071,7 @@ mod test {
     fn is_zero() {
         let felt_zero = Felt::zero();
         let felt_non_zero = Felt::new(3);
-        assert_eq!(true, felt_zero.is_zero());
-        assert_eq!(false, felt_non_zero.is_zero())
+        assert!(felt_zero.is_zero());
+        assert!(!felt_non_zero.is_zero())
     }
 }

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -1059,4 +1059,19 @@ mod test {
         let felt_min_value = Felt::min_value().to_biguint();
         assert_eq!(zero, felt_min_value)
     }
+
+    #[test]
+    fn zero_value() {
+        let zero = BigUint::zero();
+        let felt_zero = Felt::zero().to_biguint();
+        assert_eq!(zero, felt_zero)
+    }
+
+    #[test]
+    fn is_zero() {
+        let felt_zero = Felt::zero();
+        let felt_non_zero = Felt::new(3);
+        assert_eq!(true, felt_zero.is_zero());
+        assert_eq!(false, felt_non_zero.is_zero())
+    }
 }


### PR DESCRIPTION
# add tests for num_trait::Zero traits

This PR takes a bit of https://github.com/lambdaclass/cairo-rs/issues/823 in adding tests for the num_trait::Zero trait implementation for Felts : 
* `zero()`
* `is_zero()`

It only affects the `felt` library.

## Checklist
- [x] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
- [ ] Documentation has been added/updated.
