### PR TITLE
feat: integrate CodSpeed

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Install Rust 1.66.1
       uses: actions-rs/toolchain@v1

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,0 +1,31 @@
+name: codspeed
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ '*' ]
+
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Install Rust 1.66.1
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: 1.66.1
+          override: true
+    - name: Cache Rust installation
+      uses: Swatinem/rust-cache@v2
+    - name: Install cargo-codspeed (with cache)
+      uses: baptiste0928/cargo-install@v1
+      with:
+        crate: cargo-codspeed
+    - uses: actions/checkout@v3
+    - name: Build benchmarks
+      run: cargo codspeed build criterion_benchmark
+    - uses: CodSpeedHQ/action@v1
+      name: Run benchmarks
+      with:
+        run: cargo codspeed run criterion_benchmark

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "ark-ff"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,7 +194,8 @@ dependencies = [
  "bincode",
  "cairo-felt",
  "clap 3.2.23",
- "criterion",
+ "codspeed-criterion-compat",
+ "criterion 0.3.6",
  "generic-array",
  "hex",
  "iai",
@@ -236,6 +243,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24f638c70e8c5753795cc9a8c07c44da91554a09e4cf11a7326e8161b0a3c45e"
 dependencies = [
  "envmnt",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -289,6 +323,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "codspeed"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "631092c401f38ee240a2d4f3752f863b4db9d0a725b9c9518159f51027c9cc92"
+dependencies = [
+ "colored",
+ "libc",
+]
+
+[[package]]
+name = "codspeed-criterion-compat"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1824ad368c818abb6090f9f5a460bec847fcfa00a4962f7df951aa3ea24c4449"
+dependencies = [
+ "codspeed",
+ "colored",
+ "criterion 0.4.0",
+]
+
+[[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,7 +372,7 @@ dependencies = [
  "atty",
  "cast",
  "clap 2.34.0",
- "criterion-plot",
+ "criterion-plot 0.4.5",
  "csv",
  "itertools",
  "lazy_static",
@@ -324,10 +390,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
+dependencies = [
+ "anes",
+ "atty",
+ "cast",
+ "ciborium",
+ "clap 3.2.23",
+ "criterion-plot 0.5.0",
+ "itertools",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
 name = "criterion-plot"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ felt = { package = "cairo-felt", path = "./felt", version = "0.1.0" }
 [dev-dependencies]
 iai = "0.1"
 assert_matches = "1.5.0"
+codspeed-criterion-compat = "1.0.1"
 
 [dev-dependencies.rusty-hook]
 version = "0.11"

--- a/bench/criterion_benchmark.rs
+++ b/bench/criterion_benchmark.rs
@@ -4,7 +4,7 @@ use cairo_vm::{
     cairo_run,
     hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor,
 };
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use codspeed_criterion_compat::{black_box, criterion_group, criterion_main, Criterion};
 
 const BENCH_NAMES: &[&str] = &[
     "compare_arrays_200000",


### PR DESCRIPTION
# Integrate CodSpeed

## Description

This adds the integration with CodSpeed to report performance data from the criterion benches continuously. Thanks, @Eikix for the idea 😀.

Instead of using criterion.rs directly, I swap it with the compatibility crate for CodSpeed, if you're interested in more details about that, there are some more details [here](https://docs.codspeed.io/benchmarks/rust).
I also added a new GitHub Action workflow that will run the instrumented benches and upload the results to CodSpeed. This will report performance changes on any pull requests once merged.

Thrilled to have your feedback on the tool since you're relying a lot on benchmarks from what I saw !
