### PR TITLE
Add missing checks in `verify_ecsda_signature` hint 

### DIFF
--- a/src/hint_processor/builtin_hint_processor/signature.rs
+++ b/src/hint_processor/builtin_hint_processor/signature.rs
@@ -1,9 +1,12 @@
+use num_integer::Integer;
+
 use crate::{
     hint_processor::{
         builtin_hint_processor::hint_utils::{get_integer_from_var_name, get_ptr_from_var_name},
         hint_processor_definition::HintReference,
     },
     serde::deserialize_program::ApTracking,
+    types::instance_definitions::ecdsa_instance_def::CELLS_PER_SIGNATURE,
     vm::{
         errors::{hint_errors::HintError, vm_errors::VirtualMachineError},
         vm_core::VirtualMachine,
@@ -24,6 +27,12 @@ pub fn verify_ecdsa_signature(
     let ecdsa_builtin = &mut vm.get_signature_builtin()?;
     if ecdsa_ptr.segment_index != ecdsa_builtin.base() as isize {
         return Err(HintError::AddSignatureWrongEcdsaPtr(ecdsa_ptr));
+    }
+    if !ecdsa_ptr
+        .offset
+        .is_multiple_of(&(CELLS_PER_SIGNATURE as usize))
+    {
+        return Err(HintError::AddSignatureNotAPublicKey(ecdsa_ptr));
     }
     ecdsa_builtin
         .add_signature(ecdsa_ptr, &(signature_r, signature_s))
@@ -115,5 +124,34 @@ mod tests {
         vm.run_context.fp = 3;
         let ids_data = ids_data!["ecdsa_ptr", "signature_r", "signature_s"];
         assert_matches!(run_hint!(vm, ids_data, VERIFY_ECDSA_SIGNATURE), Err(HintError::AddSignatureWrongEcdsaPtr(addr)) if addr == (3,0).into());
+    }
+
+    #[test]
+    fn verify_ecdsa_signature_invalid_input_cell() {
+        let mut vm = vm!();
+        vm.builtin_runners = vec![(
+            SIGNATURE_BUILTIN_NAME,
+            SignatureBuiltinRunner::new(&EcdsaInstanceDef::default(), true).into(),
+        )];
+        vm.segments = segments![
+            ((1, 0), (0, 3)),
+            (
+                (1, 1),
+                (
+                    "3086480810278599376317923499561306189851900463386393948998357832163236918254",
+                    10
+                )
+            ),
+            (
+                (1, 2),
+                (
+                    "598673427589502599949712887611119751108407514580626464031881322743364689811",
+                    10
+                )
+            )
+        ];
+        vm.run_context.fp = 3;
+        let ids_data = ids_data!["ecdsa_ptr", "signature_r", "signature_s"];
+        assert_matches!(run_hint!(vm, ids_data, VERIFY_ECDSA_SIGNATURE), Err(HintError::AddSignatureNotAPublicKey(addr)) if addr == (0,3).into());
     }
 }

--- a/src/types/instance_definitions/ecdsa_instance_def.rs
+++ b/src/types/instance_definitions/ecdsa_instance_def.rs
@@ -1,5 +1,5 @@
-pub(crate) const _CELLS_PER_SIGNATURE: u32 = 2;
-pub(crate) const _INPUT_CELLS_PER_SIGNATURE: u32 = 2;
+pub(crate) const CELLS_PER_SIGNATURE: u32 = 2;
+pub(crate) const _INPUTCELLS_PER_SIGNATURE: u32 = 2;
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct EcdsaInstanceDef {
@@ -29,7 +29,7 @@ impl EcdsaInstanceDef {
     }
 
     pub(crate) fn _cells_per_builtin(&self) -> u32 {
-        _CELLS_PER_SIGNATURE
+        CELLS_PER_SIGNATURE
     }
 
     pub(crate) fn _range_check_units_per_builtin(&self) -> u32 {

--- a/src/vm/errors/hint_errors.rs
+++ b/src/vm/errors/hint_errors.rs
@@ -146,4 +146,6 @@ pub enum HintError {
     UnknownHint(String),
     #[error("Signature hint must point to the signature builtin segment, not {0}.")]
     AddSignatureWrongEcdsaPtr(Relocatable),
+    #[error("Signature hint must point to the public key cell, not {0}.")]
+    AddSignatureNotAPublicKey(Relocatable),
 }

--- a/src/vm/errors/hint_errors.rs
+++ b/src/vm/errors/hint_errors.rs
@@ -144,4 +144,6 @@ pub enum HintError {
     NonLeFelt(Felt, Felt),
     #[error("Unknown Hint: {0}")]
     UnknownHint(String),
+    #[error("Signature hint must point to the signature builtin segment, not {0}.")]
+    AddSignatureWrongEcdsaPtr(Relocatable),
 }


### PR DESCRIPTION
The following checks where not performed when adding a signature through the verify_signature_hints:
```
 assert (
            addr.segment_index == self.base.segment_index
        ), f"Signature hint must point to the signature builtin segment, not {addr}."
        assert (
            addr.offset % CELLS_PER_SIGNATURE == 0
        ), f"Signature hint must point to the public key cell, not {addr}."
```
Depends on: #842 (to pass clippy)