### PR TITLE
Fix bug in compare_vm_state script

### DIFF
--- a/tests/compare_vm_state.sh
+++ b/tests/compare_vm_state.sh
@@ -20,6 +20,11 @@ for i in $@; do
     esac
 done
 
+files=$(ls $tests_path)
+if [[ $? != 0 ]]; then
+    exit $?
+fi
+
 for file in $(ls $tests_path | grep .cairo$ | sed -E 's/\.cairo$//'); do
     path_file="$tests_path/$file"
 


### PR DESCRIPTION
# TITLE

## Description

`compare_vm_state.sh` looks for files to compare in cairo_programs. Previously, if the directory wasn't found, the script would continue, comparing 0 files and exiting successfully, now it properly fails if `ls cairo_programs` fails

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
