### PR TITLE
Check error types in vm_core.rs + simplify code

### DIFF
--- a/src/types/relocatable.rs
+++ b/src/types/relocatable.rs
@@ -7,7 +7,7 @@ use num_traits::{FromPrimitive, ToPrimitive, Zero};
 use serde::{Deserialize, Serialize};
 use std::{
     fmt::{self, Display},
-    ops::Add,
+    ops::{Add, AddAssign},
 };
 
 #[derive(Eq, Hash, PartialEq, PartialOrd, Clone, Copy, Debug, Serialize, Deserialize)]
@@ -92,6 +92,12 @@ impl Add<usize> for Relocatable {
     type Output = Relocatable;
     fn add(self, other: usize) -> Self {
         relocatable!(self.segment_index, self.offset + other)
+    }
+}
+
+impl AddAssign<usize> for Relocatable {
+    fn add_assign(&mut self, rhs: usize) {
+        self.offset += rhs
     }
 }
 
@@ -824,5 +830,12 @@ mod tests {
             format!("{}", MaybeRelocatable::from(Felt::new(6))),
             String::from("6")
         )
+    }
+
+    #[test]
+    fn relocatable_add_assign_usize() {
+        let mut addr = Relocatable::from((1, 0));
+        addr += 1;
+        assert_eq!(addr, Relocatable::from((1, 1)))
     }
 }

--- a/src/vm/errors/memory_errors.rs
+++ b/src/vm/errors/memory_errors.rs
@@ -75,4 +75,6 @@ pub enum MemoryError {
     MsgNonInt(Relocatable),
     #[error("Failed to convert String: {0} to FieldElement")]
     FailedStringToFieldElementConversion(String),
+    #[error("Failed to fetch {0} return values, ap is only {1}")]
+    FailedToGetReturnValues(usize, Relocatable),
 }

--- a/src/vm/errors/vm_errors.rs
+++ b/src/vm/errors/vm_errors.rs
@@ -32,6 +32,12 @@ pub enum VirtualMachineError {
     UnconstrainedResJumpRel,
     #[error("Res.UNCONSTRAINED cannot be used with Opcode.ASSERT_EQ")]
     UnconstrainedResAssertEq,
+    #[error("An integer value as Res cannot be used with PcUpdate.JUMP_REL")]
+    JumpRelNotInt,
+    #[error(
+        "Failed to compute Res.MUL: Could not complete computation of non pure values {0} * {1}"
+    )]
+    ComputeResRelocatableMul(MaybeRelocatable, MaybeRelocatable),
     #[error("Couldn't compute operand {0} at address {1}")]
     FailedToComputeOperands(String, Relocatable),
     #[error("An ASSERT_EQ instruction failed: {0} != {1}.")]
@@ -42,8 +48,6 @@ pub enum VirtualMachineError {
     CantWriteReturnFp(MaybeRelocatable, MaybeRelocatable),
     #[error("Couldn't get or load dst")]
     NoDst,
-    #[error("Pure Value Error")]
-    PureValue,
     #[error("Invalid res value: {0}")]
     InvalidRes(i64),
     #[error("Invalid opcode value: {0}")]

--- a/src/vm/errors/vm_errors.rs
+++ b/src/vm/errors/vm_errors.rs
@@ -144,6 +144,8 @@ pub enum VirtualMachineError {
     NegBuiltinBase,
     #[error("Security Error: Invalid Memory Value: temporary address not relocated: {0}")]
     InvalidMemoryValueTemporaryAddress(Relocatable),
+    #[error("accessed_addresses is None.")]
+    MissingAccessedAddresses,
     #[error(transparent)]
     Other(Box<dyn Error>),
 }

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 use felt::Felt;
 use num_traits::{ToPrimitive, Zero};
-use std::{any::Any, borrow::Cow, collections::HashMap, ops::Add};
+use std::{any::Any, borrow::Cow, collections::HashMap};
 
 const MAX_TRACEBACK_ENTRIES: u32 = 20;
 
@@ -485,9 +485,7 @@ impl VirtualMachine {
         if !self.skip_instruction_execution {
             self.run_instruction(instruction)?;
         } else {
-            let pc = &self.get_pc().clone();
-            let size = instruction.size();
-            self.set_pc(pc.add(size));
+            self.run_context.pc += instruction.size();
             self.skip_instruction_execution = false;
         }
         Ok(())

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -200,7 +200,6 @@ impl VirtualMachine {
             PcUpdate::JumpRel => match operands.res.clone() {
                 Some(res) => match res {
                     MaybeRelocatable::Int(num_res) => self.run_context.pc.add_int(&num_res)?,
-
                     _ => return Err(VirtualMachineError::JumpRelNotInt),
                 },
                 None => return Err(VirtualMachineError::UnconstrainedResJumpRel),
@@ -260,19 +259,16 @@ impl VirtualMachine {
                         }
                     }
                     Res::Mul => {
-                        if let (Some(dst_addr), Some(op1_addr)) = (dst, op1) {
-                            if let (
-                                MaybeRelocatable::Int(num_dst),
-                                MaybeRelocatable::Int(ref num_op1_ref),
-                            ) = (dst_addr, op1_addr)
-                            {
-                                let num_op1 = Clone::clone(num_op1_ref);
-                                if num_op1 != Felt::zero() {
-                                    return Ok((
-                                        Some(MaybeRelocatable::Int(num_dst / num_op1)),
-                                        Some(dst_addr.clone()),
-                                    ));
-                                }
+                        if let (
+                            Some(MaybeRelocatable::Int(num_dst)),
+                            Some(MaybeRelocatable::Int(num_op1)),
+                        ) = (dst, op1)
+                        {
+                            if !num_op1.is_zero() {
+                                return Ok((
+                                    Some(MaybeRelocatable::Int(num_dst / num_op1)),
+                                    dst.map(Clone::clone),
+                                ));
                             }
                         }
                     }

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -146,12 +146,7 @@ impl VirtualMachine {
         };
 
         let imm_addr = &self.run_context.pc + 1_i32;
-
-        if let Ok(optional_imm) = self.memory.get(&imm_addr) {
-            Ok((encoding_ref, optional_imm))
-        } else {
-            Err(VirtualMachineError::InvalidInstructionEncoding)
-        }
+        Ok((encoding_ref, self.memory.get(&imm_addr).ok().flatten()))
     }
 
     fn update_fp(


### PR DESCRIPTION
- Revise the errors returned and add the necessary variants/improve the existing ones
- Simplify some code
- Fix `is_zero` function -> its supposed to check if the offset is >= 0 in the case of relocatables, which is an impossible case. The fn no longer returns a result
- Implement `AddAssign` for `Relocatable`