### PR TITLE
Fix `KeccakBuiltinRunner::deduce_memory_cell`

### DIFF
--- a/cairo_programs/recursive_layout/_keccak_builtin.cairo
+++ b/cairo_programs/recursive_layout/_keccak_builtin.cairo
@@ -1,0 +1,11 @@
+%builtins keccak
+from starkware.cairo.common.cairo_builtins import KeccakBuiltin
+from starkware.cairo.common.keccak_state import KeccakBuiltinState
+from starkware.cairo.common.serialize import serialize_word
+
+func main{keccak_ptr: KeccakBuiltin*}() {
+    assert keccak_ptr[0].input = KeccakBuiltinState(1,2,3,4,5,6,7,8);
+    let result = keccak_ptr[0].output;
+    let keccak_ptr = keccak_ptr + KeccakBuiltin.SIZE;
+    return ();
+}

--- a/src/vm/errors/runner_errors.rs
+++ b/src/vm/errors/runner_errors.rs
@@ -101,4 +101,6 @@ pub enum RunnerError {
     MemoryError(#[from] MemoryError),
     #[error("Negative builtin base")]
     NegBuiltinBase,
+    #[error("keccak_builtin: Failed to get first input address")]
+    KeccakNoFirstInput,
 }

--- a/src/vm/errors/runner_errors.rs
+++ b/src/vm/errors/runner_errors.rs
@@ -103,4 +103,6 @@ pub enum RunnerError {
     NegBuiltinBase,
     #[error("keccak_builtin: Failed to get first input address")]
     KeccakNoFirstInput,
+    #[error("keccak_builtin: Failed to convert input cells to u64 values")]
+    KeccakInputCellsNotU64,
 }

--- a/src/vm/errors/vm_errors.rs
+++ b/src/vm/errors/vm_errors.rs
@@ -56,7 +56,7 @@ pub enum VirtualMachineError {
     NotImplemented,
     #[error("Can only subtract two relocatable values of the same segment")]
     DiffIndexSub,
-    #[error("Inconsistent auto-deduction for builtin {0}, expected {1}, got {2:?}")]
+    #[error("Inconsistent auto-deduction for builtin {0}, expected {1}, got {2}")]
     InconsistentAutoDeduction(&'static str, MaybeRelocatable, MaybeRelocatable),
     #[error(transparent)]
     RunnerError(#[from] RunnerError),

--- a/src/vm/errors/vm_errors.rs
+++ b/src/vm/errors/vm_errors.rs
@@ -57,7 +57,7 @@ pub enum VirtualMachineError {
     #[error("Can only subtract two relocatable values of the same segment")]
     DiffIndexSub,
     #[error("Inconsistent auto-deduction for builtin {0}, expected {1}, got {2:?}")]
-    InconsistentAutoDeduction(&'static str, MaybeRelocatable, Option<MaybeRelocatable>),
+    InconsistentAutoDeduction(&'static str, MaybeRelocatable, MaybeRelocatable),
     #[error(transparent)]
     RunnerError(#[from] RunnerError),
     #[error("Invalid hint encoding at pc: {0}")]

--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -65,9 +65,7 @@ impl BitwiseBuiltinRunner {
         self.ratio
     }
 
-    pub fn add_validation_rule(&self, _memory: &mut Memory) -> Result<(), RunnerError> {
-        Ok(())
-    }
+    pub fn add_validation_rule(&self, _memory: &mut Memory) {}
 
     pub fn deduce_memory_cell(
         &self,

--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -70,7 +70,7 @@ impl BitwiseBuiltinRunner {
     pub fn deduce_memory_cell(
         &self,
         address: &Relocatable,
-        memory: &Memory,
+        memory: &mut Memory,
     ) -> Result<Option<MaybeRelocatable>, RunnerError> {
         let index = address.offset % self.cells_per_instance as usize;
         if index <= 1 {
@@ -449,41 +449,41 @@ mod tests {
 
     #[test]
     fn deduce_memory_cell_bitwise_for_preset_memory_valid_and() {
-        let memory = memory![((0, 5), 10), ((0, 6), 12), ((0, 7), 0)];
+        let mut memory = memory![((0, 5), 10), ((0, 6), 12), ((0, 7), 0)];
         let builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default(), true);
-        let result = builtin.deduce_memory_cell(&Relocatable::from((0, 7)), &memory);
+        let result = builtin.deduce_memory_cell(&Relocatable::from((0, 7)), &mut memory);
         assert_eq!(result, Ok(Some(MaybeRelocatable::from(Felt::new(8)))));
     }
 
     #[test]
     fn deduce_memory_cell_bitwise_for_preset_memory_valid_xor() {
-        let memory = memory![((0, 5), 10), ((0, 6), 12), ((0, 8), 0)];
+        let mut memory = memory![((0, 5), 10), ((0, 6), 12), ((0, 8), 0)];
         let builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default(), true);
-        let result = builtin.deduce_memory_cell(&Relocatable::from((0, 8)), &memory);
+        let result = builtin.deduce_memory_cell(&Relocatable::from((0, 8)), &mut memory);
         assert_eq!(result, Ok(Some(MaybeRelocatable::from(Felt::new(6)))));
     }
 
     #[test]
     fn deduce_memory_cell_bitwise_for_preset_memory_valid_or() {
-        let memory = memory![((0, 5), 10), ((0, 6), 12), ((0, 9), 0)];
+        let mut memory = memory![((0, 5), 10), ((0, 6), 12), ((0, 9), 0)];
         let builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default(), true);
-        let result = builtin.deduce_memory_cell(&Relocatable::from((0, 9)), &memory);
+        let result = builtin.deduce_memory_cell(&Relocatable::from((0, 9)), &mut memory);
         assert_eq!(result, Ok(Some(MaybeRelocatable::from(Felt::new(14)))));
     }
 
     #[test]
     fn deduce_memory_cell_bitwise_for_preset_memory_incorrect_offset() {
-        let memory = memory![((0, 3), 10), ((0, 4), 12), ((0, 5), 0)];
+        let mut memory = memory![((0, 3), 10), ((0, 4), 12), ((0, 5), 0)];
         let builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default(), true);
-        let result = builtin.deduce_memory_cell(&Relocatable::from((0, 5)), &memory);
+        let result = builtin.deduce_memory_cell(&Relocatable::from((0, 5)), &mut memory);
         assert_eq!(result, Ok(None));
     }
 
     #[test]
     fn deduce_memory_cell_bitwise_for_preset_memory_no_values_to_operate() {
-        let memory = memory![((0, 5), 12), ((0, 7), 0)];
+        let mut memory = memory![((0, 5), 12), ((0, 7), 0)];
         let builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default(), true);
-        let result = builtin.deduce_memory_cell(&Relocatable::from((0, 5)), &memory);
+        let result = builtin.deduce_memory_cell(&Relocatable::from((0, 5)), &mut memory);
         assert_eq!(result, Ok(None));
     }
 

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -130,9 +130,7 @@ impl EcOpBuiltinRunner {
         self.ratio
     }
 
-    pub fn add_validation_rule(&self, _memory: &mut Memory) -> Result<(), RunnerError> {
-        Ok(())
-    }
+    pub fn add_validation_rule(&self, _memory: &mut Memory) {}
 
     pub fn deduce_memory_cell(
         &self,

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -135,7 +135,7 @@ impl EcOpBuiltinRunner {
     pub fn deduce_memory_cell(
         &self,
         address: &Relocatable,
-        memory: &Memory,
+        memory: &mut Memory,
     ) -> Result<Option<MaybeRelocatable>, RunnerError> {
         //Constant values declared here
         const EC_POINT_INDICES: [(usize, usize); 3] = [(0, 1), (2, 3), (5, 6)];
@@ -727,7 +727,7 @@ mod tests {
            end
     */
     fn deduce_memory_cell_ec_op_for_preset_memory_valid() {
-        let memory = memory![
+        let mut memory = memory![
             (
                 (3, 0),
                 (
@@ -767,7 +767,7 @@ mod tests {
         ];
         let builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
 
-        let result = builtin.deduce_memory_cell(&Relocatable::from((3, 6)), &memory);
+        let result = builtin.deduce_memory_cell(&Relocatable::from((3, 6)), &mut memory);
         assert_eq!(
             result,
             Ok(Some(MaybeRelocatable::from(felt_str!(
@@ -778,7 +778,7 @@ mod tests {
 
     #[test]
     fn deduce_memory_cell_ec_op_for_preset_memory_unfilled_input_cells() {
-        let memory = memory![
+        let mut memory = memory![
             (
                 (3, 1),
                 (
@@ -811,13 +811,13 @@ mod tests {
         ];
 
         let builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
-        let result = builtin.deduce_memory_cell(&Relocatable::from((3, 6)), &memory);
+        let result = builtin.deduce_memory_cell(&Relocatable::from((3, 6)), &mut memory);
         assert_eq!(result, Ok(None));
     }
 
     #[test]
     fn deduce_memory_cell_ec_op_for_preset_memory_addr_not_an_output_cell() {
-        let memory = memory![
+        let mut memory = memory![
             (
                 (3, 0),
                 (
@@ -857,13 +857,13 @@ mod tests {
         ];
         let builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
 
-        let result = builtin.deduce_memory_cell(&Relocatable::from((3, 3)), &memory);
+        let result = builtin.deduce_memory_cell(&Relocatable::from((3, 3)), &mut memory);
         assert_eq!(result, Ok(None));
     }
 
     #[test]
     fn deduce_memory_cell_ec_op_for_preset_memory_non_integer_input() {
-        let memory = memory![
+        let mut memory = memory![
             (
                 (3, 0),
                 (
@@ -898,7 +898,7 @@ mod tests {
         let builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
 
         assert_eq!(
-            builtin.deduce_memory_cell(&Relocatable::from((3, 6)), &memory),
+            builtin.deduce_memory_cell(&Relocatable::from((3, 6)), &mut memory),
             Err(RunnerError::ExpectedInteger(MaybeRelocatable::from((3, 3))))
         );
     }

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -69,7 +69,7 @@ impl HashBuiltinRunner {
     pub fn deduce_memory_cell(
         &self,
         address: &Relocatable,
-        memory: &Memory,
+        memory: &mut Memory,
     ) -> Result<Option<MaybeRelocatable>, RunnerError> {
         if address
             .offset
@@ -423,10 +423,10 @@ mod tests {
 
     #[test]
     fn deduce_memory_cell_pedersen_for_preset_memory_valid() {
-        let memory = memory![((0, 3), 32), ((0, 4), 72), ((0, 5), 0)];
+        let mut memory = memory![((0, 3), 32), ((0, 4), 72), ((0, 5), 0)];
         let builtin = HashBuiltinRunner::new(8, true);
 
-        let result = builtin.deduce_memory_cell(&Relocatable::from((0, 5)), &memory);
+        let result = builtin.deduce_memory_cell(&Relocatable::from((0, 5)), &mut memory);
         assert_eq!(
             result,
             Ok(Some(MaybeRelocatable::from(felt_str!(
@@ -441,26 +441,26 @@ mod tests {
 
     #[test]
     fn deduce_memory_cell_pedersen_for_preset_memory_incorrect_offset() {
-        let memory = memory![((0, 4), 32), ((0, 5), 72), ((0, 6), 0)];
+        let mut memory = memory![((0, 4), 32), ((0, 5), 72), ((0, 6), 0)];
         let builtin = HashBuiltinRunner::new(8, true);
-        let result = builtin.deduce_memory_cell(&Relocatable::from((0, 6)), &memory);
+        let result = builtin.deduce_memory_cell(&Relocatable::from((0, 6)), &mut memory);
         assert_eq!(result, Ok(None));
     }
 
     #[test]
     fn deduce_memory_cell_pedersen_for_preset_memory_no_values_to_hash() {
-        let memory = memory![((0, 4), 72), ((0, 5), 0)];
+        let mut memory = memory![((0, 4), 72), ((0, 5), 0)];
         let builtin = HashBuiltinRunner::new(8, true);
-        let result = builtin.deduce_memory_cell(&Relocatable::from((0, 5)), &memory);
+        let result = builtin.deduce_memory_cell(&Relocatable::from((0, 5)), &mut memory);
         assert_eq!(result, Ok(None));
     }
 
     #[test]
     fn deduce_memory_cell_pedersen_for_preset_memory_already_computed() {
-        let memory = memory![((0, 3), 32), ((0, 4), 72), ((0, 5), 0)];
+        let mut memory = memory![((0, 3), 32), ((0, 4), 72), ((0, 5), 0)];
         let mut builtin = HashBuiltinRunner::new(8, true);
         builtin.verified_addresses = RefCell::new(vec![Relocatable::from((0, 5))]);
-        let result = builtin.deduce_memory_cell(&Relocatable::from((0, 5)), &memory);
+        let result = builtin.deduce_memory_cell(&Relocatable::from((0, 5)), &mut memory);
         assert_eq!(result, Ok(None));
     }
 

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -64,9 +64,7 @@ impl HashBuiltinRunner {
         self.ratio
     }
 
-    pub fn add_validation_rule(&self, _memory: &mut Memory) -> Result<(), RunnerError> {
-        Ok(())
-    }
+    pub fn add_validation_rule(&self, _memory: &mut Memory) {}
 
     pub fn deduce_memory_cell(
         &self,

--- a/src/vm/runners/builtin_runner/keccak.rs
+++ b/src/vm/runners/builtin_runner/keccak.rs
@@ -126,7 +126,7 @@ impl KeccakBuiltinRunner {
                         &(first_input_addr + self.n_input_cells as usize + i),
                         &Felt::from(*val as i64),
                     )
-                    .map_err(RunnerError::FailedMemoryGet)?;
+                    .map_err(RunnerError::MemoryError)?;
             }
 
             return Ok(input_felts_u64

--- a/src/vm/runners/builtin_runner/keccak.rs
+++ b/src/vm/runners/builtin_runner/keccak.rs
@@ -66,9 +66,7 @@ impl KeccakBuiltinRunner {
         self.ratio
     }
 
-    pub fn add_validation_rule(&self, _memory: &mut Memory) -> Result<(), RunnerError> {
-        Ok(())
-    }
+    pub fn add_validation_rule(&self, _memory: &mut Memory) {}
 
     pub fn deduce_memory_cell(
         &self,

--- a/src/vm/runners/builtin_runner/keccak.rs
+++ b/src/vm/runners/builtin_runner/keccak.rs
@@ -630,7 +630,7 @@ mod tests {
     }
 
     #[test]
-    fn deduce_memory_cell_base_not_finished_err() {
+    fn deduce_memory_cell_expected_integer() {
         let memory = memory![((0, 35), 0)];
 
         let mut builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::default(), true);
@@ -640,7 +640,7 @@ mod tests {
 
         let result = builtin.deduce_memory_cell(&Relocatable::from((0, 99)), &memory);
 
-        assert_eq!(result, Err(RunnerError::NonRelocatableAddress));
+        assert_eq!(result, Err(RunnerError::ExpectedInteger((0, 0).into())));
     }
 
     #[test]
@@ -687,7 +687,7 @@ mod tests {
         assert_eq!(
             result,
             Err(RunnerError::IntegerBiggerThanPowerOfTwo(
-                43.into(),
+                (0, 16).into(),
                 1,
                 43.into()
             ))

--- a/src/vm/runners/builtin_runner/keccak.rs
+++ b/src/vm/runners/builtin_runner/keccak.rs
@@ -93,9 +93,7 @@ impl KeccakBuiltinRunner {
                     .get_int_ref()
                     .ok()
                     .and_then(|x| x.to_u64())
-                    .ok_or_else(|| {
-                        RunnerError::ExpectedInteger((first_input_addr + i as usize).into())
-                    })?,
+                    .ok_or(RunnerError::KeccakInputCellsNotU64)?,
                 _ => return Ok(None),
             };
 

--- a/src/vm/runners/builtin_runner/keccak.rs
+++ b/src/vm/runners/builtin_runner/keccak.rs
@@ -1,4 +1,3 @@
-use crate::hint_processor::builtin_hint_processor::cairo_keccak::keccak_hints::u64_array_to_mayberelocatable_vec;
 use crate::hint_processor::builtin_hint_processor::keccak_utils::left_pad_u64;
 use crate::math_utils::safe_div_usize;
 use crate::types::instance_definitions::keccak_instance_def::KeccakInstanceDef;
@@ -120,9 +119,9 @@ impl KeccakBuiltinRunner {
 
             keccak::f1600(&mut input_felts_u64);
 
-            let bigint_values = u64_array_to_mayberelocatable_vec(&input_felts_u64);
-
-            return Ok(Some(bigint_values[address.offset - 1].clone()));
+            return Ok(input_felts_u64
+                .get(address.offset - 1)
+                .map(|x| Felt::from(*x).into()));
         }
         Ok(None)
     }

--- a/src/vm/runners/builtin_runner/keccak.rs
+++ b/src/vm/runners/builtin_runner/keccak.rs
@@ -80,7 +80,7 @@ impl KeccakBuiltinRunner {
 
         let first_input_addr = address
             .sub_usize(index)
-            .map_err(|_| RunnerError::BaseNotFinished)?;
+            .map_err(|_| RunnerError::KeccakNoFirstInput)?;
 
         if self.verified_addresses.contains(&first_input_addr) {
             return Ok(None);

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -143,7 +143,7 @@ impl BuiltinRunner {
         }
     }
 
-    pub fn add_validation_rule(&self, memory: &mut Memory) -> Result<(), RunnerError> {
+    pub fn add_validation_rule(&self, memory: &mut Memory) {
         match *self {
             BuiltinRunner::Bitwise(ref bitwise) => bitwise.add_validation_rule(memory),
             BuiltinRunner::EcOp(ref ec) => ec.add_validation_rule(memory),

--- a/src/vm/runners/builtin_runner/output.rs
+++ b/src/vm/runners/builtin_runner/output.rs
@@ -39,9 +39,7 @@ impl OutputBuiltinRunner {
         self.base
     }
 
-    pub fn add_validation_rule(&self, _memory: &mut Memory) -> Result<(), RunnerError> {
-        Ok(())
-    }
+    pub fn add_validation_rule(&self, _memory: &mut Memory) {}
 
     pub fn deduce_memory_cell(
         &self,
@@ -418,7 +416,6 @@ mod tests {
         ];
 
         vm.segments.segment_used_sizes = Some(vec![0]);
-
-        assert_eq!(builtin.add_validation_rule(&mut vm.segments.memory), Ok(()));
+        builtin.add_validation_rule(&mut vm.segments.memory);
     }
 }

--- a/src/vm/runners/builtin_runner/output.rs
+++ b/src/vm/runners/builtin_runner/output.rs
@@ -398,7 +398,7 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin.deduce_memory_cell(&pointer, &vm.segments.memory),
+            builtin.deduce_memory_cell(&pointer, &mut vm.segments.memory),
             Ok(None)
         );
     }

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -85,7 +85,7 @@ impl RangeCheckBuiltinRunner {
         self.ratio
     }
 
-    pub fn add_validation_rule(&self, memory: &mut Memory) -> Result<(), RunnerError> {
+    pub fn add_validation_rule(&self, memory: &mut Memory) {
         let rule: ValidationRule = ValidationRule(Box::new(
             |memory: &Memory, address: &Relocatable| -> Result<Vec<Relocatable>, MemoryError> {
                 if let MaybeRelocatable::Int(ref num) = memory
@@ -104,7 +104,6 @@ impl RangeCheckBuiltinRunner {
             },
         ));
         memory.add_validation_rule(self.base, rule);
-        Ok(())
     }
 
     pub fn deduce_memory_cell(

--- a/src/vm/runners/builtin_runner/signature.rs
+++ b/src/vm/runners/builtin_runner/signature.rs
@@ -95,7 +95,7 @@ impl SignatureBuiltinRunner {
     pub fn base(&self) -> usize {
         self.base
     }
-    pub fn add_validation_rule(&self, memory: &mut Memory) -> Result<(), RunnerError> {
+    pub fn add_validation_rule(&self, memory: &mut Memory) {
         let cells_per_instance = self.cells_per_instance;
         let signatures = Rc::clone(&self.signatures);
         let rule: ValidationRule = ValidationRule(Box::new(
@@ -144,7 +144,6 @@ impl SignatureBuiltinRunner {
             },
         ));
         memory.add_validation_rule(self.base, rule);
-        Ok(())
     }
 
     pub fn deduce_memory_cell(

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -433,7 +433,7 @@ impl CairoRunner {
             self.program_base.as_ref().ok_or(RunnerError::NoProgBase)?,
         ));
         for (_, builtin) in vm.builtin_runners.iter() {
-            builtin.add_validation_rule(&mut vm.segments.memory)?;
+            builtin.add_validation_rule(&mut vm.segments.memory);
         }
 
         // Mark all addresses from the program segment as accessed

--- a/src/vm/security.rs
+++ b/src/vm/security.rs
@@ -71,7 +71,7 @@ pub fn verify_secure_runner(
         }
     }
     for (_, builtin) in vm.builtin_runners.iter() {
-        builtin.run_security_checks(vm)?;
+        builtin.run_security_checks(&mut vm.segments)?;
     }
 
     Ok(())

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -3076,7 +3076,7 @@ mod tests {
 
     #[test]
     fn deduce_memory_cell_no_pedersen_builtin() {
-        let vm = vm!();
+        let mut vm = vm!();
         assert_matches!(vm.deduce_memory_cell(&Relocatable::from((0, 0))), Ok(None));
     }
 
@@ -3426,7 +3426,7 @@ mod tests {
             )
         ];
         let error = vm.verify_auto_deductions();
-        assert_eq!(error.as_ref().unwrap_err().to_string(), "Inconsistent auto-deduction for builtin ec_op, expected 2739017437753868763038285897969098325279422804143820990343394856167768859289, got Some(Int(2778063437308421278851140253538604815869848682781135193774472480292420096757))");
+        assert_eq!(error.as_ref().unwrap_err().to_string(), "Inconsistent auto-deduction for builtin ec_op, expected 2739017437753868763038285897969098325279422804143820990343394856167768859289, got 2778063437308421278851140253538604815869848682781135193774472480292420096757");
         assert_matches!(
             error,
             Err(VirtualMachineError::InconsistentAutoDeduction(

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -582,7 +582,7 @@ mod memory_tests {
         let mut builtin = RangeCheckBuiltinRunner::new(8, 8, true);
         let mut segments = MemorySegmentManager::new();
         builtin.initialize_segments(&mut segments);
-        assert_eq!(builtin.add_validation_rule(&mut segments.memory), Ok(()));
+        builtin.add_validation_rule(&mut segments.memory);
         for _ in 0..3 {
             segments.add();
         }
@@ -614,7 +614,7 @@ mod memory_tests {
                 &MaybeRelocatable::from(Felt::new(-10)),
             )
             .unwrap();
-        assert_eq!(builtin.add_validation_rule(&mut segments.memory), Ok(()));
+        builtin.add_validation_rule(&mut segments.memory);
         let error = segments.memory.validate_existing_memory();
         assert_eq!(error, Err(MemoryError::NumOutOfBounds));
         assert_eq!(
@@ -644,7 +644,7 @@ mod memory_tests {
                 )
             )
         ];
-        builtin.add_validation_rule(&mut segments.memory).unwrap();
+        builtin.add_validation_rule(&mut segments.memory);
         let error = segments.memory.validate_existing_memory();
         assert_eq!(error, Err(MemoryError::SignatureNotFound((0, 0).into())));
     }
@@ -679,7 +679,7 @@ mod memory_tests {
 
         builtin.initialize_segments(&mut segments);
 
-        builtin.add_validation_rule(&mut segments.memory).unwrap();
+        builtin.add_validation_rule(&mut segments.memory);
 
         let result = segments.memory.validate_existing_memory();
 
@@ -692,7 +692,7 @@ mod memory_tests {
         let mut segments = MemorySegmentManager::new();
         builtin.initialize_segments(&mut segments);
         segments.memory = memory![((0, 7), (0, 4))];
-        assert_eq!(builtin.add_validation_rule(&mut segments.memory), Ok(()));
+        builtin.add_validation_rule(&mut segments.memory);
         let error = segments.memory.validate_existing_memory();
         assert_eq!(error, Err(MemoryError::FoundNonInt));
         assert_eq!(
@@ -715,7 +715,7 @@ mod memory_tests {
                 &MaybeRelocatable::from(Felt::new(-45)),
             )
             .unwrap();
-        assert_eq!(builtin.add_validation_rule(&mut segments.memory), Ok(()));
+        builtin.add_validation_rule(&mut segments.memory);
         assert_eq!(segments.memory.validate_existing_memory(), Ok(()));
     }
 


### PR DESCRIPTION
The method should write the output values of keccak into the memory
As a result of this fix, multiple method signatures changed due to the added mutability requirement
Depends on #842 
