### PR TITLE
Improve error types for builtin runners (Part 1)

### DIFF
--- a/src/hint_processor/builtin_hint_processor/signature.rs
+++ b/src/hint_processor/builtin_hint_processor/signature.rs
@@ -31,6 +31,7 @@ pub fn verify_ecdsa_signature(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vm::runners::builtin_runner::SIGNATURE_BUILTIN_NAME;
     use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
     use crate::{
         any_box,
@@ -59,7 +60,7 @@ mod tests {
     fn verify_ecdsa_signature_valid() {
         let mut vm = vm!();
         vm.builtin_runners = vec![(
-            "ecdsa".to_string(),
+            SIGNATURE_BUILTIN_NAME.to_string(),
             SignatureBuiltinRunner::new(&EcdsaInstanceDef::default(), true).into(),
         )];
         vm.segments = segments![

--- a/src/hint_processor/builtin_hint_processor/signature.rs
+++ b/src/hint_processor/builtin_hint_processor/signature.rs
@@ -60,7 +60,7 @@ mod tests {
     fn verify_ecdsa_signature_valid() {
         let mut vm = vm!();
         vm.builtin_runners = vec![(
-            SIGNATURE_BUILTIN_NAME.to_string(),
+            SIGNATURE_BUILTIN_NAME,
             SignatureBuiltinRunner::new(&EcdsaInstanceDef::default(), true).into(),
         )];
         vm.segments = segments![

--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -4,6 +4,10 @@ use crate::{
         errors::program_errors::ProgramError, instruction::Register, program::Program,
         relocatable::MaybeRelocatable,
     },
+    vm::runners::builtin_runner::{
+        BITWISE_BUILTIN_NAME, EC_OP_BUILTIN_NAME, HASH_BUILTIN_NAME, KECCAK_BUILTIN_NAME,
+        OUTPUT_BUILTIN_NAME, RANGE_CHECK_BUILTIN_NAME, SIGNATURE_BUILTIN_NAME,
+    },
 };
 use felt::{Felt, PRIME_STR};
 use num_traits::Num;
@@ -11,10 +15,37 @@ use serde::{de, de::MapAccess, de::SeqAccess, Deserialize, Deserializer, Seriali
 use serde_json::Number;
 use std::{collections::HashMap, fmt, io::Read};
 
+// This enum is used to deserialize program builtins into &str and catch non-valid names
+#[derive(Deserialize, Debug, PartialEq)]
+#[allow(non_camel_case_types)]
+pub enum BuiltinName {
+    output,
+    range_check,
+    pedersen,
+    ecdsa,
+    keccak,
+    bitwise,
+    ec_op,
+}
+
+impl BuiltinName {
+    pub(crate) fn name(&self) -> &'static str {
+        match self {
+            BuiltinName::output => OUTPUT_BUILTIN_NAME,
+            BuiltinName::range_check => RANGE_CHECK_BUILTIN_NAME,
+            BuiltinName::pedersen => HASH_BUILTIN_NAME,
+            BuiltinName::ecdsa => SIGNATURE_BUILTIN_NAME,
+            BuiltinName::keccak => KECCAK_BUILTIN_NAME,
+            BuiltinName::bitwise => BITWISE_BUILTIN_NAME,
+            BuiltinName::ec_op => EC_OP_BUILTIN_NAME,
+        }
+    }
+}
+
 #[derive(Deserialize, Debug)]
 pub struct ProgramJson {
     pub prime: String,
-    pub builtins: Vec<String>,
+    pub builtins: Vec<BuiltinName>,
     #[serde(deserialize_with = "deserialize_array_of_bigint_hex")]
     pub data: Vec<MaybeRelocatable>,
     pub identifiers: HashMap<String, Identifier>,
@@ -334,7 +365,11 @@ pub fn deserialize_program(
     };
 
     Ok(Program {
-        builtins: program_json.builtins,
+        builtins: program_json
+            .builtins
+            .iter()
+            .map(BuiltinName::name)
+            .collect(),
         prime: PRIME_STR.to_string(),
         data: program_json.data,
         constants: {
@@ -370,8 +405,6 @@ pub fn deserialize_program(
 
 #[cfg(test)]
 mod tests {
-    use crate::vm::runners::builtin_runner::{OUTPUT_BUILTIN_NAME, RANGE_CHECK_BUILTIN_NAME};
-
     use super::*;
     use assert_matches::assert_matches;
     use felt::felt_str;
@@ -528,8 +561,6 @@ mod tests {
         // ProgramJson instance for the json with an even length encoded hex.
         let program_json: ProgramJson = serde_json::from_str(valid_json).unwrap();
 
-        let builtins: Vec<String> = Vec::new();
-
         let data: Vec<MaybeRelocatable> = vec![
             MaybeRelocatable::Int(Felt::new(5189976364521848832_i64)),
             MaybeRelocatable::Int(Felt::new(1000_i64)),
@@ -636,7 +667,7 @@ mod tests {
             program_json.prime,
             "0x800000000000011000000000000000000000000000000000000000000000001"
         );
-        assert_eq!(program_json.builtins, builtins);
+        assert!(program_json.builtins.is_empty());
         assert_eq!(program_json.data, data);
         assert_eq!(program_json.identifiers["__main__.main"].pc, Some(0));
         assert_eq!(program_json.hints, hints);
@@ -650,13 +681,12 @@ mod tests {
         let mut reader = BufReader::new(file);
 
         let program_json: ProgramJson = serde_json::from_reader(&mut reader).unwrap();
-        let builtins: Vec<String> = Vec::new();
 
         assert_eq!(
             program_json.prime,
             "0x800000000000011000000000000000000000000000000000000000000000001"
         );
-        assert_eq!(program_json.builtins, builtins);
+        assert!(program_json.builtins.is_empty());
         assert_eq!(program_json.data.len(), 6);
         assert_eq!(program_json.identifiers["__main__.main"].pc, Some(0));
     }
@@ -668,10 +698,7 @@ mod tests {
         let mut reader = BufReader::new(file);
 
         let program_json: ProgramJson = serde_json::from_reader(&mut reader).unwrap();
-        let builtins: Vec<String> = vec![
-            String::from(OUTPUT_BUILTIN_NAME),
-            String::from(RANGE_CHECK_BUILTIN_NAME),
-        ];
+        let builtins: Vec<BuiltinName> = vec![BuiltinName::output, BuiltinName::range_check];
 
         assert_eq!(
             program_json.prime,

--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -370,6 +370,8 @@ pub fn deserialize_program(
 
 #[cfg(test)]
 mod tests {
+    use crate::vm::runners::builtin_runner::{OUTPUT_BUILTIN_NAME, RANGE_CHECK_BUILTIN_NAME};
+
     use super::*;
     use assert_matches::assert_matches;
     use felt::felt_str;
@@ -666,7 +668,10 @@ mod tests {
         let mut reader = BufReader::new(file);
 
         let program_json: ProgramJson = serde_json::from_reader(&mut reader).unwrap();
-        let builtins: Vec<String> = vec![String::from("output"), String::from("range_check")];
+        let builtins: Vec<String> = vec![
+            String::from(OUTPUT_BUILTIN_NAME),
+            String::from(RANGE_CHECK_BUILTIN_NAME),
+        ];
 
         assert_eq!(
             program_json.prime,

--- a/src/types/instance_definitions/keccak_instance_def.rs
+++ b/src/types/instance_definitions/keccak_instance_def.rs
@@ -25,7 +25,7 @@ impl KeccakInstanceDef {
         }
     }
 
-    pub(crate) fn _cells_per_builtin(&self) -> u32 {
+    pub(crate) fn cells_per_builtin(&self) -> u32 {
         2 * self._state_rep.len() as u32
     }
 
@@ -47,7 +47,7 @@ mod tests {
     #[test]
     fn get_cells_per_builtin() {
         let builtin_instance = KeccakInstanceDef::default();
-        assert_eq!(builtin_instance._cells_per_builtin(), 16);
+        assert_eq!(builtin_instance.cells_per_builtin(), 16);
     }
 
     #[test]

--- a/src/types/program.rs
+++ b/src/types/program.rs
@@ -6,16 +6,16 @@ use crate::{
     types::{errors::program_errors::ProgramError, relocatable::MaybeRelocatable},
 };
 use felt::{Felt, PRIME_STR};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use std::{
     fs::File,
     io::{BufReader, Read},
     {collections::HashMap, path::Path},
 };
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct Program {
-    pub builtins: Vec<String>,
+    pub builtins: Vec<&'static str>,
     pub prime: String,
     pub data: Vec<MaybeRelocatable>,
     pub constants: HashMap<String, Felt>,
@@ -33,7 +33,7 @@ pub struct Program {
 impl Program {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        builtins: Vec<String>,
+        builtins: Vec<&'static str>,
         prime: String,
         data: Vec<MaybeRelocatable>,
         main: Option<usize>,
@@ -121,8 +121,7 @@ mod tests {
             references: Vec::new(),
         };
 
-        let builtins: Vec<String> = Vec::new();
-        let _r: MaybeRelocatable = mayberelocatable!(33);
+        let builtins: Vec<&'static str> = Vec::new();
         let data: Vec<MaybeRelocatable> = vec![
             mayberelocatable!(5189976364521848832),
             mayberelocatable!(1000),
@@ -157,7 +156,7 @@ mod tests {
             references: Vec::new(),
         };
 
-        let builtins: Vec<String> = Vec::new();
+        let builtins: Vec<&'static str> = Vec::new();
 
         let data: Vec<MaybeRelocatable> = vec![
             mayberelocatable!(5189976364521848832),
@@ -226,7 +225,7 @@ mod tests {
             references: Vec::new(),
         };
 
-        let builtins: Vec<String> = Vec::new();
+        let builtins: Vec<&'static str> = Vec::new();
 
         let data: Vec<MaybeRelocatable> = vec![
             mayberelocatable!(5189976364521848832),
@@ -286,7 +285,7 @@ mod tests {
         )
         .expect("Failed to deserialize program");
 
-        let builtins: Vec<String> = Vec::new();
+        let builtins: Vec<&'static str> = Vec::new();
         let data: Vec<MaybeRelocatable> = vec![
             mayberelocatable!(5189976364521848832),
             mayberelocatable!(1000),
@@ -370,7 +369,7 @@ mod tests {
         )
         .expect("Failed to deserialize program");
 
-        let builtins: Vec<String> = Vec::new();
+        let builtins: Vec<&'static str> = Vec::new();
 
         let error_message_attributes: Vec<Attribute> = vec![Attribute {
             name: String::from("error_message"),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -207,7 +207,7 @@ pub mod test_utils {
         () => {{
             let mut vm = VirtualMachine::new(false);
             vm.builtin_runners = vec![(
-                "range_check".to_string(),
+                "range_check",
                 RangeCheckBuiltinRunner::new(8, 8, true).into(),
             )];
             vm
@@ -239,7 +239,7 @@ pub mod test_utils {
         //Program with builtins
         ( $( $builtin_name: expr ),* ) => {
             Program {
-                builtins: vec![$( $builtin_name.to_string() ),*],
+                builtins: vec![$( $builtin_name ),*],
                 prime: "0x800000000000011000000000000000000000000000000000000000000000001".to_string(),
                 data: Vec::new(),
                 constants: HashMap::new(),
@@ -886,7 +886,7 @@ mod test {
     #[test]
     fn program_macro_with_builtin() {
         let program = Program {
-            builtins: vec![RANGE_CHECK_BUILTIN_NAME.to_string()],
+            builtins: vec![RANGE_CHECK_BUILTIN_NAME],
             prime: "0x800000000000011000000000000000000000000000000000000000000000001".to_string(),
             data: Vec::new(),
             constants: HashMap::new(),
@@ -908,7 +908,7 @@ mod test {
     #[test]
     fn program_macro_custom_definition() {
         let program = Program {
-            builtins: vec![RANGE_CHECK_BUILTIN_NAME.to_string()],
+            builtins: vec![RANGE_CHECK_BUILTIN_NAME],
             prime: "0x800000000000011000000000000000000000000000000000000000000000001".to_string(),
             data: Vec::new(),
             constants: HashMap::new(),
@@ -926,10 +926,7 @@ mod test {
 
         assert_eq!(
             program,
-            program!(
-                builtins = vec![RANGE_CHECK_BUILTIN_NAME.to_string()],
-                main = Some(2),
-            )
+            program!(builtins = vec![RANGE_CHECK_BUILTIN_NAME], main = Some(2),)
         )
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -528,8 +528,8 @@ mod test {
         types::{exec_scope::ExecutionScopes, program::Program, relocatable::MaybeRelocatable},
         utils::test_utils::*,
         vm::{
-            errors::memory_errors::MemoryError, trace::trace_entry::TraceEntry,
-            vm_core::VirtualMachine, vm_memory::memory::Memory,
+            errors::memory_errors::MemoryError, runners::builtin_runner::RANGE_CHECK_BUILTIN_NAME,
+            trace::trace_entry::TraceEntry, vm_core::VirtualMachine, vm_memory::memory::Memory,
         },
     };
     use felt::Felt;
@@ -886,7 +886,7 @@ mod test {
     #[test]
     fn program_macro_with_builtin() {
         let program = Program {
-            builtins: vec!["range_check".to_string()],
+            builtins: vec![RANGE_CHECK_BUILTIN_NAME.to_string()],
             prime: "0x800000000000011000000000000000000000000000000000000000000000001".to_string(),
             data: Vec::new(),
             constants: HashMap::new(),
@@ -902,13 +902,13 @@ mod test {
             instruction_locations: None,
         };
 
-        assert_eq!(program, program!["range_check"])
+        assert_eq!(program, program![RANGE_CHECK_BUILTIN_NAME])
     }
 
     #[test]
     fn program_macro_custom_definition() {
         let program = Program {
-            builtins: vec!["range_check".to_string()],
+            builtins: vec![RANGE_CHECK_BUILTIN_NAME.to_string()],
             prime: "0x800000000000011000000000000000000000000000000000000000000000001".to_string(),
             data: Vec::new(),
             constants: HashMap::new(),
@@ -926,7 +926,10 @@ mod test {
 
         assert_eq!(
             program,
-            program!(builtins = vec!["range_check".to_string()], main = Some(2),)
+            program!(
+                builtins = vec![RANGE_CHECK_BUILTIN_NAME.to_string()],
+                main = Some(2),
+            )
         )
     }
 }

--- a/src/vm/errors/memory_errors.rs
+++ b/src/vm/errors/memory_errors.rs
@@ -43,12 +43,6 @@ pub enum MemoryError {
     GetRangeMemoryGap,
     #[error("Error calculating builtin memory units")]
     ErrorCalculatingMemoryUnits,
-    #[error("Number of steps must be at least {0} for the {1} builtin.")]
-    InsufficientAllocatedCellsMinStepNotReached(usize, &'static str),
-    #[error("Failed to get allocated size for builtin {0}, current vm step {1} is not divisible by builtin ratio {2")]
-    CurrentStepNotDivisibleByBuiltinRatio(&'static str, usize, usize),
-    #[error("The {0} builtin used {1} cells but the capacity is {2}.")]
-    InsufficientAllocatedCells(&'static str, usize, usize),
     #[error("Missing memory cells for builtin {0}")]
     MissingMemoryCells(&'static str),
     #[error("Missing memory cells for builtin {0}: {1:?}")]
@@ -79,4 +73,22 @@ pub enum MemoryError {
     MsgNonInt(Relocatable),
     #[error("Failed to convert String: {0} to FieldElement")]
     FailedStringToFieldElementConversion(String),
+    #[error(transparent)]
+    InsufficientAllocatedCells(#[from] InsufficientAllocatedCellsError),
+}
+
+#[derive(Debug, PartialEq, Eq, Error)]
+pub enum InsufficientAllocatedCellsError {
+    #[error("Number of steps must be at least {0} for the {1} builtin.")]
+    MinStepNotReached(usize, &'static str),
+    #[error("Failed to get allocated size for builtin {0}, current vm step {1} is not divisible by builtin ratio {2}")]
+    CurrentStepNotDivisibleByBuiltinRatio(&'static str, usize, usize),
+    #[error("The {0} builtin used {1} cells but the capacity is {2}.")]
+    BuiltinCells(&'static str, usize, usize),
+    #[error("There are only {0} cells to fill the range checks holes, but potentially {1} are required.")]
+    RangeCheckUnits(usize, usize),
+    #[error("There are only {0} cells to fill the diluted check holes, but potentially {1} are required.")]
+    DilutedCells(usize, usize),
+    #[error("There are only {0} cells to fill the memory address holes, but {1} are required.")]
+    MemoryAddresses(u32, usize),
 }

--- a/src/vm/errors/memory_errors.rs
+++ b/src/vm/errors/memory_errors.rs
@@ -43,8 +43,12 @@ pub enum MemoryError {
     GetRangeMemoryGap,
     #[error("Error calculating builtin memory units")]
     ErrorCalculatingMemoryUnits,
-    #[error("Number of steps is insufficient in the builtin.")]
-    InsufficientAllocatedCells,
+    #[error("Number of steps must be at least {0} for the {1} builtin.")]
+    InsufficientAllocatedCellsMinStepNotReached(usize, &'static str),
+    #[error("Failed to get allocated size for builtin {0}, current vm step {1} is not divisible by builtin ratio {2")]
+    CurrentStepNotDivisibleByBuiltinRatio(&'static str, usize, usize),
+    #[error("The {0} builtin used {1} cells but the capacity is {2}.")]
+    InsufficientAllocatedCells(&'static str, usize, usize),
     #[error("Missing memory cells for builtin {0}")]
     MissingMemoryCells(&'static str),
     #[error("Missing memory cells for builtin {0}: {1:?}")]

--- a/src/vm/errors/runner_errors.rs
+++ b/src/vm/errors/runner_errors.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use super::memory_errors::MemoryError;
-use crate::types::relocatable::MaybeRelocatable;
+use crate::types::relocatable::{MaybeRelocatable, Relocatable};
 use felt::Felt;
 use thiserror::Error;
 
@@ -71,10 +71,12 @@ pub enum RunnerError {
     FinalizeSegements(MemoryError),
     #[error("finalize_segments called but proof_mode is not enabled")]
     FinalizeSegmentsNoProofMode,
-    #[error("Final stack error")]
-    FinalStack,
-    #[error("Invalid stop pointer for {0} ")]
-    InvalidStopPointer(String),
+    #[error("Invalid stop pointer for {0}: Stop pointer has value {1} but builtin segment is {2}")]
+    InvalidStopPointerIndex(&'static str, Relocatable, isize),
+    #[error("Invalid stop pointer for {0}. Expected: {1}, found: {2}")]
+    InvalidStopPointer(&'static str, Relocatable, Relocatable),
+    #[error("No stop pointer found for builtin {0}")]
+    NoStopPointer(&'static str),
     #[error("Running in proof-mode but no __start__ label found, try compiling with proof-mode")]
     NoProgramStart,
     #[error("Running in proof-mode but no __end__ label found, try compiling with proof-mode")]

--- a/src/vm/errors/runner_errors.rs
+++ b/src/vm/errors/runner_errors.rs
@@ -54,7 +54,7 @@ pub enum RunnerError {
     #[error("EcOpBuiltin: point {0:?} is not on the curve")]
     PointNotOnCurve((Felt, Felt)),
     #[error("Builtin(s) {0:?} not present in layout {1}")]
-    NoBuiltinForInstance(HashSet<String>, String),
+    NoBuiltinForInstance(HashSet<&'static str>, String),
     #[error("Invalid layout {0}")]
     InvalidLayoutName(String),
     #[error("Run has already ended.")]

--- a/src/vm/errors/runner_errors.rs
+++ b/src/vm/errors/runner_errors.rs
@@ -93,7 +93,7 @@ pub enum RunnerError {
     CouldntParsePrime,
     #[error("Could not convert vec with Maybe Relocatables into u64 array")]
     MaybeRelocVecToU64ArrayError,
-    #[error("Expected Maybe Relocatable with Int value but get one with Relocatable")]
+    #[error("Expected Integer value, got Relocatable instead")]
     FoundNonInt,
     #[error("{0} is not divisible by {1}")]
     SafeDivFailUsize(usize, usize),
@@ -101,4 +101,6 @@ pub enum RunnerError {
     MemoryError(#[from] MemoryError),
     #[error("Negative builtin base")]
     NegBuiltinBase,
+    #[error("There are only {0} cells to fill the range checks holes, but potentially {1} are required.")]
+    InsufficientRangeCheckUnits(usize, usize),
 }

--- a/src/vm/errors/runner_errors.rs
+++ b/src/vm/errors/runner_errors.rs
@@ -101,6 +101,4 @@ pub enum RunnerError {
     MemoryError(#[from] MemoryError),
     #[error("Negative builtin base")]
     NegBuiltinBase,
-    #[error("There are only {0} cells to fill the range checks holes, but potentially {1} are required.")]
-    InsufficientRangeCheckUnits(usize, usize),
 }

--- a/src/vm/errors/vm_errors.rs
+++ b/src/vm/errors/vm_errors.rs
@@ -57,7 +57,7 @@ pub enum VirtualMachineError {
     #[error("Can only subtract two relocatable values of the same segment")]
     DiffIndexSub,
     #[error("Inconsistent auto-deduction for builtin {0}, expected {1}, got {2:?}")]
-    InconsistentAutoDeduction(String, MaybeRelocatable, Option<MaybeRelocatable>),
+    InconsistentAutoDeduction(&'static str, MaybeRelocatable, Option<MaybeRelocatable>),
     #[error(transparent)]
     RunnerError(#[from] RunnerError),
     #[error("Invalid hint encoding at pc: {0}")]

--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 use num_integer::div_ceil;
 
-pub(crate) const NAME: &'static str = "bitwise";
+pub(crate) const NAME: &str = "bitwise";
 
 #[derive(Debug, Clone)]
 pub struct BitwiseBuiltinRunner {

--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -222,6 +222,7 @@ impl BitwiseBuiltinRunner {
         segments: &MemorySegmentManager,
     ) -> Result<usize, MemoryError> {
         let used_cells = self.get_used_cells(segments)?;
+        dbg!(div_ceil(used_cells, self.cells_per_instance as usize));
         Ok(div_ceil(used_cells, self.cells_per_instance as usize))
     }
 }
@@ -294,7 +295,7 @@ mod tests {
             ((2, 1), (0, 0))
         ];
 
-        vm.segments.segment_used_sizes = Some(vec![999]);
+        vm.segments.segment_used_sizes = Some(vec![995]);
 
         let pointer = Relocatable::from((2, 2));
 
@@ -302,7 +303,7 @@ mod tests {
             builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::InvalidStopPointer(
                 NAME,
-                relocatable!(0, 999),
+                relocatable!(0, 995),
                 relocatable!(0, 0)
             ))
         );

--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -256,8 +256,8 @@ mod tests {
             builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::InvalidStopPointer(
                 "bitwise",
-                relocatable!(0, 999),
-                relocatable!(0, 0)
+                relocatable!(0, 0),
+                relocatable!(0, 999)
             ))
         );
     }

--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -178,14 +178,6 @@ impl BitwiseBuiltinRunner {
         4 * partition_lengh + num_trimmed
     }
 
-    pub fn get_used_instances(
-        &self,
-        segments: &MemorySegmentManager,
-    ) -> Result<usize, MemoryError> {
-        let used_cells = self.get_used_cells(segments)?;
-        Ok(div_ceil(used_cells, self.cells_per_instance as usize))
-    }
-
     pub fn final_stack(
         &mut self,
         segments: &MemorySegmentManager,
@@ -207,9 +199,8 @@ impl BitwiseBuiltinRunner {
                 ));
             }
             let stop_ptr = stop_pointer.offset;
-            let used = self
-                .get_used_cells(segments)
-                .map_err(RunnerError::MemoryError)?;
+            let num_instances = self.get_used_instances(segments)?;
+            let used = num_instances * self.cells_per_instance as CoerceUnsized;
             if stop_ptr != used {
                 return Err(RunnerError::InvalidStopPointer(
                     NAME,
@@ -224,6 +215,14 @@ impl BitwiseBuiltinRunner {
             self.stop_ptr = Some(stop_ptr);
             Ok(pointer)
         }
+    }
+
+    pub fn get_used_instances(
+        &self,
+        segments: &MemorySegmentManager,
+    ) -> Result<usize, MemoryError> {
+        let used_cells = self.get_used_cells(segments)?;
+        Ok(div_ceil(used_cells, self.cells_per_instance as usize))
     }
 }
 

--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -14,6 +14,8 @@ use crate::{
 };
 use num_integer::div_ceil;
 
+pub(crate) const NAME: &'static str = "bitwise";
+
 #[derive(Debug, Clone)]
 pub struct BitwiseBuiltinRunner {
     ratio: u32,
@@ -135,17 +137,19 @@ impl BitwiseBuiltinRunner {
         vm: &VirtualMachine,
     ) -> Result<(usize, usize), MemoryError> {
         let ratio = self.ratio as usize;
-        let cells_per_instance = self.cells_per_instance;
         let min_step = ratio * self.instances_per_component as usize;
         if vm.current_step < min_step {
-            Err(MemoryError::InsufficientAllocatedCells)
+            Err(MemoryError::InsufficientAllocatedCellsMinStepNotReached(
+                min_step, NAME,
+            ))
         } else {
             let used = self.get_used_cells(&vm.segments)?;
-            let size = cells_per_instance as usize
-                * safe_div_usize(vm.current_step, ratio)
-                    .map_err(|_| MemoryError::InsufficientAllocatedCells)?;
+            let size = self.cells_per_instance as usize
+                * safe_div_usize(vm.current_step, ratio).map_err(|_| {
+                    MemoryError::CurrentStepNotDivisibleByBuiltinRatio(NAME, vm.current_step, ratio)
+                })?;
             if used > size {
-                return Err(MemoryError::InsufficientAllocatedCells);
+                return Err(MemoryError::InsufficientAllocatedCells(NAME, used, size));
             }
             Ok((used, size))
         }

--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -185,6 +185,46 @@ impl BitwiseBuiltinRunner {
         let used_cells = self.get_used_cells(segments)?;
         Ok(div_ceil(used_cells, self.cells_per_instance as usize))
     }
+
+    pub fn final_stack(
+        &mut self,
+        segments: &MemorySegmentManager,
+        pointer: Relocatable,
+    ) -> Result<Relocatable, RunnerError> {
+        if self.included {
+            let stop_pointer_addr = pointer
+                .sub_usize(1)
+                .map_err(|_| RunnerError::NoStopPointer(NAME))?;
+            let stop_pointer = segments
+                .memory
+                .get_relocatable(&stop_pointer_addr)
+                .map_err(|_| RunnerError::NoStopPointer(NAME))?;
+            if self.base != stop_pointer.segment_index {
+                return Err(RunnerError::InvalidStopPointerIndex(
+                    NAME,
+                    stop_pointer,
+                    self.base(),
+                ));
+            }
+            let stop_ptr = stop_pointer.offset;
+            let used = self
+                .get_used_cells(segments)
+                .map_err(RunnerError::MemoryError)?;
+            if stop_ptr != used {
+                return Err(RunnerError::InvalidStopPointer(
+                    NAME,
+                    Relocatable::from((self.base, used)),
+                    Relocatable::from((self.base, stop_ptr)),
+                ));
+            }
+            self.stop_ptr = Some(stop_ptr);
+            Ok(stop_pointer_addr)
+        } else {
+            let stop_ptr = self.base as usize;
+            self.stop_ptr = Some(stop_ptr);
+            Ok(pointer)
+        }
+    }
 }
 
 #[cfg(test)]
@@ -221,8 +261,7 @@ mod tests {
 
     #[test]
     fn final_stack() {
-        let mut builtin: BuiltinRunner =
-            BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(10), true).into();
+        let mut builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(10), true);
 
         let mut vm = vm!();
 
@@ -245,8 +284,7 @@ mod tests {
 
     #[test]
     fn final_stack_error_stop_pointer() {
-        let mut builtin: BuiltinRunner =
-            BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(10), true).into();
+        let mut builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(10), true);
 
         let mut vm = vm!();
 
@@ -273,8 +311,7 @@ mod tests {
 
     #[test]
     fn final_stack_error_when_notincluded() {
-        let mut builtin: BuiltinRunner =
-            BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(10), false).into();
+        let mut builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(10), false);
 
         let mut vm = vm!();
 
@@ -297,8 +334,7 @@ mod tests {
 
     #[test]
     fn final_stack_error_non_relocatable() {
-        let mut builtin: BuiltinRunner =
-            BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(10), true).into();
+        let mut builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(10), true);
 
         let mut vm = vm!();
 

--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -200,7 +200,7 @@ impl BitwiseBuiltinRunner {
             }
             let stop_ptr = stop_pointer.offset;
             let num_instances = self.get_used_instances(segments)?;
-            let used = num_instances * self.cells_per_instance as CoerceUnsized;
+            let used = num_instances * self.cells_per_instance as usize;
             if stop_ptr != used {
                 return Err(RunnerError::InvalidStopPointer(
                     NAME,

--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -374,7 +374,7 @@ mod tests {
         vm.segments.segment_used_sizes = Some(vec![0]);
 
         let program = program!(
-            builtins = vec![String::from(BITWISE_BUILTIN_NAME)],
+            builtins = vec![BITWISE_BUILTIN_NAME],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),
@@ -417,10 +417,7 @@ mod tests {
         let mut vm = vm!();
 
         let program = program!(
-            builtins = vec![
-                String::from(HASH_BUILTIN_NAME),
-                String::from(BITWISE_BUILTIN_NAME)
-            ],
+            builtins = vec![HASH_BUILTIN_NAME, BITWISE_BUILTIN_NAME],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),

--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -265,8 +265,8 @@ mod tests {
             builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::InvalidStopPointer(
                 "bitwise",
-                relocatable!(0, 0),
-                relocatable!(0, 999)
+                relocatable!(0, 999),
+                relocatable!(0, 0)
             ))
         );
     }

--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -274,7 +274,7 @@ mod tests {
     #[test]
     fn final_stack_error_when_notincluded() {
         let mut builtin: BuiltinRunner =
-            BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(10), true).into();
+            BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(10), false).into();
 
         let mut vm = vm!();
 
@@ -372,7 +372,10 @@ mod tests {
         let mut vm = vm!();
 
         let program = program!(
-            builtins = vec![String::from(NAME), String::from(NAME)],
+            builtins = vec![
+                String::from(crate::vm::runners::builtin_runner::hash::NAME),
+                String::from(NAME)
+            ],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),

--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -264,7 +264,7 @@ mod tests {
         assert_eq!(
             builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::InvalidStopPointer(
-                "bitwise",
+                NAME,
                 relocatable!(0, 999),
                 relocatable!(0, 0)
             ))
@@ -315,7 +315,7 @@ mod tests {
 
         assert_eq!(
             builtin.final_stack(&vm.segments, pointer),
-            Err(RunnerError::NoStopPointer("bitwise"))
+            Err(RunnerError::NoStopPointer(NAME))
         );
     }
 
@@ -329,7 +329,7 @@ mod tests {
         vm.segments.segment_used_sizes = Some(vec![0]);
 
         let program = program!(
-            builtins = vec![String::from("pedersen")],
+            builtins = vec![String::from(NAME)],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),
@@ -372,7 +372,7 @@ mod tests {
         let mut vm = vm!();
 
         let program = program!(
-            builtins = vec![String::from("output"), String::from("bitwise")],
+            builtins = vec![String::from(NAME), String::from(NAME)],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -390,7 +390,7 @@ mod tests {
             ((2, 1), (0, 0))
         ];
 
-        vm.segments.segment_used_sizes = Some(vec![999]);
+        vm.segments.segment_used_sizes = Some(vec![994]);
 
         let pointer = Relocatable::from((2, 2));
 
@@ -398,7 +398,7 @@ mod tests {
             builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::InvalidStopPointer(
                 NAME,
-                relocatable!(0, 999),
+                relocatable!(0, 994),
                 relocatable!(0, 0)
             ))
         );

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -355,8 +355,8 @@ mod tests {
             builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::InvalidStopPointer(
                 "ec_op",
-                relocatable!(0, 999),
-                relocatable!(0, 0)
+                relocatable!(0, 0),
+                relocatable!(0, 999)
             ))
         );
     }

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -14,6 +14,8 @@ use num_integer::{div_ceil, Integer};
 use num_traits::{Num, One, Pow, Zero};
 use std::borrow::Cow;
 
+pub(crate) const NAME: &'static str = "ec_op";
+
 #[derive(Debug, Clone)]
 pub struct EcOpBuiltinRunner {
     ratio: u32,
@@ -241,17 +243,19 @@ impl EcOpBuiltinRunner {
         vm: &VirtualMachine,
     ) -> Result<(usize, usize), MemoryError> {
         let ratio = self.ratio as usize;
-        let cells_per_instance = self.cells_per_instance;
         let min_step = ratio * self.instances_per_component as usize;
         if vm.current_step < min_step {
-            Err(MemoryError::InsufficientAllocatedCells)
+            Err(MemoryError::InsufficientAllocatedCellsMinStepNotReached(
+                min_step, NAME,
+            ))
         } else {
             let used = self.get_used_cells(&vm.segments)?;
-            let size = cells_per_instance as usize
-                * safe_div_usize(vm.current_step, ratio)
-                    .map_err(|_| MemoryError::InsufficientAllocatedCells)?;
+            let size = self.cells_per_instance as usize
+                * safe_div_usize(vm.current_step, ratio).map_err(|_| {
+                    MemoryError::CurrentStepNotDivisibleByBuiltinRatio(NAME, vm.current_step, ratio)
+                })?;
             if used > size {
-                return Err(MemoryError::InsufficientAllocatedCells);
+                return Err(MemoryError::InsufficientAllocatedCells(NAME, used, size));
             }
             Ok((used, size))
         }

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -360,7 +360,7 @@ mod tests {
         assert_eq!(
             builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::InvalidStopPointer(
-                "ec_op",
+                NAME,
                 relocatable!(0, 999),
                 relocatable!(0, 0)
             ))
@@ -411,7 +411,7 @@ mod tests {
 
         assert_eq!(
             builtin.final_stack(&vm.segments, pointer),
-            Err(RunnerError::NoStopPointer("ec_op"))
+            Err(RunnerError::NoStopPointer(NAME))
         );
     }
 
@@ -466,7 +466,7 @@ mod tests {
         let mut vm = vm!();
 
         let program = program!(
-            builtins = vec![String::from("ec_op")],
+            builtins = vec![String::from(NAME)],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -468,7 +468,7 @@ mod tests {
         vm.segments.segment_used_sizes = Some(vec![0]);
 
         let program = program!(
-            builtins = vec![String::from(HASH_BUILTIN_NAME)],
+            builtins = vec![HASH_BUILTIN_NAME],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),
@@ -510,7 +510,7 @@ mod tests {
         let mut vm = vm!();
 
         let program = program!(
-            builtins = vec![String::from(EC_OP_BUILTIN_NAME)],
+            builtins = vec![EC_OP_BUILTIN_NAME],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -361,8 +361,8 @@ mod tests {
             builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::InvalidStopPointer(
                 "ec_op",
-                relocatable!(0, 0),
-                relocatable!(0, 999)
+                relocatable!(0, 999),
+                relocatable!(0, 0)
             ))
         );
     }

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -292,9 +292,8 @@ impl EcOpBuiltinRunner {
                 ));
             }
             let stop_ptr = stop_pointer.offset;
-            let used = self
-                .get_used_cells(segments)
-                .map_err(RunnerError::MemoryError)?;
+            let num_instances = self.get_used_instances(segments)?;
+            let used = num_instances * self.cells_per_instance as usize;
             if stop_ptr != used {
                 return Err(RunnerError::InvalidStopPointer(
                     NAME,

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -14,7 +14,7 @@ use num_integer::{div_ceil, Integer};
 use num_traits::{Num, One, Pow, Zero};
 use std::borrow::Cow;
 
-pub(crate) const NAME: &'static str = "ec_op";
+pub(crate) const NAME: &str = "ec_op";
 
 #[derive(Debug, Clone)]
 pub struct EcOpBuiltinRunner {

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -3,7 +3,7 @@ use crate::types::instance_definitions::ec_op_instance_def::{
     EcOpInstanceDef, CELLS_PER_EC_OP, INPUT_CELLS_PER_EC_OP,
 };
 use crate::types::relocatable::{MaybeRelocatable, Relocatable};
-use crate::vm::errors::memory_errors::MemoryError;
+use crate::vm::errors::memory_errors::{InsufficientAllocatedCellsError, MemoryError};
 use crate::vm::errors::runner_errors::RunnerError;
 use crate::vm::vm_core::VirtualMachine;
 use crate::vm::vm_memory::memory::Memory;
@@ -245,17 +245,19 @@ impl EcOpBuiltinRunner {
         let ratio = self.ratio as usize;
         let min_step = ratio * self.instances_per_component as usize;
         if vm.current_step < min_step {
-            Err(MemoryError::InsufficientAllocatedCellsMinStepNotReached(
-                min_step, NAME,
-            ))
+            Err(InsufficientAllocatedCellsError::MinStepNotReached(min_step, NAME).into())
         } else {
             let used = self.get_used_cells(&vm.segments)?;
             let size = self.cells_per_instance as usize
                 * safe_div_usize(vm.current_step, ratio).map_err(|_| {
-                    MemoryError::CurrentStepNotDivisibleByBuiltinRatio(NAME, vm.current_step, ratio)
+                    InsufficientAllocatedCellsError::CurrentStepNotDivisibleByBuiltinRatio(
+                        NAME,
+                        vm.current_step,
+                        ratio,
+                    )
                 })?;
             if used > size {
-                return Err(MemoryError::InsufficientAllocatedCells(NAME, used, size));
+                return Err(InsufficientAllocatedCellsError::BuiltinCells(NAME, used, size).into());
             }
             Ok((used, size))
         }

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -190,9 +190,8 @@ impl HashBuiltinRunner {
                 ));
             }
             let stop_ptr = stop_pointer.offset;
-            let used = self
-                .get_used_cells(segments)
-                .map_err(RunnerError::MemoryError)?;
+            let num_instances = self.get_used_instances(segments)?;
+            let used = num_instances * self.cells_per_instance as usize;
             if stop_ptr != used {
                 return Err(RunnerError::InvalidStopPointer(
                     NAME,

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -239,7 +239,7 @@ mod tests {
         assert_eq!(
             builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::InvalidStopPointer(
-                "pedersen",
+                NAME,
                 relocatable!(0, 999),
                 relocatable!(0, 0)
             ))
@@ -288,7 +288,7 @@ mod tests {
 
         assert_eq!(
             builtin.final_stack(&vm.segments, pointer),
-            Err(RunnerError::NoStopPointer("hash"))
+            Err(RunnerError::NoStopPointer(NAME))
         );
     }
 
@@ -301,7 +301,7 @@ mod tests {
         vm.segments.segment_used_sizes = Some(vec![0]);
 
         let program = program!(
-            builtins = vec![String::from("pedersen")],
+            builtins = vec![String::from(NAME)],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),
@@ -344,7 +344,7 @@ mod tests {
         let mut vm = vm!();
 
         let program = program!(
-            builtins = vec![String::from("pedersen")],
+            builtins = vec![String::from(NAME)],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -348,7 +348,7 @@ mod tests {
         vm.segments.segment_used_sizes = Some(vec![0]);
 
         let program = program!(
-            builtins = vec![String::from(EC_OP_BUILTIN_NAME)],
+            builtins = vec![EC_OP_BUILTIN_NAME],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),
@@ -391,7 +391,7 @@ mod tests {
         let mut vm = vm!();
 
         let program = program!(
-            builtins = vec![String::from(EC_OP_BUILTIN_NAME)],
+            builtins = vec![EC_OP_BUILTIN_NAME],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -248,7 +248,7 @@ mod tests {
 
     #[test]
     fn final_stack_error_when_not_included() {
-        let mut builtin: BuiltinRunner = HashBuiltinRunner::new(10, true).into();
+        let mut builtin: BuiltinRunner = HashBuiltinRunner::new(10, false).into();
 
         let mut vm = vm!();
 

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -162,46 +162,13 @@ impl HashBuiltinRunner {
         let used_cells = self.get_used_cells(segments)?;
         Ok(div_ceil(used_cells, self.cells_per_instance as usize))
     }
-
-    pub fn final_stack(
-        &mut self,
-        segments: &MemorySegmentManager,
-        pointer: Relocatable,
-    ) -> Result<Relocatable, RunnerError> {
-        if self.included {
-            if let Ok(stop_pointer) = segments
-                .memory
-                .get_relocatable(&(pointer.sub_usize(1)).map_err(|_| RunnerError::FinalStack)?)
-            {
-                if self.base() != stop_pointer.segment_index {
-                    return Err(RunnerError::InvalidStopPointer("pedersen".to_string()));
-                }
-
-                let stop_ptr = stop_pointer.offset;
-                let num_instances = self
-                    .get_used_instances(segments)
-                    .map_err(|_| RunnerError::FinalStack)?;
-                let used_cells = num_instances * self.cells_per_instance as usize;
-                if stop_ptr != used_cells {
-                    return Err(RunnerError::InvalidStopPointer("pedersen".to_string()));
-                }
-                self.stop_ptr = Some(stop_ptr);
-                Ok(pointer.sub_usize(1).map_err(|_| RunnerError::FinalStack)?)
-            } else {
-                Err(RunnerError::FinalStack)
-            }
-        } else {
-            let stop_ptr = self.base() as usize;
-            self.stop_ptr = Some(stop_ptr);
-            Ok(pointer)
-        }
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor;
+    use crate::relocatable;
     use crate::types::program::Program;
     use crate::utils::test_utils::*;
     use crate::vm::runners::cairo_runner::CairoRunner;
@@ -225,7 +192,7 @@ mod tests {
 
     #[test]
     fn final_stack() {
-        let mut builtin = HashBuiltinRunner::new(10, true);
+        let mut builtin: BuiltinRunner = HashBuiltinRunner::new(10, true).into();
 
         let mut vm = vm!();
 
@@ -248,7 +215,7 @@ mod tests {
 
     #[test]
     fn final_stack_error_stop_pointer() {
-        let mut builtin = HashBuiltinRunner::new(10, true);
+        let mut builtin: BuiltinRunner = HashBuiltinRunner::new(10, true).into();
 
         let mut vm = vm!();
 
@@ -265,13 +232,17 @@ mod tests {
 
         assert_eq!(
             builtin.final_stack(&vm.segments, pointer),
-            Err(RunnerError::InvalidStopPointer("pedersen".to_string()))
+            Err(RunnerError::InvalidStopPointer(
+                "pedersen",
+                relocatable!(0, 999),
+                relocatable!(0, 0)
+            ))
         );
     }
 
     #[test]
-    fn final_stack_error_when_notincluded() {
-        let mut builtin = HashBuiltinRunner::new(10, false);
+    fn final_stack_error_when_not_included() {
+        let mut builtin: BuiltinRunner = HashBuiltinRunner::new(10, true).into();
 
         let mut vm = vm!();
 
@@ -294,7 +265,7 @@ mod tests {
 
     #[test]
     fn final_stack_error_non_relocatable() {
-        let mut builtin = HashBuiltinRunner::new(10, true);
+        let mut builtin: BuiltinRunner = HashBuiltinRunner::new(10, true).into();
 
         let mut vm = vm!();
 
@@ -311,7 +282,7 @@ mod tests {
 
         assert_eq!(
             builtin.final_stack(&vm.segments, pointer),
-            Err(RunnerError::FinalStack)
+            Err(RunnerError::NoStopPointer("pedersen"))
         );
     }
 

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -234,8 +234,8 @@ mod tests {
             builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::InvalidStopPointer(
                 "pedersen",
-                relocatable!(0, 999),
-                relocatable!(0, 0)
+                relocatable!(0, 0),
+                relocatable!(0, 999)
             ))
         );
     }
@@ -282,7 +282,7 @@ mod tests {
 
         assert_eq!(
             builtin.final_stack(&vm.segments, pointer),
-            Err(RunnerError::NoStopPointer("pedersen"))
+            Err(RunnerError::NoStopPointer("hash"))
         );
     }
 

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -14,7 +14,7 @@ use felt::Felt;
 use num_integer::{div_ceil, Integer};
 use starknet_crypto::{pedersen_hash, FieldElement};
 
-pub(crate) const NAME: &'static str = "pedersen";
+pub(crate) const NAME: &str = "pedersen";
 
 #[derive(Debug, Clone)]
 pub struct HashBuiltinRunner {

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -168,6 +168,46 @@ impl HashBuiltinRunner {
         let used_cells = self.get_used_cells(segments)?;
         Ok(div_ceil(used_cells, self.cells_per_instance as usize))
     }
+
+    pub fn final_stack(
+        &mut self,
+        segments: &MemorySegmentManager,
+        pointer: Relocatable,
+    ) -> Result<Relocatable, RunnerError> {
+        if self.included {
+            let stop_pointer_addr = pointer
+                .sub_usize(1)
+                .map_err(|_| RunnerError::NoStopPointer(NAME))?;
+            let stop_pointer = segments
+                .memory
+                .get_relocatable(&stop_pointer_addr)
+                .map_err(|_| RunnerError::NoStopPointer(NAME))?;
+            if self.base != stop_pointer.segment_index {
+                return Err(RunnerError::InvalidStopPointerIndex(
+                    NAME,
+                    stop_pointer,
+                    self.base,
+                ));
+            }
+            let stop_ptr = stop_pointer.offset;
+            let used = self
+                .get_used_cells(segments)
+                .map_err(RunnerError::MemoryError)?;
+            if stop_ptr != used {
+                return Err(RunnerError::InvalidStopPointer(
+                    NAME,
+                    Relocatable::from((self.base, used)),
+                    Relocatable::from((self.base, stop_ptr)),
+                ));
+            }
+            self.stop_ptr = Some(stop_ptr);
+            Ok(stop_pointer_addr)
+        } else {
+            let stop_ptr = self.base as usize;
+            self.stop_ptr = Some(stop_ptr);
+            Ok(pointer)
+        }
+    }
 }
 
 #[cfg(test)]
@@ -198,7 +238,7 @@ mod tests {
 
     #[test]
     fn final_stack() {
-        let mut builtin: BuiltinRunner = HashBuiltinRunner::new(10, true).into();
+        let mut builtin = HashBuiltinRunner::new(10, true);
 
         let mut vm = vm!();
 
@@ -221,7 +261,7 @@ mod tests {
 
     #[test]
     fn final_stack_error_stop_pointer() {
-        let mut builtin: BuiltinRunner = HashBuiltinRunner::new(10, true).into();
+        let mut builtin = HashBuiltinRunner::new(10, true);
 
         let mut vm = vm!();
 
@@ -248,7 +288,7 @@ mod tests {
 
     #[test]
     fn final_stack_error_when_not_included() {
-        let mut builtin: BuiltinRunner = HashBuiltinRunner::new(10, false).into();
+        let mut builtin = HashBuiltinRunner::new(10, false);
 
         let mut vm = vm!();
 
@@ -271,7 +311,7 @@ mod tests {
 
     #[test]
     fn final_stack_error_non_relocatable() {
-        let mut builtin: BuiltinRunner = HashBuiltinRunner::new(10, true).into();
+        let mut builtin = HashBuiltinRunner::new(10, true);
 
         let mut vm = vm!();
 

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -14,6 +14,8 @@ use felt::Felt;
 use num_integer::{div_ceil, Integer};
 use starknet_crypto::{pedersen_hash, FieldElement};
 
+pub(crate) const NAME: &'static str = "pedersen";
+
 #[derive(Debug, Clone)]
 pub struct HashBuiltinRunner {
     pub base: isize,
@@ -139,17 +141,19 @@ impl HashBuiltinRunner {
         vm: &VirtualMachine,
     ) -> Result<(usize, usize), MemoryError> {
         let ratio = self.ratio as usize;
-        let cells_per_instance = self.cells_per_instance;
         let min_step = ratio * self.instances_per_component as usize;
         if vm.current_step < min_step {
-            Err(MemoryError::InsufficientAllocatedCells)
+            Err(MemoryError::InsufficientAllocatedCellsMinStepNotReached(
+                min_step, NAME,
+            ))
         } else {
             let used = self.get_used_cells(&vm.segments)?;
-            let size = cells_per_instance as usize
-                * safe_div_usize(vm.current_step, ratio)
-                    .map_err(|_| MemoryError::InsufficientAllocatedCells)?;
+            let size = self.cells_per_instance as usize
+                * safe_div_usize(vm.current_step, ratio).map_err(|_| {
+                    MemoryError::CurrentStepNotDivisibleByBuiltinRatio(NAME, vm.current_step, ratio)
+                })?;
             if used > size {
-                return Err(MemoryError::InsufficientAllocatedCells);
+                return Err(MemoryError::InsufficientAllocatedCells(NAME, used, size));
             }
             Ok((used, size))
         }

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -240,8 +240,8 @@ mod tests {
             builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::InvalidStopPointer(
                 "pedersen",
-                relocatable!(0, 0),
-                relocatable!(0, 999)
+                relocatable!(0, 999),
+                relocatable!(0, 0)
             ))
         );
     }

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -14,7 +14,7 @@ use felt::Felt;
 use num_integer::{div_ceil, Integer};
 use starknet_crypto::{pedersen_hash, FieldElement};
 
-pub(crate) const NAME: &str = "pedersen";
+use super::EC_OP_BUILTIN_NAME;
 
 #[derive(Debug, Clone)]
 pub struct HashBuiltinRunner {
@@ -143,19 +143,27 @@ impl HashBuiltinRunner {
         let ratio = self.ratio as usize;
         let min_step = ratio * self.instances_per_component as usize;
         if vm.current_step < min_step {
-            Err(InsufficientAllocatedCellsError::MinStepNotReached(min_step, NAME).into())
+            Err(
+                InsufficientAllocatedCellsError::MinStepNotReached(min_step, EC_OP_BUILTIN_NAME)
+                    .into(),
+            )
         } else {
             let used = self.get_used_cells(&vm.segments)?;
             let size = self.cells_per_instance as usize
                 * safe_div_usize(vm.current_step, ratio).map_err(|_| {
                     InsufficientAllocatedCellsError::CurrentStepNotDivisibleByBuiltinRatio(
-                        NAME,
+                        EC_OP_BUILTIN_NAME,
                         vm.current_step,
                         ratio,
                     )
                 })?;
             if used > size {
-                return Err(InsufficientAllocatedCellsError::BuiltinCells(NAME, used, size).into());
+                return Err(InsufficientAllocatedCellsError::BuiltinCells(
+                    EC_OP_BUILTIN_NAME,
+                    used,
+                    size,
+                )
+                .into());
             }
             Ok((used, size))
         }
@@ -177,14 +185,14 @@ impl HashBuiltinRunner {
         if self.included {
             let stop_pointer_addr = pointer
                 .sub_usize(1)
-                .map_err(|_| RunnerError::NoStopPointer(NAME))?;
+                .map_err(|_| RunnerError::NoStopPointer(EC_OP_BUILTIN_NAME))?;
             let stop_pointer = segments
                 .memory
                 .get_relocatable(&stop_pointer_addr)
-                .map_err(|_| RunnerError::NoStopPointer(NAME))?;
+                .map_err(|_| RunnerError::NoStopPointer(EC_OP_BUILTIN_NAME))?;
             if self.base != stop_pointer.segment_index {
                 return Err(RunnerError::InvalidStopPointerIndex(
-                    NAME,
+                    EC_OP_BUILTIN_NAME,
                     stop_pointer,
                     self.base,
                 ));
@@ -194,7 +202,7 @@ impl HashBuiltinRunner {
             let used = num_instances * self.cells_per_instance as usize;
             if stop_ptr != used {
                 return Err(RunnerError::InvalidStopPointer(
-                    NAME,
+                    EC_OP_BUILTIN_NAME,
                     Relocatable::from((self.base, used)),
                     Relocatable::from((self.base, stop_ptr)),
                 ));
@@ -278,7 +286,7 @@ mod tests {
         assert_eq!(
             builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::InvalidStopPointer(
-                NAME,
+                EC_OP_BUILTIN_NAME,
                 relocatable!(0, 999),
                 relocatable!(0, 0)
             ))
@@ -327,7 +335,7 @@ mod tests {
 
         assert_eq!(
             builtin.final_stack(&vm.segments, pointer),
-            Err(RunnerError::NoStopPointer(NAME))
+            Err(RunnerError::NoStopPointer(EC_OP_BUILTIN_NAME))
         );
     }
 
@@ -340,7 +348,7 @@ mod tests {
         vm.segments.segment_used_sizes = Some(vec![0]);
 
         let program = program!(
-            builtins = vec![String::from(NAME)],
+            builtins = vec![String::from(EC_OP_BUILTIN_NAME)],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),
@@ -383,7 +391,7 @@ mod tests {
         let mut vm = vm!();
 
         let program = program!(
-            builtins = vec![String::from(NAME)],
+            builtins = vec![String::from(EC_OP_BUILTIN_NAME)],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),

--- a/src/vm/runners/builtin_runner/keccak.rs
+++ b/src/vm/runners/builtin_runner/keccak.rs
@@ -299,7 +299,7 @@ mod tests {
         assert_eq!(
             builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::InvalidStopPointer(
-                "keccak",
+                NAME,
                 relocatable!(0, 999),
                 relocatable!(0, 0)
             ))
@@ -350,7 +350,7 @@ mod tests {
 
         assert_eq!(
             builtin.final_stack(&vm.segments, pointer),
-            Err(RunnerError::NoStopPointer("keccak"))
+            Err(RunnerError::NoStopPointer(NAME))
         );
     }
 
@@ -389,7 +389,7 @@ mod tests {
         let mut vm = vm!();
 
         let program = program!(
-            builtins = vec![String::from("keccak")],
+            builtins = vec![String::from(NAME)],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),

--- a/src/vm/runners/builtin_runner/keccak.rs
+++ b/src/vm/runners/builtin_runner/keccak.rs
@@ -216,9 +216,8 @@ impl KeccakBuiltinRunner {
                 ));
             }
             let stop_ptr = stop_pointer.offset;
-            let used = self
-                .get_used_cells(segments)
-                .map_err(RunnerError::MemoryError)?;
+            let num_instances = self.get_used_instances(segments)?;
+            let used = num_instances * self.cells_per_instance as usize;
             if stop_ptr != used {
                 return Err(RunnerError::InvalidStopPointer(
                     NAME,
@@ -345,7 +344,7 @@ mod tests {
     }
 
     #[test]
-    fn final_stack_error_when_notincluded() {
+    fn final_stack_error_when_not_included() {
         let mut builtin =
             KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10, vec![200; 8]), false);
 

--- a/src/vm/runners/builtin_runner/keccak.rs
+++ b/src/vm/runners/builtin_runner/keccak.rs
@@ -292,8 +292,8 @@ mod tests {
             builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::InvalidStopPointer(
                 "keccak",
-                relocatable!(0, 999),
-                relocatable!(0, 0)
+                relocatable!(0, 0),
+                relocatable!(0, 999)
             ))
         );
     }

--- a/src/vm/runners/builtin_runner/keccak.rs
+++ b/src/vm/runners/builtin_runner/keccak.rs
@@ -16,7 +16,7 @@ use num_traits::One;
 
 const KECCAK_ARRAY_LEN: usize = 25;
 
-pub(crate) const NAME: &'static str = "keccak";
+pub(crate) const NAME: &str = "keccak";
 
 #[derive(Debug, Clone)]
 pub struct KeccakBuiltinRunner {

--- a/src/vm/runners/builtin_runner/keccak.rs
+++ b/src/vm/runners/builtin_runner/keccak.rs
@@ -5,7 +5,7 @@ use crate::hint_processor::builtin_hint_processor::keccak_utils::left_pad_u64;
 use crate::math_utils::safe_div_usize;
 use crate::types::instance_definitions::keccak_instance_def::KeccakInstanceDef;
 use crate::types::relocatable::{MaybeRelocatable, Relocatable};
-use crate::vm::errors::memory_errors::MemoryError;
+use crate::vm::errors::memory_errors::{InsufficientAllocatedCellsError, MemoryError};
 use crate::vm::errors::runner_errors::RunnerError;
 use crate::vm::vm_core::VirtualMachine;
 use crate::vm::vm_memory::memory::Memory;
@@ -169,17 +169,19 @@ impl KeccakBuiltinRunner {
         let ratio = self.ratio as usize;
         let min_step = ratio * self.instances_per_component as usize;
         if vm.current_step < min_step {
-            Err(MemoryError::InsufficientAllocatedCellsMinStepNotReached(
-                min_step, NAME,
-            ))
+            Err(InsufficientAllocatedCellsError::MinStepNotReached(min_step, NAME).into())
         } else {
             let used = self.get_used_cells(&vm.segments)?;
             let size = self.cells_per_instance as usize
                 * safe_div_usize(vm.current_step, ratio).map_err(|_| {
-                    MemoryError::CurrentStepNotDivisibleByBuiltinRatio(NAME, vm.current_step, ratio)
+                    InsufficientAllocatedCellsError::CurrentStepNotDivisibleByBuiltinRatio(
+                        NAME,
+                        vm.current_step,
+                        ratio,
+                    )
                 })?;
             if used > size {
-                return Err(MemoryError::InsufficientAllocatedCells(NAME, used, size));
+                return Err(InsufficientAllocatedCellsError::BuiltinCells(NAME, used, size).into());
             }
             Ok((used, size))
         }

--- a/src/vm/runners/builtin_runner/keccak.rs
+++ b/src/vm/runners/builtin_runner/keccak.rs
@@ -300,8 +300,8 @@ mod tests {
             builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::InvalidStopPointer(
                 "keccak",
-                relocatable!(0, 0),
-                relocatable!(0, 999)
+                relocatable!(0, 999),
+                relocatable!(0, 0)
             ))
         );
     }

--- a/src/vm/runners/builtin_runner/keccak.rs
+++ b/src/vm/runners/builtin_runner/keccak.rs
@@ -37,7 +37,7 @@ impl KeccakBuiltinRunner {
             base: 0,
             ratio: instance_def._ratio,
             n_input_cells: instance_def._state_rep.len() as u32,
-            cells_per_instance: instance_def._cells_per_builtin(),
+            cells_per_instance: instance_def.cells_per_builtin(),
             stop_ptr: None,
             verified_addresses: Vec::new(),
             included,
@@ -329,15 +329,15 @@ mod tests {
             ((2, 1), (0, 0))
         ];
 
-        vm.segments.segment_used_sizes = Some(vec![999]);
+        vm.segments.segment_used_sizes = Some(vec![992]);
 
         let pointer = Relocatable::from((2, 2));
-
+        dbg!(builtin.cells_per_instance);
         assert_eq!(
             builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::InvalidStopPointer(
                 NAME,
-                relocatable!(0, 999),
+                relocatable!(0, 992),
                 relocatable!(0, 0)
             ))
         );

--- a/src/vm/runners/builtin_runner/keccak.rs
+++ b/src/vm/runners/builtin_runner/keccak.rs
@@ -195,6 +195,46 @@ impl KeccakBuiltinRunner {
         Ok(div_ceil(used_cells, self.cells_per_instance as usize))
     }
 
+    pub fn final_stack(
+        &mut self,
+        segments: &MemorySegmentManager,
+        pointer: Relocatable,
+    ) -> Result<Relocatable, RunnerError> {
+        if self.included {
+            let stop_pointer_addr = pointer
+                .sub_usize(1)
+                .map_err(|_| RunnerError::NoStopPointer(NAME))?;
+            let stop_pointer = segments
+                .memory
+                .get_relocatable(&stop_pointer_addr)
+                .map_err(|_| RunnerError::NoStopPointer(NAME))?;
+            if self.base != stop_pointer.segment_index {
+                return Err(RunnerError::InvalidStopPointerIndex(
+                    NAME,
+                    stop_pointer,
+                    self.base,
+                ));
+            }
+            let stop_ptr = stop_pointer.offset;
+            let used = self
+                .get_used_cells(segments)
+                .map_err(RunnerError::MemoryError)?;
+            if stop_ptr != used {
+                return Err(RunnerError::InvalidStopPointer(
+                    NAME,
+                    Relocatable::from((self.base, used)),
+                    Relocatable::from((self.base, stop_ptr)),
+                ));
+            }
+            self.stop_ptr = Some(stop_ptr);
+            Ok(stop_pointer_addr)
+        } else {
+            let stop_ptr = self.base as usize;
+            self.stop_ptr = Some(stop_ptr);
+            Ok(pointer)
+        }
+    }
+
     pub fn get_memory_accesses(
         &self,
         vm: &VirtualMachine,
@@ -256,8 +296,7 @@ mod tests {
 
     #[test]
     fn final_stack() {
-        let mut builtin: BuiltinRunner =
-            KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10, vec![200; 8]), true).into();
+        let mut builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10, vec![200; 8]), true);
 
         let mut vm = vm!();
 
@@ -280,8 +319,7 @@ mod tests {
 
     #[test]
     fn final_stack_error_stop_pointer() {
-        let mut builtin: BuiltinRunner =
-            KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10, vec![200; 8]), true).into();
+        let mut builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10, vec![200; 8]), true);
 
         let mut vm = vm!();
 
@@ -308,8 +346,8 @@ mod tests {
 
     #[test]
     fn final_stack_error_when_notincluded() {
-        let mut builtin: BuiltinRunner =
-            KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10, vec![200; 8]), false).into();
+        let mut builtin =
+            KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10, vec![200; 8]), false);
 
         let mut vm = vm!();
 
@@ -332,8 +370,7 @@ mod tests {
 
     #[test]
     fn final_stack_error_non_relocatable() {
-        let mut builtin: BuiltinRunner =
-            KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10, vec![200; 8]), true).into();
+        let mut builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::new(10, vec![200; 8]), true);
 
         let mut vm = vm!();
 

--- a/src/vm/runners/builtin_runner/keccak.rs
+++ b/src/vm/runners/builtin_runner/keccak.rs
@@ -433,7 +433,7 @@ mod tests {
         let mut vm = vm!();
 
         let program = program!(
-            builtins = vec![String::from(KECCAK_BUILTIN_NAME)],
+            builtins = vec![KECCAK_BUILTIN_NAME],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -372,18 +372,6 @@ impl BuiltinRunner {
             }
         }
     }
-
-    pub fn set_stop_ptr(&mut self, stop_ptr: usize) {
-        match self {
-            BuiltinRunner::Bitwise(ref mut bitwise) => bitwise.stop_ptr = Some(stop_ptr),
-            BuiltinRunner::EcOp(ref mut ec) => ec.stop_ptr = Some(stop_ptr),
-            BuiltinRunner::Hash(ref mut hash) => hash.stop_ptr = Some(stop_ptr),
-            BuiltinRunner::Output(ref mut output) => output.stop_ptr = Some(stop_ptr),
-            BuiltinRunner::RangeCheck(ref mut range_check) => range_check.stop_ptr = Some(stop_ptr),
-            BuiltinRunner::Keccak(ref mut keccak) => keccak.stop_ptr = Some(stop_ptr),
-            BuiltinRunner::Signature(ref mut signature) => signature.stop_ptr = Some(stop_ptr),
-        }
-    }
 }
 
 impl From<KeccakBuiltinRunner> for BuiltinRunner {
@@ -1476,36 +1464,6 @@ mod tests {
 
         for br in builtins.iter_mut() {
             assert_eq!(br.final_stack(&vm.segments, vm.get_ap()), Ok(vm.get_ap()));
-        }
-    }
-
-    #[test]
-    fn runners_set_stop_ptr() {
-        let builtins = vec![
-            BuiltinRunner::Bitwise(BitwiseBuiltinRunner::new(
-                &BitwiseInstanceDef::default(),
-                false,
-            )),
-            BuiltinRunner::EcOp(EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), false)),
-            BuiltinRunner::Hash(HashBuiltinRunner::new(1, false)),
-            BuiltinRunner::Output(OutputBuiltinRunner::new(false)),
-            BuiltinRunner::RangeCheck(RangeCheckBuiltinRunner::new(8, 8, false)),
-            BuiltinRunner::Keccak(KeccakBuiltinRunner::new(
-                &KeccakInstanceDef::default(),
-                false,
-            )),
-            BuiltinRunner::Signature(SignatureBuiltinRunner::new(
-                &EcdsaInstanceDef::default(),
-                false,
-            )),
-        ];
-
-        let ptr = 3;
-
-        for mut br in builtins {
-            br.set_stop_ptr(ptr);
-            let (_, stop_ptr) = br.get_memory_segment_addresses();
-            assert_eq!(stop_ptr, Some(ptr));
         }
     }
 }

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -99,7 +99,7 @@ impl BuiltinRunner {
                 return Err(RunnerError::InvalidStopPointer(
                     self.name(),
                     Relocatable::from((self.base(), used)),
-                    Relocatable::from((self.base(), used)),
+                    Relocatable::from((self.base(), stop_ptr)),
                 ));
             }
             self.set_stop_ptr(stop_ptr);

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -24,6 +24,14 @@ pub use output::OutputBuiltinRunner;
 pub use range_check::RangeCheckBuiltinRunner;
 pub use signature::SignatureBuiltinRunner;
 
+pub(crate) const OUTPUT_BUILTIN_NAME: &str = "output";
+pub(crate) const HASH_BUILTIN_NAME: &str = "pedersen";
+pub(crate) const RANGE_CHECK_BUILTIN_NAME: &str = "range_check";
+pub(crate) const SIGNATURE_BUILTIN_NAME: &str = "ecdsa";
+pub(crate) const BITWISE_BUILTIN_NAME: &str = "bitwise";
+pub(crate) const EC_OP_BUILTIN_NAME: &str = "ec_op";
+pub(crate) const KECCAK_BUILTIN_NAME: &str = "keccak";
+
 /* NB: this enum is no accident: we may need (and cairo-rs-py *does* need)
  * structs containing this to be `Send`. The only two ways to achieve that
  * are either storing a `dyn Trait` inside an `Arc<Mutex<&dyn Trait>>` or
@@ -282,13 +290,13 @@ impl BuiltinRunner {
 
     pub fn name(&self) -> &'static str {
         match self {
-            BuiltinRunner::Bitwise(_) => bitwise::NAME,
-            BuiltinRunner::EcOp(_) => ec_op::NAME,
-            BuiltinRunner::Hash(_) => hash::NAME,
-            BuiltinRunner::RangeCheck(_) => range_check::NAME,
-            BuiltinRunner::Output(_) => output::NAME,
-            BuiltinRunner::Keccak(_) => keccak::NAME,
-            BuiltinRunner::Signature(_) => signature::NAME,
+            BuiltinRunner::Bitwise(_) => BITWISE_BUILTIN_NAME,
+            BuiltinRunner::EcOp(_) => EC_OP_BUILTIN_NAME,
+            BuiltinRunner::Hash(_) => HASH_BUILTIN_NAME,
+            BuiltinRunner::RangeCheck(_) => RANGE_CHECK_BUILTIN_NAME,
+            BuiltinRunner::Output(_) => OUTPUT_BUILTIN_NAME,
+            BuiltinRunner::Keccak(_) => KECCAK_BUILTIN_NAME,
+            BuiltinRunner::Signature(_) => SIGNATURE_BUILTIN_NAME,
         }
     }
 
@@ -583,42 +591,42 @@ mod tests {
     fn get_name_bitwise() {
         let bitwise = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(10), true);
         let builtin: BuiltinRunner = bitwise.into();
-        assert_eq!(bitwise::NAME, builtin.name())
+        assert_eq!(BITWISE_BUILTIN_NAME, builtin.name())
     }
 
     #[test]
     fn get_name_hash() {
         let hash = HashBuiltinRunner::new(10, true);
         let builtin: BuiltinRunner = hash.into();
-        assert_eq!(hash::NAME, builtin.name())
+        assert_eq!(HASH_BUILTIN_NAME, builtin.name())
     }
 
     #[test]
     fn get_name_range_check() {
         let range_check = RangeCheckBuiltinRunner::new(10, 10, true);
         let builtin: BuiltinRunner = range_check.into();
-        assert_eq!(range_check::NAME, builtin.name())
+        assert_eq!(RANGE_CHECK_BUILTIN_NAME, builtin.name())
     }
 
     #[test]
     fn get_name_ec_op() {
         let ec_op = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
         let builtin: BuiltinRunner = ec_op.into();
-        assert_eq!(ec_op::NAME, builtin.name())
+        assert_eq!(EC_OP_BUILTIN_NAME, builtin.name())
     }
 
     #[test]
     fn get_name_ecdsa() {
         let signature = SignatureBuiltinRunner::new(&EcdsaInstanceDef::new(10), true);
         let builtin: BuiltinRunner = signature.into();
-        assert_eq!(signature::NAME, builtin.name())
+        assert_eq!(SIGNATURE_BUILTIN_NAME, builtin.name())
     }
 
     #[test]
     fn get_name_output() {
         let output = OutputBuiltinRunner::new(true);
         let builtin: BuiltinRunner = output.into();
-        assert_eq!(output::NAME, builtin.name())
+        assert_eq!(OUTPUT_BUILTIN_NAME, builtin.name())
     }
 
     #[test]
@@ -631,7 +639,7 @@ mod tests {
         let mut vm = vm!();
 
         let program = program!(
-            builtins = vec![String::from(bitwise::NAME)],
+            builtins = vec![String::from(BITWISE_BUILTIN_NAME)],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),
@@ -674,7 +682,7 @@ mod tests {
         let mut vm = vm!();
 
         let program = program!(
-            builtins = vec![String::from(ec_op::NAME)],
+            builtins = vec![String::from(EC_OP_BUILTIN_NAME)],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),
@@ -717,7 +725,7 @@ mod tests {
         let mut vm = vm!();
 
         let program = program!(
-            builtins = vec![String::from(hash::NAME)],
+            builtins = vec![String::from(HASH_BUILTIN_NAME)],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),
@@ -760,7 +768,7 @@ mod tests {
         let mut vm = vm!();
 
         let program = program!(
-            builtins = vec![String::from(range_check::NAME)],
+            builtins = vec![String::from(RANGE_CHECK_BUILTIN_NAME)],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),
@@ -806,7 +814,7 @@ mod tests {
         let mut vm = vm!();
 
         let program = program!(
-            builtins = vec![String::from(keccak::NAME)],
+            builtins = vec![String::from(KECCAK_BUILTIN_NAME)],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),
@@ -1069,7 +1077,7 @@ mod tests {
         assert_matches!(
             builtin.run_security_checks(&vm),
             Err(VirtualMachineError::MemoryError(
-                MemoryError::MissingMemoryCellsWithOffsets(bitwise::NAME, x)
+                MemoryError::MissingMemoryCellsWithOffsets(BITWISE_BUILTIN_NAME, x)
             )) if x == vec![0]
         );
     }
@@ -1097,7 +1105,7 @@ mod tests {
         assert_matches!(
             builtin.run_security_checks(&vm),
             Err(VirtualMachineError::MemoryError(
-                MemoryError::MissingMemoryCells(bitwise::NAME)
+                MemoryError::MissingMemoryCells(BITWISE_BUILTIN_NAME)
             ))
         );
     }
@@ -1118,7 +1126,7 @@ mod tests {
         assert_matches!(
             builtin.run_security_checks(&vm),
             Err(VirtualMachineError::MemoryError(
-                MemoryError::MissingMemoryCellsWithOffsets(hash::NAME, x)
+                MemoryError::MissingMemoryCellsWithOffsets(HASH_BUILTIN_NAME, x)
             )) if x == vec![0]
         );
     }
@@ -1136,7 +1144,7 @@ mod tests {
         assert_matches!(
             builtin.run_security_checks(&vm),
             Err(VirtualMachineError::MemoryError(
-                MemoryError::MissingMemoryCells(hash::NAME)
+                MemoryError::MissingMemoryCells(HASH_BUILTIN_NAME)
             ))
         );
     }
@@ -1161,7 +1169,7 @@ mod tests {
         assert_matches!(
             builtin.run_security_checks(&vm),
             Err(VirtualMachineError::MemoryError(
-                MemoryError::MissingMemoryCells(range_check::NAME)
+                MemoryError::MissingMemoryCells(RANGE_CHECK_BUILTIN_NAME)
             ))
         );
     }
@@ -1177,7 +1185,7 @@ mod tests {
         assert_matches!(
             builtin.run_security_checks(&vm),
             Err(VirtualMachineError::MemoryError(
-                MemoryError::MissingMemoryCells(range_check::NAME)
+                MemoryError::MissingMemoryCells(RANGE_CHECK_BUILTIN_NAME)
             ))
         );
     }
@@ -1243,7 +1251,7 @@ mod tests {
         assert_matches!(
             builtin.run_security_checks(&vm),
             Err(VirtualMachineError::MemoryError(
-                MemoryError::MissingMemoryCells(ec_op::NAME)
+                MemoryError::MissingMemoryCells(EC_OP_BUILTIN_NAME)
             ))
         );
     }
@@ -1265,7 +1273,7 @@ mod tests {
         assert_matches!(
             builtin.run_security_checks(&vm),
             Err(VirtualMachineError::MemoryError(
-                MemoryError::MissingMemoryCells(ec_op::NAME)
+                MemoryError::MissingMemoryCells(EC_OP_BUILTIN_NAME)
             ))
         );
     }
@@ -1289,7 +1297,7 @@ mod tests {
         assert_matches!(
             builtin.run_security_checks(&vm),
             Err(VirtualMachineError::MemoryError(
-                MemoryError::MissingMemoryCellsWithOffsets(ec_op::NAME, x)
+                MemoryError::MissingMemoryCellsWithOffsets(EC_OP_BUILTIN_NAME, x)
             )) if x == vec![0]
         );
     }
@@ -1320,7 +1328,7 @@ mod tests {
         assert_matches!(
             builtin.run_security_checks(&vm),
             Err(VirtualMachineError::MemoryError(
-                MemoryError::MissingMemoryCellsWithOffsets(ec_op::NAME, x)
+                MemoryError::MissingMemoryCellsWithOffsets(EC_OP_BUILTIN_NAME, x)
             )) if x == vec![7]
         );
     }

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -639,7 +639,7 @@ mod tests {
         let mut vm = vm!();
 
         let program = program!(
-            builtins = vec![String::from(BITWISE_BUILTIN_NAME)],
+            builtins = vec![BITWISE_BUILTIN_NAME],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),
@@ -682,7 +682,7 @@ mod tests {
         let mut vm = vm!();
 
         let program = program!(
-            builtins = vec![String::from(EC_OP_BUILTIN_NAME)],
+            builtins = vec![EC_OP_BUILTIN_NAME],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),
@@ -725,7 +725,7 @@ mod tests {
         let mut vm = vm!();
 
         let program = program!(
-            builtins = vec![String::from(HASH_BUILTIN_NAME)],
+            builtins = vec![HASH_BUILTIN_NAME],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),
@@ -768,7 +768,7 @@ mod tests {
         let mut vm = vm!();
 
         let program = program!(
-            builtins = vec![String::from(RANGE_CHECK_BUILTIN_NAME)],
+            builtins = vec![RANGE_CHECK_BUILTIN_NAME],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),
@@ -814,7 +814,7 @@ mod tests {
         let mut vm = vm!();
 
         let program = program!(
-            builtins = vec![String::from(KECCAK_BUILTIN_NAME)],
+            builtins = vec![KECCAK_BUILTIN_NAME],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -747,7 +747,7 @@ mod tests {
         let mut vm = vm!();
 
         let program = program!(
-            builtins = vec![String::from(signature::NAME)],
+            builtins = vec![String::from(hash::NAME)],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -313,13 +313,13 @@ impl BuiltinRunner {
 
     pub fn name(&self) -> &'static str {
         match self {
-            BuiltinRunner::Bitwise(_) => "bitwise",
-            BuiltinRunner::EcOp(_) => "ec_op",
-            BuiltinRunner::Hash(_) => "hash",
-            BuiltinRunner::RangeCheck(_) => "range_check",
-            BuiltinRunner::Output(_) => "output",
-            BuiltinRunner::Keccak(_) => "keccak",
-            BuiltinRunner::Signature(_) => "ecdsa",
+            BuiltinRunner::Bitwise(_) => bitwise::NAME,
+            BuiltinRunner::EcOp(_) => ec_op::NAME,
+            BuiltinRunner::Hash(_) => hash::NAME,
+            BuiltinRunner::RangeCheck(_) => range_check::NAME,
+            BuiltinRunner::Output(_) => output::NAME,
+            BuiltinRunner::Keccak(_) => keccak::NAME,
+            BuiltinRunner::Signature(_) => signature::NAME,
         }
     }
 
@@ -613,42 +613,42 @@ mod tests {
     fn get_name_bitwise() {
         let bitwise = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(10), true);
         let builtin: BuiltinRunner = bitwise.into();
-        assert_eq!("bitwise", builtin.name())
+        assert_eq!(bitwise::NAME, builtin.name())
     }
 
     #[test]
     fn get_name_hash() {
         let hash = HashBuiltinRunner::new(10, true);
         let builtin: BuiltinRunner = hash.into();
-        assert_eq!("hash", builtin.name())
+        assert_eq!(hash::NAME, builtin.name())
     }
 
     #[test]
     fn get_name_range_check() {
         let range_check = RangeCheckBuiltinRunner::new(10, 10, true);
         let builtin: BuiltinRunner = range_check.into();
-        assert_eq!("range_check", builtin.name())
+        assert_eq!(range_check::NAME, builtin.name())
     }
 
     #[test]
     fn get_name_ec_op() {
         let ec_op = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
         let builtin: BuiltinRunner = ec_op.into();
-        assert_eq!("ec_op", builtin.name())
+        assert_eq!(ec_op::NAME, builtin.name())
     }
 
     #[test]
     fn get_name_ecdsa() {
         let signature = SignatureBuiltinRunner::new(&EcdsaInstanceDef::new(10), true);
         let builtin: BuiltinRunner = signature.into();
-        assert_eq!("ecdsa", builtin.name())
+        assert_eq!(signature::NAME, builtin.name())
     }
 
     #[test]
     fn get_name_output() {
         let output = OutputBuiltinRunner::new(true);
         let builtin: BuiltinRunner = output.into();
-        assert_eq!("output", builtin.name())
+        assert_eq!(output::NAME, builtin.name())
     }
 
     #[test]
@@ -661,7 +661,7 @@ mod tests {
         let mut vm = vm!();
 
         let program = program!(
-            builtins = vec![String::from("bitwise")],
+            builtins = vec![String::from(bitwise::NAME)],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),
@@ -704,7 +704,7 @@ mod tests {
         let mut vm = vm!();
 
         let program = program!(
-            builtins = vec![String::from("ec_op")],
+            builtins = vec![String::from(ec_op::NAME)],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),
@@ -747,7 +747,7 @@ mod tests {
         let mut vm = vm!();
 
         let program = program!(
-            builtins = vec![String::from("pedersen")],
+            builtins = vec![String::from(signature::NAME)],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),
@@ -790,7 +790,7 @@ mod tests {
         let mut vm = vm!();
 
         let program = program!(
-            builtins = vec![String::from("range_check")],
+            builtins = vec![String::from(range_check::NAME)],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),
@@ -836,7 +836,7 @@ mod tests {
         let mut vm = vm!();
 
         let program = program!(
-            builtins = vec![String::from("keccak")],
+            builtins = vec![String::from(keccak::NAME)],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),
@@ -1099,7 +1099,7 @@ mod tests {
         assert_matches!(
             builtin.run_security_checks(&vm),
             Err(VirtualMachineError::MemoryError(
-                MemoryError::MissingMemoryCellsWithOffsets("bitwise", x)
+                MemoryError::MissingMemoryCellsWithOffsets(bitwise::NAME, x)
             )) if x == vec![0]
         );
     }
@@ -1127,7 +1127,7 @@ mod tests {
         assert_matches!(
             builtin.run_security_checks(&vm),
             Err(VirtualMachineError::MemoryError(
-                MemoryError::MissingMemoryCells("bitwise")
+                MemoryError::MissingMemoryCells(bitwise::NAME)
             ))
         );
     }
@@ -1148,7 +1148,7 @@ mod tests {
         assert_matches!(
             builtin.run_security_checks(&vm),
             Err(VirtualMachineError::MemoryError(
-                MemoryError::MissingMemoryCellsWithOffsets("hash", x)
+                MemoryError::MissingMemoryCellsWithOffsets(hash::NAME, x)
             )) if x == vec![0]
         );
     }
@@ -1166,7 +1166,7 @@ mod tests {
         assert_matches!(
             builtin.run_security_checks(&vm),
             Err(VirtualMachineError::MemoryError(
-                MemoryError::MissingMemoryCells("hash")
+                MemoryError::MissingMemoryCells(hash::NAME)
             ))
         );
     }
@@ -1191,7 +1191,7 @@ mod tests {
         assert_matches!(
             builtin.run_security_checks(&vm),
             Err(VirtualMachineError::MemoryError(
-                MemoryError::MissingMemoryCells("range_check")
+                MemoryError::MissingMemoryCells(range_check::NAME)
             ))
         );
     }
@@ -1207,7 +1207,7 @@ mod tests {
         assert_matches!(
             builtin.run_security_checks(&vm),
             Err(VirtualMachineError::MemoryError(
-                MemoryError::MissingMemoryCells("range_check")
+                MemoryError::MissingMemoryCells(range_check::NAME)
             ))
         );
     }
@@ -1273,7 +1273,7 @@ mod tests {
         assert_matches!(
             builtin.run_security_checks(&vm),
             Err(VirtualMachineError::MemoryError(
-                MemoryError::MissingMemoryCells("ec_op")
+                MemoryError::MissingMemoryCells(ec_op::NAME)
             ))
         );
     }
@@ -1295,7 +1295,7 @@ mod tests {
         assert_matches!(
             builtin.run_security_checks(&vm),
             Err(VirtualMachineError::MemoryError(
-                MemoryError::MissingMemoryCells("ec_op")
+                MemoryError::MissingMemoryCells(ec_op::NAME)
             ))
         );
     }
@@ -1319,7 +1319,7 @@ mod tests {
         assert_matches!(
             builtin.run_security_checks(&vm),
             Err(VirtualMachineError::MemoryError(
-                MemoryError::MissingMemoryCellsWithOffsets("ec_op", x)
+                MemoryError::MissingMemoryCellsWithOffsets(ec_op::NAME, x)
             )) if x == vec![0]
         );
     }
@@ -1350,7 +1350,7 @@ mod tests {
         assert_matches!(
             builtin.run_security_checks(&vm),
             Err(VirtualMachineError::MemoryError(
-                MemoryError::MissingMemoryCellsWithOffsets("ec_op", x)
+                MemoryError::MissingMemoryCellsWithOffsets(ec_op::NAME, x)
             )) if x == vec![7]
         );
     }

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -71,43 +71,24 @@ impl BuiltinRunner {
         }
     }
 
+    ///Returns the builtin's final stack
     pub fn final_stack(
         &mut self,
         segments: &MemorySegmentManager,
-        pointer: Relocatable,
+        stack_pointer: Relocatable,
     ) -> Result<Relocatable, RunnerError> {
-        if self.included() {
-            let stop_pointer_addr = pointer
-                .sub_usize(1)
-                .map_err(|_| RunnerError::NoStopPointer(self.name()))?;
-            let stop_pointer = segments
-                .memory
-                .get_relocatable(&stop_pointer_addr)
-                .map_err(|_| RunnerError::NoStopPointer(self.name()))?;
-            if self.base() != stop_pointer.segment_index {
-                return Err(RunnerError::InvalidStopPointerIndex(
-                    self.name(),
-                    stop_pointer,
-                    self.base(),
-                ));
+        match self {
+            BuiltinRunner::Bitwise(ref mut bitwise) => bitwise.final_stack(segments, stack_pointer),
+            BuiltinRunner::EcOp(ref mut ec) => ec.final_stack(segments, stack_pointer),
+            BuiltinRunner::Hash(ref mut hash) => hash.final_stack(segments, stack_pointer),
+            BuiltinRunner::Output(ref mut output) => output.final_stack(segments, stack_pointer),
+            BuiltinRunner::RangeCheck(ref mut range_check) => {
+                range_check.final_stack(segments, stack_pointer)
             }
-            let stop_ptr = stop_pointer.offset;
-            let used = self
-                .get_used_cells(segments)
-                .map_err(RunnerError::MemoryError)?;
-            if stop_ptr != used {
-                return Err(RunnerError::InvalidStopPointer(
-                    self.name(),
-                    Relocatable::from((self.base(), used)),
-                    Relocatable::from((self.base(), stop_ptr)),
-                ));
+            BuiltinRunner::Keccak(ref mut keccak) => keccak.final_stack(segments, stack_pointer),
+            BuiltinRunner::Signature(ref mut signature) => {
+                signature.final_stack(segments, stack_pointer)
             }
-            self.set_stop_ptr(stop_ptr);
-            Ok(stop_pointer_addr)
-        } else {
-            let stop_ptr = self.base() as usize;
-            self.set_stop_ptr(stop_ptr);
-            Ok(pointer)
         }
     }
 
@@ -139,18 +120,6 @@ impl BuiltinRunner {
             BuiltinRunner::RangeCheck(ref range_check) => range_check.base(),
             BuiltinRunner::Keccak(ref keccak) => keccak.base(),
             BuiltinRunner::Signature(ref signature) => signature.base(),
-        }
-    }
-
-    pub fn included(&self) -> bool {
-        match *self {
-            BuiltinRunner::Bitwise(ref bitwise) => bitwise.included,
-            BuiltinRunner::EcOp(ref ec) => ec.included,
-            BuiltinRunner::Hash(ref hash) => hash.included,
-            BuiltinRunner::Output(ref output) => output.included,
-            BuiltinRunner::RangeCheck(ref range_check) => range_check.included,
-            BuiltinRunner::Keccak(ref keccak) => keccak.included,
-            BuiltinRunner::Signature(ref signature) => signature.included,
         }
     }
 

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -374,6 +374,7 @@ impl BuiltinRunner {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn set_stop_ptr(&mut self, stop_ptr: usize) {
         match self {
             BuiltinRunner::Bitwise(ref mut bitwise) => bitwise.stop_ptr = Some(stop_ptr),

--- a/src/vm/runners/builtin_runner/output.rs
+++ b/src/vm/runners/builtin_runner/output.rs
@@ -157,8 +157,8 @@ mod tests {
             builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::InvalidStopPointer(
                 "output",
-                relocatable!(0, 0),
-                relocatable!(0, 999)
+                relocatable!(0, 999),
+                relocatable!(0, 0)
             ))
         );
     }

--- a/src/vm/runners/builtin_runner/output.rs
+++ b/src/vm/runners/builtin_runner/output.rs
@@ -191,7 +191,7 @@ mod tests {
             ((2, 1), (0, 0))
         ];
 
-        vm.segments.segment_used_sizes = Some(vec![999]);
+        vm.segments.segment_used_sizes = Some(vec![998]);
 
         let pointer = Relocatable::from((2, 2));
 
@@ -199,7 +199,7 @@ mod tests {
             builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::InvalidStopPointer(
                 NAME,
-                relocatable!(0, 999),
+                relocatable!(0, 998),
                 relocatable!(0, 0)
             ))
         );

--- a/src/vm/runners/builtin_runner/output.rs
+++ b/src/vm/runners/builtin_runner/output.rs
@@ -5,6 +5,8 @@ use crate::vm::vm_core::VirtualMachine;
 use crate::vm::vm_memory::memory::Memory;
 use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
 
+pub(crate) const NAME: &'static str = "output";
+
 #[derive(Debug, Clone)]
 pub struct OutputBuiltinRunner {
     base: isize,
@@ -156,7 +158,7 @@ mod tests {
         assert_eq!(
             builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::InvalidStopPointer(
-                "output",
+                NAME,
                 relocatable!(0, 999),
                 relocatable!(0, 0)
             ))
@@ -205,7 +207,7 @@ mod tests {
 
         assert_eq!(
             builtin.final_stack(&vm.segments, pointer),
-            Err(RunnerError::NoStopPointer("output"))
+            Err(RunnerError::NoStopPointer(NAME))
         );
     }
 

--- a/src/vm/runners/builtin_runner/output.rs
+++ b/src/vm/runners/builtin_runner/output.rs
@@ -5,7 +5,7 @@ use crate::vm::vm_core::VirtualMachine;
 use crate::vm::vm_memory::memory::Memory;
 use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
 
-pub(crate) const NAME: &'static str = "output";
+pub(crate) const NAME: &str = "output";
 
 #[derive(Debug, Clone)]
 pub struct OutputBuiltinRunner {

--- a/src/vm/runners/builtin_runner/output.rs
+++ b/src/vm/runners/builtin_runner/output.rs
@@ -5,7 +5,7 @@ use crate::vm::vm_core::VirtualMachine;
 use crate::vm::vm_memory::memory::Memory;
 use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
 
-pub(crate) const NAME: &str = "output";
+use super::OUTPUT_BUILTIN_NAME;
 
 #[derive(Debug, Clone)]
 pub struct OutputBuiltinRunner {
@@ -92,14 +92,14 @@ impl OutputBuiltinRunner {
         if self.included {
             let stop_pointer_addr = pointer
                 .sub_usize(1)
-                .map_err(|_| RunnerError::NoStopPointer(NAME))?;
+                .map_err(|_| RunnerError::NoStopPointer(OUTPUT_BUILTIN_NAME))?;
             let stop_pointer = segments
                 .memory
                 .get_relocatable(&stop_pointer_addr)
-                .map_err(|_| RunnerError::NoStopPointer(NAME))?;
+                .map_err(|_| RunnerError::NoStopPointer(OUTPUT_BUILTIN_NAME))?;
             if self.base != stop_pointer.segment_index {
                 return Err(RunnerError::InvalidStopPointerIndex(
-                    NAME,
+                    OUTPUT_BUILTIN_NAME,
                     stop_pointer,
                     self.base,
                 ));
@@ -110,7 +110,7 @@ impl OutputBuiltinRunner {
                 .map_err(RunnerError::MemoryError)?;
             if stop_ptr != used {
                 return Err(RunnerError::InvalidStopPointer(
-                    NAME,
+                    OUTPUT_BUILTIN_NAME,
                     Relocatable::from((self.base, used)),
                     Relocatable::from((self.base, stop_ptr)),
                 ));
@@ -198,7 +198,7 @@ mod tests {
         assert_eq!(
             builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::InvalidStopPointer(
-                NAME,
+                OUTPUT_BUILTIN_NAME,
                 relocatable!(0, 998),
                 relocatable!(0, 0)
             ))
@@ -247,7 +247,7 @@ mod tests {
 
         assert_eq!(
             builtin.final_stack(&vm.segments, pointer),
-            Err(RunnerError::NoStopPointer(NAME))
+            Err(RunnerError::NoStopPointer(OUTPUT_BUILTIN_NAME))
         );
     }
 

--- a/src/vm/runners/builtin_runner/output.rs
+++ b/src/vm/runners/builtin_runner/output.rs
@@ -157,8 +157,8 @@ mod tests {
             builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::InvalidStopPointer(
                 "output",
-                relocatable!(0, 999),
-                relocatable!(0, 0)
+                relocatable!(0, 0),
+                relocatable!(0, 999)
             ))
         );
     }

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -279,8 +279,8 @@ mod tests {
             builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::InvalidStopPointer(
                 "range_check",
-                relocatable!(0, 0),
-                relocatable!(0, 999)
+                relocatable!(0, 999),
+                relocatable!(0, 0)
             ))
         );
     }

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -220,9 +220,8 @@ impl RangeCheckBuiltinRunner {
                 ));
             }
             let stop_ptr = stop_pointer.offset;
-            let used = self
-                .get_used_cells(segments)
-                .map_err(RunnerError::MemoryError)?;
+            let num_instances = self.get_used_instances(segments)?;
+            let used = num_instances * self.cells_per_instance as usize;
             if stop_ptr != used {
                 return Err(RunnerError::InvalidStopPointer(
                     NAME,

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -388,7 +388,7 @@ mod tests {
         vm.segments.segment_used_sizes = Some(vec![0]);
 
         let program = program!(
-            builtins = vec![String::from(RANGE_CHECK_BUILTIN_NAME)],
+            builtins = vec![RANGE_CHECK_BUILTIN_NAME],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),
@@ -431,7 +431,7 @@ mod tests {
         let mut vm = vm!();
 
         let program = program!(
-            builtins = vec![String::from(RANGE_CHECK_BUILTIN_NAME)],
+            builtins = vec![RANGE_CHECK_BUILTIN_NAME],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -310,7 +310,7 @@ mod tests {
             ((2, 1), (0, 0))
         ];
 
-        vm.segments.segment_used_sizes = Some(vec![999]);
+        vm.segments.segment_used_sizes = Some(vec![998]);
 
         let pointer = Relocatable::from((2, 2));
 
@@ -318,7 +318,7 @@ mod tests {
             builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::InvalidStopPointer(
                 NAME,
-                relocatable!(0, 999),
+                relocatable!(0, 998),
                 relocatable!(0, 0)
             ))
         );

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -270,8 +270,8 @@ mod tests {
             builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::InvalidStopPointer(
                 "range_check",
-                relocatable!(0, 999),
-                relocatable!(0, 0)
+                relocatable!(0, 0),
+                relocatable!(0, 999)
             ))
         );
     }

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -24,7 +24,7 @@ use std::{
     ops::Shl,
 };
 
-pub(crate) const NAME: &'static str = "range_check";
+pub(crate) const NAME: &str = "range_check";
 
 #[derive(Debug, Clone)]
 pub struct RangeCheckBuiltinRunner {

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -278,7 +278,7 @@ mod tests {
         assert_eq!(
             builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::InvalidStopPointer(
-                "range_check",
+                NAME,
                 relocatable!(0, 999),
                 relocatable!(0, 0)
             ))
@@ -327,7 +327,7 @@ mod tests {
 
         assert_eq!(
             builtin.final_stack(&vm.segments, pointer),
-            Err(RunnerError::NoStopPointer("range_check"))
+            Err(RunnerError::NoStopPointer(NAME))
         );
     }
 
@@ -340,7 +340,7 @@ mod tests {
         vm.segments.segment_used_sizes = Some(vec![0]);
 
         let program = program!(
-            builtins = vec![String::from("pedersen")],
+            builtins = vec![String::from(NAME)],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),
@@ -383,7 +383,7 @@ mod tests {
         let mut vm = vm!();
 
         let program = program!(
-            builtins = vec![String::from("pedersen")],
+            builtins = vec![String::from(NAME)],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -5,7 +5,10 @@ use crate::{
         relocatable::{MaybeRelocatable, Relocatable},
     },
     vm::{
-        errors::{memory_errors::MemoryError, runner_errors::RunnerError},
+        errors::{
+            memory_errors::{InsufficientAllocatedCellsError, MemoryError},
+            runner_errors::RunnerError,
+        },
         vm_core::VirtualMachine,
         vm_memory::{
             memory::{Memory, ValidationRule},
@@ -144,17 +147,19 @@ impl RangeCheckBuiltinRunner {
         let ratio = self.ratio as usize;
         let min_step = ratio * self.instances_per_component as usize;
         if vm.current_step < min_step {
-            Err(MemoryError::InsufficientAllocatedCellsMinStepNotReached(
-                min_step, NAME,
-            ))
+            Err(InsufficientAllocatedCellsError::MinStepNotReached(min_step, NAME).into())
         } else {
             let used = self.get_used_cells(&vm.segments)?;
             let size = self.cells_per_instance as usize
                 * safe_div_usize(vm.current_step, ratio).map_err(|_| {
-                    MemoryError::CurrentStepNotDivisibleByBuiltinRatio(NAME, vm.current_step, ratio)
+                    InsufficientAllocatedCellsError::CurrentStepNotDivisibleByBuiltinRatio(
+                        NAME,
+                        vm.current_step,
+                        ratio,
+                    )
                 })?;
             if used > size {
-                return Err(MemoryError::InsufficientAllocatedCells(NAME, used, size));
+                return Err(InsufficientAllocatedCellsError::BuiltinCells(NAME, used, size).into());
             }
             Ok((used, size))
         }

--- a/src/vm/runners/builtin_runner/signature.rs
+++ b/src/vm/runners/builtin_runner/signature.rs
@@ -240,9 +240,8 @@ impl SignatureBuiltinRunner {
                 ));
             }
             let stop_ptr = stop_pointer.offset;
-            let used = self
-                .get_used_cells(segments)
-                .map_err(RunnerError::MemoryError)?;
+            let num_instances = self.get_used_instances(segments)?;
+            let used = num_instances * self.cells_per_instance as usize;
             if stop_ptr != used {
                 return Err(RunnerError::InvalidStopPointer(
                     NAME,

--- a/src/vm/runners/builtin_runner/signature.rs
+++ b/src/vm/runners/builtin_runner/signature.rs
@@ -22,7 +22,7 @@ use num_traits::ToPrimitive;
 use starknet_crypto::{verify, FieldElement, Signature};
 use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
-pub(crate) const NAME: &'static str = "ecdsa";
+pub(crate) const NAME: &'static str = "ecda";
 
 #[derive(Debug, Clone)]
 pub struct SignatureBuiltinRunner {
@@ -322,7 +322,7 @@ mod tests {
         assert_eq!(
             builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::InvalidStopPointer(
-                "signature",
+                NAME,
                 relocatable!(0, 999),
                 relocatable!(0, 0)
             ))
@@ -349,7 +349,7 @@ mod tests {
 
         assert_eq!(
             builtin.final_stack(&vm.segments, pointer),
-            Err(RunnerError::NoStopPointer("ecdsa"))
+            Err(RunnerError::NoStopPointer(NAME))
         );
     }
 
@@ -549,7 +549,7 @@ mod tests {
         assert_eq!(
             builtin.final_stack(&vm.segments, (0, 1).into()),
             Err(RunnerError::InvalidStopPointerIndex(
-                "ecdsa",
+                NAME,
                 relocatable!(1, 0),
                 0
             ))

--- a/src/vm/runners/builtin_runner/signature.rs
+++ b/src/vm/runners/builtin_runner/signature.rs
@@ -22,7 +22,7 @@ use num_traits::ToPrimitive;
 use starknet_crypto::{verify, FieldElement, Signature};
 use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
-pub(crate) const NAME: &'static str = "ecdsa";
+pub(crate) const NAME: &str = "ecdsa";
 
 #[derive(Debug, Clone)]
 pub struct SignatureBuiltinRunner {

--- a/src/vm/runners/builtin_runner/signature.rs
+++ b/src/vm/runners/builtin_runner/signature.rs
@@ -22,7 +22,7 @@ use num_traits::ToPrimitive;
 use starknet_crypto::{verify, FieldElement, Signature};
 use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
-pub(crate) const NAME: &'static str = "ecda";
+pub(crate) const NAME: &'static str = "ecdsa";
 
 #[derive(Debug, Clone)]
 pub struct SignatureBuiltinRunner {
@@ -191,7 +191,6 @@ impl SignatureBuiltinRunner {
     ) -> Result<(usize, usize), MemoryError> {
         let ratio = self.ratio as usize;
         let min_step = ratio * self.instances_per_component as usize;
-        dbg!(min_step);
         if vm.current_step < min_step {
             Err(InsufficientAllocatedCellsError::MinStepNotReached(min_step, NAME).into())
         } else {
@@ -352,7 +351,7 @@ mod tests {
             ((2, 1), (0, 0))
         ];
 
-        vm.segments.segment_used_sizes = Some(vec![999]);
+        vm.segments.segment_used_sizes = Some(vec![998]);
 
         let pointer = Relocatable::from((2, 2));
 
@@ -360,7 +359,7 @@ mod tests {
             builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::InvalidStopPointer(
                 NAME,
-                relocatable!(0, 999),
+                relocatable!(0, 998),
                 relocatable!(0, 0)
             ))
         );

--- a/src/vm/runners/builtin_runner/signature.rs
+++ b/src/vm/runners/builtin_runner/signature.rs
@@ -322,9 +322,9 @@ mod tests {
         assert_eq!(
             builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::InvalidStopPointer(
-                "range_check",
-                relocatable!(0, 0),
-                relocatable!(0, 999)
+                "signature",
+                relocatable!(0, 999),
+                relocatable!(0, 0)
             ))
         );
     }

--- a/src/vm/runners/builtin_runner/signature.rs
+++ b/src/vm/runners/builtin_runner/signature.rs
@@ -311,8 +311,8 @@ mod tests {
             builtin.final_stack(&vm.segments, pointer),
             Err(RunnerError::InvalidStopPointer(
                 "range_check",
-                relocatable!(0, 999),
-                relocatable!(0, 0)
+                relocatable!(0, 0),
+                relocatable!(0, 999)
             ))
         );
     }

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -626,7 +626,11 @@ impl CairoRunner {
         let unused_rc_units =
             (self.layout.rc_units as usize - 3) * vm.current_step - rc_units_used_by_builtins;
         if unused_rc_units < (rc_max - rc_min) as usize {
-            return Err(MemoryError::InsufficientAllocatedCells.into());
+            return Err(RunnerError::InsufficientRangeCheckUnits(
+                unused_rc_units,
+                (rc_max - rc_min) as usize,
+            )
+            .into());
         }
 
         Ok(())

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -101,7 +101,7 @@ impl CairoRunner {
             "small" => CairoLayout::small_instance(),
             "dex" => CairoLayout::dex_instance(),
             "perpetual_with_bitwise" => CairoLayout::perpetual_with_bitwise_instance(),
-            BITWISE_BUILTIN_NAME => CairoLayout::bitwise_instance(),
+            "bitwise" => CairoLayout::bitwise_instance(),
             "recursive" => CairoLayout::recursive_instance(),
             "all" => CairoLayout::all_instance(),
             name => return Err(RunnerError::InvalidLayoutName(name.to_string())),

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -47,7 +47,10 @@ use std::{
     ops::{Add, Sub},
 };
 
-use super::builtin_runner::KeccakBuiltinRunner;
+use super::builtin_runner::{
+    KeccakBuiltinRunner, BITWISE_BUILTIN_NAME, EC_OP_BUILTIN_NAME, HASH_BUILTIN_NAME,
+    KECCAK_BUILTIN_NAME, OUTPUT_BUILTIN_NAME, RANGE_CHECK_BUILTIN_NAME, SIGNATURE_BUILTIN_NAME,
+};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum CairoArg {
@@ -98,7 +101,7 @@ impl CairoRunner {
             "small" => CairoLayout::small_instance(),
             "dex" => CairoLayout::dex_instance(),
             "perpetual_with_bitwise" => CairoLayout::perpetual_with_bitwise_instance(),
-            "bitwise" => CairoLayout::bitwise_instance(),
+            BITWISE_BUILTIN_NAME => CairoLayout::bitwise_instance(),
             "recursive" => CairoLayout::recursive_instance(),
             "all" => CairoLayout::all_instance(),
             name => return Err(RunnerError::InvalidLayoutName(name.to_string())),
@@ -133,13 +136,13 @@ impl CairoRunner {
 
     pub fn initialize_builtins(&self, vm: &mut VirtualMachine) -> Result<(), RunnerError> {
         let builtin_ordered_list = vec![
-            String::from("output"),
-            String::from("pedersen"),
-            String::from("range_check"),
-            String::from("ecdsa"),
-            String::from("bitwise"),
-            String::from("ec_op"),
-            String::from("keccak"),
+            String::from(OUTPUT_BUILTIN_NAME),
+            String::from(HASH_BUILTIN_NAME),
+            String::from(RANGE_CHECK_BUILTIN_NAME),
+            String::from(SIGNATURE_BUILTIN_NAME),
+            String::from(BITWISE_BUILTIN_NAME),
+            String::from(EC_OP_BUILTIN_NAME),
+            String::from(KECCAK_BUILTIN_NAME),
         ];
         if !is_subsequence(&self.program.builtins, &builtin_ordered_list) {
             return Err(RunnerError::DisorderedBuiltins);
@@ -147,30 +150,39 @@ impl CairoRunner {
         let mut builtin_runners = Vec::<(String, BuiltinRunner)>::new();
 
         if self.layout.builtins._output {
-            let included = self.program.builtins.contains(&"output".to_string());
+            let included = self
+                .program
+                .builtins
+                .contains(&OUTPUT_BUILTIN_NAME.to_string());
             if included || self.proof_mode {
                 builtin_runners.push((
-                    "output".to_string(),
+                    OUTPUT_BUILTIN_NAME.to_string(),
                     OutputBuiltinRunner::new(included).into(),
                 ));
             }
         }
 
         if let Some(instance_def) = self.layout.builtins.pedersen.as_ref() {
-            let included = self.program.builtins.contains(&"pedersen".to_string());
+            let included = self
+                .program
+                .builtins
+                .contains(&HASH_BUILTIN_NAME.to_string());
             if included || self.proof_mode {
                 builtin_runners.push((
-                    "pedersen".to_string(),
+                    HASH_BUILTIN_NAME.to_string(),
                     HashBuiltinRunner::new(instance_def.ratio, included).into(),
                 ));
             }
         }
 
         if let Some(instance_def) = self.layout.builtins.range_check.as_ref() {
-            let included = self.program.builtins.contains(&"range_check".to_string());
+            let included = self
+                .program
+                .builtins
+                .contains(&RANGE_CHECK_BUILTIN_NAME.to_string());
             if included || self.proof_mode {
                 builtin_runners.push((
-                    "range_check".to_string(),
+                    RANGE_CHECK_BUILTIN_NAME.to_string(),
                     RangeCheckBuiltinRunner::new(
                         instance_def.ratio,
                         instance_def.n_parts,
@@ -182,40 +194,52 @@ impl CairoRunner {
         }
 
         if let Some(instance_def) = self.layout.builtins._ecdsa.as_ref() {
-            let included = self.program.builtins.contains(&"ecdsa".to_string());
+            let included = self
+                .program
+                .builtins
+                .contains(&SIGNATURE_BUILTIN_NAME.to_string());
             if included || self.proof_mode {
                 builtin_runners.push((
-                    "ecdsa".to_string(),
+                    SIGNATURE_BUILTIN_NAME.to_string(),
                     SignatureBuiltinRunner::new(instance_def, included).into(),
                 ));
             }
         }
 
         if let Some(instance_def) = self.layout.builtins.bitwise.as_ref() {
-            let included = self.program.builtins.contains(&"bitwise".to_string());
+            let included = self
+                .program
+                .builtins
+                .contains(&BITWISE_BUILTIN_NAME.to_string());
             if included || self.proof_mode {
                 builtin_runners.push((
-                    "bitwise".to_string(),
+                    BITWISE_BUILTIN_NAME.to_string(),
                     BitwiseBuiltinRunner::new(instance_def, included).into(),
                 ));
             }
         }
 
         if let Some(instance_def) = self.layout.builtins.ec_op.as_ref() {
-            let included = self.program.builtins.contains(&"ec_op".to_string());
+            let included = self
+                .program
+                .builtins
+                .contains(&EC_OP_BUILTIN_NAME.to_string());
             if included || self.proof_mode {
                 builtin_runners.push((
-                    "ec_op".to_string(),
+                    EC_OP_BUILTIN_NAME.to_string(),
                     EcOpBuiltinRunner::new(instance_def, included).into(),
                 ));
             }
         }
 
         if let Some(instance_def) = self.layout.builtins.keccak.as_ref() {
-            let included = self.program.builtins.contains(&"keccak".to_string());
+            let included = self
+                .program
+                .builtins
+                .contains(&KECCAK_BUILTIN_NAME.to_string());
             if included || self.proof_mode {
                 builtin_runners.push((
-                    "keccak".to_string(),
+                    KECCAK_BUILTIN_NAME.to_string(),
                     KeccakBuiltinRunner::new(instance_def, included).into(),
                 ));
             }
@@ -246,40 +270,40 @@ impl CairoRunner {
     // Values extracted from here: https://github.com/starkware-libs/cairo-lang/blob/4fb83010ab77aa7ead0c9df4b0c05e030bc70b87/src/starkware/cairo/common/cairo_function_runner.py#L28
     fn initialize_all_builtins(&self, vm: &mut VirtualMachine) -> Result<(), RunnerError> {
         let starknet_preset_builtins = vec![
-            String::from("pedersen"),
-            String::from("range_check"),
-            String::from("output"),
-            String::from("ecdsa"),
-            String::from("bitwise"),
-            String::from("ec_op"),
-            String::from("keccak"),
+            String::from(HASH_BUILTIN_NAME),
+            String::from(RANGE_CHECK_BUILTIN_NAME),
+            String::from(OUTPUT_BUILTIN_NAME),
+            String::from(SIGNATURE_BUILTIN_NAME),
+            String::from(BITWISE_BUILTIN_NAME),
+            String::from(EC_OP_BUILTIN_NAME),
+            String::from(KECCAK_BUILTIN_NAME),
         ];
 
         fn initialize_builtin(name: &str, vm: &mut VirtualMachine) {
             match name {
-                "pedersen" => vm
+                HASH_BUILTIN_NAME => vm
                     .builtin_runners
                     .push((name.to_string(), HashBuiltinRunner::new(32, true).into())),
-                "range_check" => vm.builtin_runners.push((
+                RANGE_CHECK_BUILTIN_NAME => vm.builtin_runners.push((
                     name.to_string(),
                     RangeCheckBuiltinRunner::new(1, 8, true).into(),
                 )),
-                "output" => vm
+                OUTPUT_BUILTIN_NAME => vm
                     .builtin_runners
                     .push((name.to_string(), OutputBuiltinRunner::new(true).into())),
-                "ecdsa" => vm.builtin_runners.push((
+                SIGNATURE_BUILTIN_NAME => vm.builtin_runners.push((
                     name.to_string(),
                     SignatureBuiltinRunner::new(&EcdsaInstanceDef::new(1), true).into(),
                 )),
-                "bitwise" => vm.builtin_runners.push((
+                BITWISE_BUILTIN_NAME => vm.builtin_runners.push((
                     name.to_string(),
                     BitwiseBuiltinRunner::new(&BitwiseInstanceDef::new(1), true).into(),
                 )),
-                "ec_op" => vm.builtin_runners.push((
+                EC_OP_BUILTIN_NAME => vm.builtin_runners.push((
                     name.to_string(),
                     EcOpBuiltinRunner::new(&EcOpInstanceDef::new(1), true).into(),
                 )),
-                "keccak" => vm.builtin_runners.push((
+                KECCAK_BUILTIN_NAME => vm.builtin_runners.push((
                     name.to_string(),
                     EcOpBuiltinRunner::new(&EcOpInstanceDef::new(1), true).into(),
                 )),
@@ -889,7 +913,7 @@ impl CairoRunner {
             .builtin_runners
             .iter_mut()
             .find_map(|(k, v)| match k.as_str() {
-                "output" => Some(v),
+                OUTPUT_BUILTIN_NAME => Some(v),
                 _ => None,
             });
         let builtin = match builtin {
@@ -1261,7 +1285,7 @@ mod tests {
     #[test]
     fn check_memory_usage_ok_case() {
         //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
-        let program = program!["range_check", "output"];
+        let program = program![RANGE_CHECK_BUILTIN_NAME, OUTPUT_BUILTIN_NAME];
         let cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         vm.segments.segment_used_sizes = Some(vec![4]);
@@ -1281,7 +1305,7 @@ mod tests {
             let mut builtin_runner: BuiltinRunner = OutputBuiltinRunner::new(true).into();
             builtin_runner.initialize_segments(&mut vm.segments);
 
-            ("output".to_string(), builtin_runner)
+            (OUTPUT_BUILTIN_NAME.to_string(), builtin_runner)
         }];
         vm.segments.segment_used_sizes = Some(vec![4, 12]);
         assert_matches!(
@@ -1295,7 +1319,7 @@ mod tests {
     #[test]
     fn initialize_builtins_with_disordered_builtins() {
         //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
-        let program = program!["range_check", "output"];
+        let program = program![RANGE_CHECK_BUILTIN_NAME, OUTPUT_BUILTIN_NAME];
         let cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         assert!(cairo_runner.initialize_builtins(&mut vm).is_err());
@@ -1304,7 +1328,7 @@ mod tests {
     #[test]
     fn create_cairo_runner_with_ordered_but_missing_builtins() {
         //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
-        let program = program!["output", "ecdsa"];
+        let program = program![OUTPUT_BUILTIN_NAME, SIGNATURE_BUILTIN_NAME];
         //We only check that the creation doesnt panic
         let _cairo_runner = cairo_runner!(program);
     }
@@ -1312,7 +1336,7 @@ mod tests {
     #[test]
     fn initialize_segments_with_base() {
         //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
-        let program = program!["output"];
+        let program = program![OUTPUT_BUILTIN_NAME];
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         let program_base = Some(Relocatable {
@@ -1336,7 +1360,7 @@ mod tests {
                 offset: 0,
             })
         );
-        assert_eq!(vm.builtin_runners[0].0, String::from("output"));
+        assert_eq!(vm.builtin_runners[0].0, String::from(OUTPUT_BUILTIN_NAME));
         assert_eq!(vm.builtin_runners[0].1.base(), 7);
 
         assert_eq!(vm.segments.num_segments(), 8);
@@ -1345,7 +1369,7 @@ mod tests {
     #[test]
     fn initialize_segments_no_base() {
         //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
-        let program = program!["output"];
+        let program = program![OUTPUT_BUILTIN_NAME];
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         cairo_runner.initialize_builtins(&mut vm).unwrap();
@@ -1364,7 +1388,7 @@ mod tests {
                 offset: 0
             })
         );
-        assert_eq!(vm.builtin_runners[0].0, String::from("output"));
+        assert_eq!(vm.builtin_runners[0].0, String::from(OUTPUT_BUILTIN_NAME));
         assert_eq!(vm.builtin_runners[0].1.base(), 2);
 
         assert_eq!(vm.segments.num_segments(), 3);
@@ -1373,7 +1397,7 @@ mod tests {
     #[test]
     fn initialize_state_empty_data_and_stack() {
         //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
-        let program = program!["output"];
+        let program = program![OUTPUT_BUILTIN_NAME];
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         cairo_runner.program_base = Some(relocatable!(1, 0));
@@ -1394,7 +1418,7 @@ mod tests {
     fn initialize_state_some_data_empty_stack() {
         //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
         let program = program!(
-            builtins = vec![String::from("output")],
+            builtins = vec![String::from(OUTPUT_BUILTIN_NAME)],
             data = vec_data!((4), (6)),
         );
         let mut cairo_runner = cairo_runner!(program);
@@ -1415,7 +1439,7 @@ mod tests {
     #[test]
     fn initialize_state_empty_data_some_stack() {
         //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
-        let program = program!["output"];
+        let program = program![OUTPUT_BUILTIN_NAME];
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         for _ in 0..3 {
@@ -1431,7 +1455,7 @@ mod tests {
     #[test]
     fn initialize_state_no_program_base() {
         //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
-        let program = program!["output"];
+        let program = program![OUTPUT_BUILTIN_NAME];
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         for _ in 0..2 {
@@ -1452,7 +1476,7 @@ mod tests {
     #[should_panic]
     fn initialize_state_no_execution_base() {
         //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
-        let program = program!["output"];
+        let program = program![OUTPUT_BUILTIN_NAME];
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         for _ in 0..2 {
@@ -1469,7 +1493,7 @@ mod tests {
     #[test]
     fn initialize_function_entrypoint_empty_stack() {
         //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
-        let program = program!["output"];
+        let program = program![OUTPUT_BUILTIN_NAME];
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         for _ in 0..2 {
@@ -1490,7 +1514,7 @@ mod tests {
     #[test]
     fn initialize_function_entrypoint_some_stack() {
         //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
-        let program = program!["output"];
+        let program = program![OUTPUT_BUILTIN_NAME];
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         for _ in 0..2 {
@@ -1517,7 +1541,7 @@ mod tests {
     #[should_panic]
     fn initialize_function_entrypoint_no_execution_base() {
         //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
-        let program = program!["output"];
+        let program = program![OUTPUT_BUILTIN_NAME];
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         let stack = vec![MaybeRelocatable::from(Felt::new(7_i32))];
@@ -1531,7 +1555,7 @@ mod tests {
     #[should_panic]
     fn initialize_main_entrypoint_no_main() {
         //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
-        let program = program!["output"];
+        let program = program![OUTPUT_BUILTIN_NAME];
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         cairo_runner.initialize_main_entrypoint(&mut vm).unwrap();
@@ -1604,7 +1628,10 @@ mod tests {
     #[test]
     fn initialize_vm_with_range_check_valid() {
         //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
-        let program = program!(builtins = vec![String::from("range_check")], main = Some(1),);
+        let program = program!(
+            builtins = vec![String::from(RANGE_CHECK_BUILTIN_NAME)],
+            main = Some(1),
+        );
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         cairo_runner.initial_pc = Some(relocatable!(0, 1));
@@ -1613,7 +1640,10 @@ mod tests {
         cairo_runner.initialize_builtins(&mut vm).unwrap();
         cairo_runner.initialize_segments(&mut vm, None);
         vm.segments = segments![((2, 0), 23), ((2, 1), 233)];
-        assert_eq!(vm.builtin_runners[0].0, String::from("range_check"));
+        assert_eq!(
+            vm.builtin_runners[0].0,
+            String::from(RANGE_CHECK_BUILTIN_NAME)
+        );
         assert_eq!(vm.builtin_runners[0].1.base(), 2);
         cairo_runner.initialize_vm(&mut vm).unwrap();
         assert!(vm
@@ -1632,7 +1662,10 @@ mod tests {
     #[test]
     fn initialize_vm_with_range_check_invalid() {
         //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
-        let program = program!(builtins = vec![String::from("range_check")], main = Some(1),);
+        let program = program!(
+            builtins = vec![String::from(RANGE_CHECK_BUILTIN_NAME)],
+            main = Some(1),
+        );
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         cairo_runner.initial_pc = Some(relocatable!(0, 1));
@@ -1737,7 +1770,7 @@ mod tests {
     */
     fn initialization_phase_output_builtin() {
         let program = program!(
-            builtins = vec![String::from("output")],
+            builtins = vec![String::from(OUTPUT_BUILTIN_NAME)],
             data = vec_data!(
                 (4612671182993129469_u64),
                 (5198983563776393216_u64),
@@ -1820,7 +1853,7 @@ mod tests {
     */
     fn initialization_phase_range_check_builtin() {
         let program = program!(
-            builtins = vec![String::from("range_check")],
+            builtins = vec![String::from(RANGE_CHECK_BUILTIN_NAME)],
             data = vec_data!(
                 (4612671182993129469_u64),
                 (5189976364521848832_u64),
@@ -1984,7 +2017,7 @@ mod tests {
     fn initialize_and_run_range_check_builtin() {
         //Initialization Phase
         let program = program!(
-            builtins = vec![String::from("range_check")],
+            builtins = vec![String::from(RANGE_CHECK_BUILTIN_NAME)],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),
@@ -2045,7 +2078,10 @@ mod tests {
             ]
         );
         //Check the range_check builtin segment
-        assert_eq!(vm.builtin_runners[0].0, String::from("range_check"));
+        assert_eq!(
+            vm.builtin_runners[0].0,
+            String::from(RANGE_CHECK_BUILTIN_NAME)
+        );
         assert_eq!(vm.builtin_runners[0].1.base(), 2);
 
         check_memory!(
@@ -2094,7 +2130,7 @@ mod tests {
     fn initialize_and_run_output_builtin() {
         //Initialization Phase
         let program = program!(
-            builtins = vec![String::from("output")],
+            builtins = vec![String::from(OUTPUT_BUILTIN_NAME)],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5198983563776393216_i64),
@@ -2161,7 +2197,7 @@ mod tests {
             ]
         );
         //Check that the output to be printed is correct
-        assert_eq!(vm.builtin_runners[0].0, String::from("output"));
+        assert_eq!(vm.builtin_runners[0].0, String::from(OUTPUT_BUILTIN_NAME));
         assert_eq!(vm.builtin_runners[0].1.base(), 2);
         check_memory!(vm.segments.memory, ((2, 0), 1), ((2, 1), 17));
         assert_eq!(
@@ -2221,7 +2257,10 @@ mod tests {
     fn initialize_and_run_output_range_check_builtin() {
         //Initialization Phase
         let program = program!(
-            builtins = vec![String::from("output"), String::from("range_check")],
+            builtins = vec![
+                String::from(OUTPUT_BUILTIN_NAME),
+                String::from(RANGE_CHECK_BUILTIN_NAME)
+            ],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5198983563776393216_i64),
@@ -2303,7 +2342,10 @@ mod tests {
             ]
         );
         //Check the range_check builtin segment
-        assert_eq!(vm.builtin_runners[1].0, String::from("range_check"));
+        assert_eq!(
+            vm.builtin_runners[1].0,
+            String::from(RANGE_CHECK_BUILTIN_NAME)
+        );
         assert_eq!(vm.builtin_runners[1].1.base(), 3);
 
         check_memory!(
@@ -2320,7 +2362,7 @@ mod tests {
         );
 
         //Check the output segment
-        assert_eq!(vm.builtin_runners[0].0, String::from("output"));
+        assert_eq!(vm.builtin_runners[0].0, String::from(OUTPUT_BUILTIN_NAME));
         assert_eq!(vm.builtin_runners[0].1.base(), 2);
 
         check_memory!(vm.segments.memory, ((2, 0), 7));
@@ -2477,7 +2519,7 @@ mod tests {
      */
     fn initialize_run_and_relocate_output_builtin() {
         let program = program!(
-            builtins = vec![String::from("output")],
+            builtins = vec![String::from(OUTPUT_BUILTIN_NAME)],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5198983563776393216_i64),
@@ -2612,7 +2654,7 @@ mod tests {
     */
     fn relocate_trace_output_builtin() {
         let program = program!(
-            builtins = vec![String::from("output")],
+            builtins = vec![String::from(OUTPUT_BUILTIN_NAME)],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5198983563776393216_i64),
@@ -2756,12 +2798,12 @@ mod tests {
 
     #[test]
     fn write_output_from_preset_memory() {
-        let program = program!["output"];
+        let program = program![OUTPUT_BUILTIN_NAME];
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         cairo_runner.initialize_builtins(&mut vm).unwrap();
         cairo_runner.initialize_segments(&mut vm, None);
-        assert_eq!(vm.builtin_runners[0].0, String::from("output"));
+        assert_eq!(vm.builtin_runners[0].0, String::from(OUTPUT_BUILTIN_NAME));
         assert_eq!(vm.builtin_runners[0].1.base(), 2);
 
         vm.segments = segments![((2, 0), 1), ((2, 1), 2)];
@@ -2785,7 +2827,7 @@ mod tests {
     fn write_output_from_program() {
         //Initialization Phase
         let program = program!(
-            builtins = vec![String::from("output")],
+            builtins = vec![String::from(OUTPUT_BUILTIN_NAME)],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5198983563776393216_i64),
@@ -2830,12 +2872,12 @@ mod tests {
 
     #[test]
     fn write_output_from_preset_memory_neg_output() {
-        let program = program!["output"];
+        let program = program![OUTPUT_BUILTIN_NAME];
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         cairo_runner.initialize_builtins(&mut vm).unwrap();
         cairo_runner.initialize_segments(&mut vm, None);
-        assert_eq!(vm.builtin_runners[0].0, String::from("output"));
+        assert_eq!(vm.builtin_runners[0].0, String::from(OUTPUT_BUILTIN_NAME));
         assert_eq!(vm.builtin_runners[0].1.base(), 2);
         vm.segments = segments![(
             (2, 0),
@@ -2855,7 +2897,10 @@ mod tests {
     fn write_output_unordered_builtins() {
         //Initialization Phase
         let program = program!(
-            builtins = vec!["output".to_string(), "bitwise".to_string()],
+            builtins = vec![
+                OUTPUT_BUILTIN_NAME.to_string(),
+                BITWISE_BUILTIN_NAME.to_string()
+            ],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5198983563776393216_i64),
@@ -2915,15 +2960,24 @@ mod tests {
 
     #[test]
     fn insert_all_builtins_in_order() {
-        let program = program!["output", "pedersen", "range_check", "bitwise", "ec_op"];
+        let program = program![
+            OUTPUT_BUILTIN_NAME,
+            HASH_BUILTIN_NAME,
+            RANGE_CHECK_BUILTIN_NAME,
+            BITWISE_BUILTIN_NAME,
+            EC_OP_BUILTIN_NAME
+        ];
         let cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         cairo_runner.initialize_builtins(&mut vm).unwrap();
-        assert_eq!(vm.builtin_runners[0].0, String::from("output"));
-        assert_eq!(vm.builtin_runners[1].0, String::from("pedersen"));
-        assert_eq!(vm.builtin_runners[2].0, String::from("range_check"));
-        assert_eq!(vm.builtin_runners[3].0, String::from("bitwise"));
-        assert_eq!(vm.builtin_runners[4].0, String::from("ec_op"));
+        assert_eq!(vm.builtin_runners[0].0, String::from(OUTPUT_BUILTIN_NAME));
+        assert_eq!(vm.builtin_runners[1].0, String::from(HASH_BUILTIN_NAME));
+        assert_eq!(
+            vm.builtin_runners[2].0,
+            String::from(RANGE_CHECK_BUILTIN_NAME)
+        );
+        assert_eq!(vm.builtin_runners[3].0, String::from(BITWISE_BUILTIN_NAME));
+        assert_eq!(vm.builtin_runners[4].0, String::from(EC_OP_BUILTIN_NAME));
     }
 
     #[test]
@@ -2948,7 +3002,7 @@ mod tests {
     */
     fn run_for_steps() {
         let program = program!(
-            builtins = vec![String::from("range_check")],
+            builtins = vec![String::from(RANGE_CHECK_BUILTIN_NAME)],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),
@@ -3014,7 +3068,7 @@ mod tests {
     */
     fn run_until_steps() {
         let program = program!(
-            builtins = vec![String::from("range_check")],
+            builtins = vec![String::from(RANGE_CHECK_BUILTIN_NAME)],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),
@@ -3086,7 +3140,7 @@ mod tests {
     /// step reaches a power of two, or an error occurs.
     fn run_until_next_power_of_2() {
         let program = program!(
-            builtins = vec![String::from("range_check")],
+            builtins = vec![String::from(RANGE_CHECK_BUILTIN_NAME)],
             data = vec_data!(
                 (4612671182993129469_i64),
                 (5189976364521848832_i64),
@@ -3246,7 +3300,7 @@ mod tests {
             let mut builtin_runner: BuiltinRunner = OutputBuiltinRunner::new(true).into();
             builtin_runner.initialize_segments(&mut vm.segments);
 
-            ("output".to_string(), builtin_runner)
+            (OUTPUT_BUILTIN_NAME.to_string(), builtin_runner)
         }];
         vm.segments.segment_used_sizes = Some(vec![4]);
         assert_eq!(cairo_runner.get_memory_holes(&vm), Ok(0));
@@ -3264,7 +3318,7 @@ mod tests {
             let mut builtin_runner: BuiltinRunner = OutputBuiltinRunner::new(true).into();
             builtin_runner.initialize_segments(&mut vm.segments);
 
-            ("output".to_string(), builtin_runner)
+            (OUTPUT_BUILTIN_NAME.to_string(), builtin_runner)
         }];
         vm.segments.segment_used_sizes = Some(vec![4, 4]);
         assert_eq!(cairo_runner.get_memory_holes(&vm), Ok(2));
@@ -3326,7 +3380,7 @@ mod tests {
 
         vm.current_step = 8192;
         vm.builtin_runners = vec![(
-            "bitwise".to_string(),
+            BITWISE_BUILTIN_NAME.to_string(),
             BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default(), true).into(),
         )];
         assert_matches!(cairo_runner.check_diluted_check_usage(&vm), Ok(()));
@@ -3412,7 +3466,7 @@ mod tests {
         let mut vm = vm!();
 
         vm.builtin_runners = vec![(
-            "output".to_string(),
+            OUTPUT_BUILTIN_NAME.to_string(),
             BuiltinRunner::Output(OutputBuiltinRunner::new(true)),
         )];
         assert_eq!(
@@ -3471,14 +3525,17 @@ mod tests {
             let mut builtin = OutputBuiltinRunner::new(true);
             builtin.initialize_segments(&mut vm.segments);
 
-            ("output".to_string(), BuiltinRunner::Output(builtin))
+            (
+                OUTPUT_BUILTIN_NAME.to_string(),
+                BuiltinRunner::Output(builtin),
+            )
         }];
         assert_eq!(
             cairo_runner.get_execution_resources(&vm),
             Ok(ExecutionResources {
                 n_steps: 10,
                 n_memory_holes: 0,
-                builtin_instance_counter: HashMap::from([("output".to_string(), 4)]),
+                builtin_instance_counter: HashMap::from([(OUTPUT_BUILTIN_NAME.to_string(), 4)]),
             }),
         );
     }
@@ -3701,7 +3758,7 @@ mod tests {
         }]);
         vm.segments.memory.data = vec![vec![mayberelocatable!(0x80FF_8000_0530u64).into()]];
         vm.builtin_runners = vec![(
-            "range_check".to_string(),
+            RANGE_CHECK_BUILTIN_NAME.to_string(),
             RangeCheckBuiltinRunner::new(12, 5, true).into(),
         )];
 
@@ -3753,7 +3810,7 @@ mod tests {
         let cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         vm.builtin_runners = vec![(
-            "range_check".to_string(),
+            RANGE_CHECK_BUILTIN_NAME.to_string(),
             RangeCheckBuiltinRunner::new(8, 8, true).into(),
         )];
         vm.segments.memory.data = vec![vec![Some(mayberelocatable!(0x80FF_8000_0530u64))]];
@@ -3783,7 +3840,7 @@ mod tests {
     #[test]
     fn get_initial_fp_can_be_obtained() {
         //This test works with basic Program definition, will later be updated to use Program::new() when fully defined
-        let program = program!["output"];
+        let program = program![OUTPUT_BUILTIN_NAME];
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         for _ in 0..2 {
@@ -3800,7 +3857,7 @@ mod tests {
 
     #[test]
     fn check_used_cells_valid_case() {
-        let program = program!["range_check", "output"];
+        let program = program![RANGE_CHECK_BUILTIN_NAME, OUTPUT_BUILTIN_NAME];
         let mut cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         vm.segments.segment_used_sizes = Some(vec![4]);
@@ -3817,7 +3874,7 @@ mod tests {
         let cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         vm.builtin_runners = vec![(
-            "range_check".to_string(),
+            RANGE_CHECK_BUILTIN_NAME.to_string(),
             RangeCheckBuiltinRunner::new(8, 8, true).into(),
         )];
         vm.segments.memory.data = vec![vec![Some(mayberelocatable!(0x80FF_8000_0530u64))]];
@@ -3847,7 +3904,7 @@ mod tests {
             let mut builtin_runner: BuiltinRunner = OutputBuiltinRunner::new(true).into();
             builtin_runner.initialize_segments(&mut vm.segments);
 
-            ("output".to_string(), builtin_runner)
+            (OUTPUT_BUILTIN_NAME.to_string(), builtin_runner)
         }];
         vm.segments.segment_used_sizes = Some(vec![4, 12]);
         vm.trace = Some(vec![]);
@@ -3862,7 +3919,7 @@ mod tests {
 
     #[test]
     fn check_used_cells_check_diluted_check_usage_error() {
-        let program = program!["range_check", "output"];
+        let program = program![RANGE_CHECK_BUILTIN_NAME, OUTPUT_BUILTIN_NAME];
         let cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
         vm.segments.segment_used_sizes = Some(vec![4]);
@@ -3889,18 +3946,22 @@ mod tests {
 
         let given_output = vm.get_builtin_runners();
 
-        assert_eq!(given_output[0].0, "pedersen");
-        assert_eq!(given_output[1].0, "range_check");
-        assert_eq!(given_output[2].0, "output");
-        assert_eq!(given_output[3].0, "ecdsa");
-        assert_eq!(given_output[4].0, "bitwise");
-        assert_eq!(given_output[5].0, "ec_op");
-        assert_eq!(given_output[6].0, "keccak");
+        assert_eq!(given_output[0].0, HASH_BUILTIN_NAME);
+        assert_eq!(given_output[1].0, RANGE_CHECK_BUILTIN_NAME);
+        assert_eq!(given_output[2].0, OUTPUT_BUILTIN_NAME);
+        assert_eq!(given_output[3].0, SIGNATURE_BUILTIN_NAME);
+        assert_eq!(given_output[4].0, BITWISE_BUILTIN_NAME);
+        assert_eq!(given_output[5].0, EC_OP_BUILTIN_NAME);
+        assert_eq!(given_output[6].0, KECCAK_BUILTIN_NAME);
     }
 
     #[test]
     fn initialize_all_builtins_maintain_program_order() {
-        let program = program!["pedersen", "range_check", "ecdsa"];
+        let program = program![
+            HASH_BUILTIN_NAME,
+            RANGE_CHECK_BUILTIN_NAME,
+            SIGNATURE_BUILTIN_NAME
+        ];
 
         let cairo_runner = cairo_runner!(program);
         let mut vm = vm!();
@@ -3911,13 +3972,13 @@ mod tests {
 
         let given_output = vm.get_builtin_runners();
 
-        assert_eq!(given_output[0].0, "pedersen");
-        assert_eq!(given_output[1].0, "range_check");
-        assert_eq!(given_output[2].0, "ecdsa");
-        assert_eq!(given_output[3].0, "output");
-        assert_eq!(given_output[4].0, "bitwise");
-        assert_eq!(given_output[5].0, "ec_op");
-        assert_eq!(given_output[6].0, "keccak");
+        assert_eq!(given_output[0].0, HASH_BUILTIN_NAME);
+        assert_eq!(given_output[1].0, RANGE_CHECK_BUILTIN_NAME);
+        assert_eq!(given_output[2].0, SIGNATURE_BUILTIN_NAME);
+        assert_eq!(given_output[3].0, OUTPUT_BUILTIN_NAME);
+        assert_eq!(given_output[4].0, BITWISE_BUILTIN_NAME);
+        assert_eq!(given_output[5].0, EC_OP_BUILTIN_NAME);
+        assert_eq!(given_output[6].0, KECCAK_BUILTIN_NAME);
     }
 
     #[test]
@@ -3933,13 +3994,13 @@ mod tests {
 
         let builtin_runners = vm.get_builtin_runners();
 
-        assert_eq!(builtin_runners[0].0, "pedersen");
-        assert_eq!(builtin_runners[1].0, "range_check");
-        assert_eq!(builtin_runners[2].0, "output");
-        assert_eq!(builtin_runners[3].0, "ecdsa");
-        assert_eq!(builtin_runners[4].0, "bitwise");
-        assert_eq!(builtin_runners[5].0, "ec_op");
-        assert_eq!(builtin_runners[6].0, "keccak");
+        assert_eq!(builtin_runners[0].0, HASH_BUILTIN_NAME);
+        assert_eq!(builtin_runners[1].0, RANGE_CHECK_BUILTIN_NAME);
+        assert_eq!(builtin_runners[2].0, OUTPUT_BUILTIN_NAME);
+        assert_eq!(builtin_runners[3].0, SIGNATURE_BUILTIN_NAME);
+        assert_eq!(builtin_runners[4].0, BITWISE_BUILTIN_NAME);
+        assert_eq!(builtin_runners[5].0, EC_OP_BUILTIN_NAME);
+        assert_eq!(builtin_runners[6].0, KECCAK_BUILTIN_NAME);
 
         assert_eq!(
             cairo_runner.program_base,
@@ -3960,13 +4021,13 @@ mod tests {
 
     #[test]
     fn initialize_segments_incorrect_layout_plain_one_builtin() {
-        let program = program!["output"];
+        let program = program![OUTPUT_BUILTIN_NAME];
         let mut vm = vm!();
         let cairo_runner = cairo_runner!(program, "plain");
         assert_eq!(
             cairo_runner.initialize_builtins(&mut vm),
             Err(RunnerError::NoBuiltinForInstance(
-                HashSet::from([String::from("output")]),
+                HashSet::from([String::from(OUTPUT_BUILTIN_NAME)]),
                 String::from("plain")
             ))
         );
@@ -3974,13 +4035,16 @@ mod tests {
 
     #[test]
     fn initialize_segments_incorrect_layout_plain_two_builtins() {
-        let program = program!["output", "pedersen"];
+        let program = program![OUTPUT_BUILTIN_NAME, HASH_BUILTIN_NAME];
         let mut vm = vm!();
         let cairo_runner = cairo_runner!(program, "plain");
         assert_eq!(
             cairo_runner.initialize_builtins(&mut vm),
             Err(RunnerError::NoBuiltinForInstance(
-                HashSet::from([String::from("output"), String::from("pedersen")]),
+                HashSet::from([
+                    String::from(OUTPUT_BUILTIN_NAME),
+                    String::from(HASH_BUILTIN_NAME)
+                ]),
                 String::from("plain")
             ))
         );
@@ -3988,13 +4052,13 @@ mod tests {
 
     #[test]
     fn initialize_segments_incorrect_layout_small_two_builtins() {
-        let program = program!["output", "bitwise"];
+        let program = program![OUTPUT_BUILTIN_NAME, BITWISE_BUILTIN_NAME];
         let mut vm = vm!();
         let cairo_runner = cairo_runner!(program, "small");
         assert_eq!(
             cairo_runner.initialize_builtins(&mut vm),
             Err(RunnerError::NoBuiltinForInstance(
-                HashSet::from([String::from("bitwise")]),
+                HashSet::from([String::from(BITWISE_BUILTIN_NAME)]),
                 String::from("small")
             ))
         );
@@ -4023,7 +4087,10 @@ mod tests {
             start = Some(0),
             end = Some(0),
             main = Some(8),
-            builtins = vec!["output".to_string(), "ec_op".to_string()],
+            builtins = vec![
+                OUTPUT_BUILTIN_NAME.to_string(),
+                EC_OP_BUILTIN_NAME.to_string()
+            ],
         );
         let mut runner = cairo_runner!(program);
         runner.proof_mode = true;
@@ -4047,7 +4114,10 @@ mod tests {
             start = Some(0),
             end = Some(0),
             main = Some(8),
-            builtins = vec!["output".to_string(), "ec_op".to_string()],
+            builtins = vec![
+                OUTPUT_BUILTIN_NAME.to_string(),
+                EC_OP_BUILTIN_NAME.to_string()
+            ],
         );
         let runner = cairo_runner!(program);
 
@@ -4203,7 +4273,7 @@ mod tests {
 
     #[test]
     fn read_return_values_updates_builtin_stop_ptr_one_builtin_empty() {
-        let mut program = program!["output"];
+        let mut program = program![OUTPUT_BUILTIN_NAME];
         program.data = vec_data![(1), (2), (3), (4), (5), (6), (7), (8)];
         //Program data len = 8
         let mut cairo_runner = cairo_runner!(program, "all", true);
@@ -4214,7 +4284,7 @@ mod tests {
         let mut vm = vm!();
         let output_builtin = OutputBuiltinRunner::new(true);
         vm.builtin_runners
-            .push((String::from("output"), output_builtin.into()));
+            .push((String::from(OUTPUT_BUILTIN_NAME), output_builtin.into()));
         vm.segments.memory.data = vec![vec![], vec![Some(MaybeRelocatable::from((0, 0)))], vec![]];
         vm.set_ap(1);
         vm.segments.segment_used_sizes = Some(vec![0, 1, 0]);
@@ -4229,7 +4299,7 @@ mod tests {
 
     #[test]
     fn read_return_values_updates_builtin_stop_ptr_one_builtin_one_element() {
-        let mut program = program!["output"];
+        let mut program = program![OUTPUT_BUILTIN_NAME];
         program.data = vec_data![(1), (2), (3), (4), (5), (6), (7), (8)];
         //Program data len = 8
         let mut cairo_runner = cairo_runner!(program, "all", true);
@@ -4240,7 +4310,7 @@ mod tests {
         let mut vm = vm!();
         let output_builtin = OutputBuiltinRunner::new(true);
         vm.builtin_runners
-            .push((String::from("output"), output_builtin.into()));
+            .push((String::from(OUTPUT_BUILTIN_NAME), output_builtin.into()));
         vm.segments.memory.data = vec![
             vec![Some(MaybeRelocatable::from((0, 0)))],
             vec![Some(MaybeRelocatable::from((0, 1)))],
@@ -4259,7 +4329,7 @@ mod tests {
 
     #[test]
     fn read_return_values_updates_builtin_stop_ptr_two_builtins() {
-        let mut program = program!["output", "bitwise"];
+        let mut program = program![OUTPUT_BUILTIN_NAME, BITWISE_BUILTIN_NAME];
         program.data = vec_data![(1), (2), (3), (4), (5), (6), (7), (8)];
         //Program data len = 8
         let mut cairo_runner = cairo_runner!(program, "all", true);
@@ -4271,9 +4341,9 @@ mod tests {
         let output_builtin = OutputBuiltinRunner::new(true);
         let bitwise_builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default(), true);
         vm.builtin_runners
-            .push((String::from("output"), output_builtin.into()));
+            .push((String::from(OUTPUT_BUILTIN_NAME), output_builtin.into()));
         vm.builtin_runners
-            .push((String::from("bitwise"), bitwise_builtin.into()));
+            .push((String::from(BITWISE_BUILTIN_NAME), bitwise_builtin.into()));
         cairo_runner.initialize_segments(&mut vm, None);
         vm.segments.memory.data = vec![
             vec![Some(MaybeRelocatable::from((0, 0)))],
@@ -4434,7 +4504,7 @@ mod tests {
 
     fn setup_execution_resources() -> (ExecutionResources, ExecutionResources) {
         let mut builtin_instance_counter: HashMap<std::string::String, usize> = HashMap::new();
-        builtin_instance_counter.insert("output".to_string(), 8);
+        builtin_instance_counter.insert(OUTPUT_BUILTIN_NAME.to_string(), 8);
 
         let execution_resources_1 = ExecutionResources {
             n_steps: 100,
@@ -4443,7 +4513,7 @@ mod tests {
         };
 
         //Test that the combined Execution Resources only contains the shared builtins
-        builtin_instance_counter.insert("range_check".to_string(), 8);
+        builtin_instance_counter.insert(RANGE_CHECK_BUILTIN_NAME.to_string(), 8);
 
         let execution_resources_2 = ExecutionResources {
             n_steps: 100,
@@ -4464,13 +4534,13 @@ mod tests {
         assert_eq!(
             combined_resources
                 .builtin_instance_counter
-                .get("output")
+                .get(OUTPUT_BUILTIN_NAME)
                 .unwrap(),
             &16
         );
         assert!(!combined_resources
             .builtin_instance_counter
-            .contains_key("range_check"));
+            .contains_key(RANGE_CHECK_BUILTIN_NAME));
     }
 
     #[test]
@@ -4484,13 +4554,13 @@ mod tests {
         assert_eq!(
             combined_resources
                 .builtin_instance_counter
-                .get("output")
+                .get(OUTPUT_BUILTIN_NAME)
                 .unwrap(),
             &0
         );
         assert!(!combined_resources
             .builtin_instance_counter
-            .contains_key("range_check"));
+            .contains_key(RANGE_CHECK_BUILTIN_NAME));
     }
 
     #[test]

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -703,8 +703,7 @@ impl CairoRunner {
                 InsufficientAllocatedCellsError::DilutedCells(
                     unused_diluted_units,
                     diluted_usage_upper_bound,
-                )
-                .into(),
+                ),
             )
             .into());
         }

--- a/src/vm/security.rs
+++ b/src/vm/security.rs
@@ -84,6 +84,7 @@ mod test {
     use crate::types::relocatable::MaybeRelocatable;
     use crate::types::relocatable::Relocatable;
     use crate::vm::errors::memory_errors::MemoryError;
+    use crate::vm::runners::builtin_runner::BuiltinRunner;
     use crate::vm::vm_memory::memory::Memory;
     use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
     use crate::{relocatable, types::program::Program, utils::test_utils::*};

--- a/src/vm/security.rs
+++ b/src/vm/security.rs
@@ -84,7 +84,6 @@ mod test {
     use crate::types::relocatable::MaybeRelocatable;
     use crate::types::relocatable::Relocatable;
     use crate::vm::errors::memory_errors::MemoryError;
-    use crate::vm::runners::builtin_runner::BuiltinRunner;
     use crate::vm::vm_memory::memory::Memory;
     use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
     use crate::{relocatable, types::program::Program, utils::test_utils::*};

--- a/src/vm/security.rs
+++ b/src/vm/security.rs
@@ -84,6 +84,7 @@ mod test {
     use crate::types::relocatable::MaybeRelocatable;
     use crate::types::relocatable::Relocatable;
     use crate::vm::errors::memory_errors::MemoryError;
+    use crate::vm::runners::builtin_runner::RANGE_CHECK_BUILTIN_NAME;
     use crate::vm::vm_memory::memory::Memory;
     use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
     use crate::{relocatable, types::program::Program, utils::test_utils::*};
@@ -137,7 +138,10 @@ mod test {
 
     #[test]
     fn verify_secure_runner_builtin_access_out_of_bounds() {
-        let program = program!(main = Some(0), builtins = vec!["range_check".to_string()],);
+        let program = program!(
+            main = Some(0),
+            builtins = vec![RANGE_CHECK_BUILTIN_NAME.to_string()],
+        );
 
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
@@ -155,7 +159,10 @@ mod test {
 
     #[test]
     fn verify_secure_runner_builtin_access_correct() {
-        let program = program!(main = Some(0), builtins = vec!["range_check".to_string()],);
+        let program = program!(
+            main = Some(0),
+            builtins = vec![RANGE_CHECK_BUILTIN_NAME.to_string()],
+        );
 
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();

--- a/src/vm/security.rs
+++ b/src/vm/security.rs
@@ -138,10 +138,7 @@ mod test {
 
     #[test]
     fn verify_secure_runner_builtin_access_out_of_bounds() {
-        let program = program!(
-            main = Some(0),
-            builtins = vec![RANGE_CHECK_BUILTIN_NAME.to_string()],
-        );
+        let program = program!(main = Some(0), builtins = vec![RANGE_CHECK_BUILTIN_NAME],);
 
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();
@@ -159,10 +156,7 @@ mod test {
 
     #[test]
     fn verify_secure_runner_builtin_access_correct() {
-        let program = program!(
-            main = Some(0),
-            builtins = vec![RANGE_CHECK_BUILTIN_NAME.to_string()],
-        );
+        let program = program!(main = Some(0), builtins = vec![RANGE_CHECK_BUILTIN_NAME],);
 
         let mut runner = cairo_runner!(program);
         let mut vm = vm!();


### PR DESCRIPTION
- Add different errors for failures during `BuiltinRunner::final_stack()`
- Expand the  `MemoryError::InsufficientAllocatedCells` with its own error type `InsuficientAllocatedCellsError` and create diferent variants for each failure case (these variants get their message from the original vm to increase compatibility)
- Use constants for error names to avoid differences