### PR TITLE
Remove references to `Relocatable`

### DIFF
--- a/src/hint_processor/builtin_hint_processor/blake2s_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/blake2s_utils.rs
@@ -47,11 +47,11 @@ output_ptr should point to the middle of an instance, right after initial_state,
 which should all have a value at this point, and right before the output portion which will be
 written by this function.*/
 fn compute_blake2s_func(vm: &mut VirtualMachine, output_rel: Relocatable) -> Result<(), HintError> {
-    let h = get_fixed_size_u32_array::<8>(&vm.get_integer_range(&(output_rel.sub_usize(26)?), 8)?)?;
+    let h = get_fixed_size_u32_array::<8>(&vm.get_integer_range(output_rel.sub_usize(26)?, 8)?)?;
     let message =
-        get_fixed_size_u32_array::<16>(&vm.get_integer_range(&(output_rel.sub_usize(18)?), 16)?)?;
-    let t = felt_to_u32(vm.get_integer(&output_rel.sub_usize(2)?)?.as_ref())?;
-    let f = felt_to_u32(vm.get_integer(&output_rel.sub_usize(1)?)?.as_ref())?;
+        get_fixed_size_u32_array::<16>(&vm.get_integer_range(output_rel.sub_usize(18)?, 16)?)?;
+    let t = felt_to_u32(vm.get_integer(output_rel.sub_usize(2)?)?.as_ref())?;
+    let f = felt_to_u32(vm.get_integer(output_rel.sub_usize(1)?)?.as_ref())?;
     let new_state =
         get_maybe_relocatable_array_from_u32(&blake2s_compress(&h, &message, t, 0, f, 0));
     let output_ptr = MaybeRelocatable::RelocatableValue(output_rel);
@@ -136,8 +136,8 @@ pub fn blake2s_add_uint256(
     let data_ptr = get_ptr_from_var_name("data", vm, ids_data, ap_tracking)?;
     let low_addr = get_relocatable_from_var_name("low", vm, ids_data, ap_tracking)?;
     let high_addr = get_relocatable_from_var_name("high", vm, ids_data, ap_tracking)?;
-    let low = vm.get_integer(&low_addr)?.into_owned();
-    let high = vm.get_integer(&high_addr)?.into_owned();
+    let low = vm.get_integer(low_addr)?.into_owned();
+    let high = vm.get_integer(high_addr)?.into_owned();
     //Main logic
     //Declare constant
     const MASK: u32 = u32::MAX;
@@ -183,8 +183,8 @@ pub fn blake2s_add_uint256_bigend(
     let data_ptr = get_ptr_from_var_name("data", vm, ids_data, ap_tracking)?;
     let low_addr = get_relocatable_from_var_name("low", vm, ids_data, ap_tracking)?;
     let high_addr = get_relocatable_from_var_name("high", vm, ids_data, ap_tracking)?;
-    let low = vm.get_integer(&low_addr)?.into_owned();
-    let high = vm.get_integer(&high_addr)?.into_owned();
+    let low = vm.get_integer(low_addr)?.into_owned();
+    let high = vm.get_integer(high_addr)?.into_owned();
     //Main logic
     //Declare constant
     const MASK: u32 = u32::MAX;
@@ -383,7 +383,7 @@ mod tests {
         let data = get_fixed_size_u32_array::<204>(
             &vm.segments
                 .memory
-                .get_integer_range(&relocatable!(2, 0), 204)
+                .get_integer_range(relocatable!(2, 0), 204)
                 .unwrap(),
         )
         .unwrap();

--- a/src/hint_processor/builtin_hint_processor/cairo_keccak/keccak_hints.rs
+++ b/src/hint_processor/builtin_hint_processor/cairo_keccak/keccak_hints.rs
@@ -49,11 +49,11 @@ pub fn keccak_write_args(
     let high_args = [high & Felt::new(u64::MAX), high >> 64];
 
     let low_args: Vec<_> = low_args.into_iter().map(MaybeRelocatable::from).collect();
-    vm.write_arg(&inputs_ptr, &low_args)
+    vm.write_arg(inputs_ptr, &low_args)
         .map_err(VirtualMachineError::MemoryError)?;
 
     let high_args: Vec<_> = high_args.into_iter().map(MaybeRelocatable::from).collect();
-    vm.write_arg(&inputs_ptr.add(2_i32), &high_args)
+    vm.write_arg(inputs_ptr.add(2_i32), &high_args)
         .map_err(VirtualMachineError::MemoryError)?;
 
     Ok(())
@@ -160,7 +160,7 @@ pub fn block_permutation(
 
     let bigint_values = u64_array_to_mayberelocatable_vec(&u64_values);
 
-    vm.write_arg(&keccak_ptr, &bigint_values)
+    vm.write_arg(keccak_ptr, &bigint_values)
         .map_err(VirtualMachineError::MemoryError)?;
 
     Ok(())
@@ -220,7 +220,7 @@ pub fn cairo_keccak_finalize(
 
     let keccak_ptr_end = get_ptr_from_var_name("keccak_ptr_end", vm, ids_data, ap_tracking)?;
 
-    vm.write_arg(&keccak_ptr_end, &padding)
+    vm.write_arg(keccak_ptr_end, &padding)
         .map_err(VirtualMachineError::MemoryError)?;
 
     Ok(())

--- a/src/hint_processor/builtin_hint_processor/dict_hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/dict_hint_utils.rs
@@ -111,7 +111,7 @@ pub fn dict_read(
     let dict_ptr = get_ptr_from_var_name("dict_ptr", vm, ids_data, ap_tracking)?;
     let dict_manager_ref = exec_scopes.get_dict_manager()?;
     let mut dict = dict_manager_ref.borrow_mut();
-    let tracker = dict.get_tracker_mut(&dict_ptr)?;
+    let tracker = dict.get_tracker_mut(dict_ptr)?;
     tracker.current_ptr.offset += DICT_ACCESS_SIZE;
     let value = tracker.get_value(&key)?;
     insert_value_from_var_name("value", value.clone(), vm, ids_data, ap_tracking)
@@ -135,7 +135,7 @@ pub fn dict_write(
     //Get tracker for dictionary
     let dict_manager_ref = exec_scopes.get_dict_manager()?;
     let mut dict = dict_manager_ref.borrow_mut();
-    let tracker = dict.get_tracker_mut(&dict_ptr)?;
+    let tracker = dict.get_tracker_mut(dict_ptr)?;
     //dict_ptr is a pointer to a struct, with the ordered fields (key, prev_value, new_value),
     //dict_ptr.prev_value will be equal to dict_ptr + 1
     let dict_ptr_prev_value = dict_ptr + 1_i32;
@@ -147,7 +147,7 @@ pub fn dict_write(
     tracker.insert_value(&key, &new_value);
     //Insert previous value into dict_ptr.prev_value
     //Addres for dict_ptr.prev_value should be dict_ptr* + 1 (defined above)
-    vm.insert_value(&dict_ptr_prev_value, prev_value)?;
+    vm.insert_value(dict_ptr_prev_value, prev_value)?;
     Ok(())
 }
 
@@ -176,7 +176,7 @@ pub fn dict_update(
     //Get tracker for dictionary
     let dict_manager_ref = exec_scopes.get_dict_manager()?;
     let mut dict = dict_manager_ref.borrow_mut();
-    let tracker = dict.get_tracker_mut(&dict_ptr)?;
+    let tracker = dict.get_tracker_mut(dict_ptr)?;
     //Check that prev_value is equal to the current value at the given key
     let current_value = tracker.get_value(&key)?;
     if current_value != &prev_value {
@@ -213,7 +213,7 @@ pub fn dict_squash_copy_dict(
     let dict_manager = dict_manager_ref.borrow();
     let dict_copy: Box<dyn Any> = Box::new(
         dict_manager
-            .get_tracker(&dict_accesses_end)?
+            .get_tracker(dict_accesses_end)?
             .get_dictionary_copy(),
     );
     exec_scopes.enter_scope(HashMap::from([
@@ -243,7 +243,7 @@ pub fn dict_squash_update_ptr(
     exec_scopes
         .get_dict_manager()?
         .borrow_mut()
-        .get_tracker_mut(&squashed_dict_start)?
+        .get_tracker_mut(squashed_dict_start)?
         .current_ptr = squashed_dict_end;
     Ok(())
 }
@@ -298,7 +298,7 @@ mod tests {
                 .borrow()
                 .trackers
                 .get(&1),
-            Some(&DictTracker::new_empty(&relocatable!(1, 0)))
+            Some(&DictTracker::new_empty(relocatable!(1, 0)))
         );
     }
 
@@ -426,7 +426,7 @@ mod tests {
                 .trackers
                 .get(&2),
             Some(&DictTracker::new_default_dict(
-                &relocatable!(2, 0),
+                relocatable!(2, 0),
                 &MaybeRelocatable::from(17),
                 None
             ))

--- a/src/hint_processor/builtin_hint_processor/find_element_hint.rs
+++ b/src/hint_processor/builtin_hint_processor/find_element_hint.rs
@@ -39,7 +39,7 @@ pub fn find_element(
     if let Some(find_element_index_value) = find_element_index {
         let find_element_index_usize = felt_to_usize(&find_element_index_value)?;
         let found_key = vm
-            .get_integer(&(array_start + (elm_size * find_element_index_usize)))
+            .get_integer(array_start + (elm_size * find_element_index_usize))
             .map_err(|_| HintError::KeyNotFound)?;
 
         if found_key.as_ref() != key.as_ref() {
@@ -71,7 +71,7 @@ pub fn find_element(
 
         for i in 0..n_elms_iter {
             let iter_key = vm
-                .get_integer(&(array_start + (elm_size * i as usize)))
+                .get_integer(array_start + (elm_size * i as usize))
                 .map_err(|_| HintError::KeyNotFound)?;
 
             if iter_key.as_ref() == key.as_ref() {
@@ -118,12 +118,12 @@ pub fn search_sorted_lower(
         }
     }
 
-    let mut array_iter = vm.get_relocatable(&rel_array_ptr)?;
+    let mut array_iter = vm.get_relocatable(rel_array_ptr)?;
     let n_elms_usize = n_elms.to_usize().ok_or(HintError::KeyNotFound)?;
     let elm_size_usize = elm_size.to_usize().ok_or(HintError::KeyNotFound)?;
 
     for i in 0..n_elms_usize {
-        let value = vm.get_integer(&array_iter)?;
+        let value = vm.get_integer(array_iter)?;
         if value.as_ref() >= key.as_ref() {
             return insert_value_from_var_name("index", Felt::new(i), vm, ids_data, ap_tracking);
         }

--- a/src/hint_processor/builtin_hint_processor/hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/hint_utils.rs
@@ -22,7 +22,7 @@ pub fn insert_value_from_var_name(
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError> {
     let var_address = get_relocatable_from_var_name(var_name, vm, ids_data, ap_tracking)?;
-    vm.insert_value(&var_address, value)
+    vm.insert_value(var_address, value)
         .map_err(HintError::Internal)
 }
 
@@ -31,7 +31,7 @@ pub fn insert_value_into_ap(
     vm: &mut VirtualMachine,
     value: impl Into<MaybeRelocatable>,
 ) -> Result<(), HintError> {
-    vm.insert_value(&vm.get_ap(), value)
+    vm.insert_value(vm.get_ap(), value)
         .map_err(HintError::Internal)
 }
 
@@ -48,7 +48,7 @@ pub fn get_ptr_from_var_name(
         .get(&String::from(var_name))
         .ok_or(HintError::FailedToGetIds)?;
     if hint_reference.dereference {
-        let value = vm.get_relocatable(&var_addr)?;
+        let value = vm.get_relocatable(var_addr)?;
         Ok(value)
     } else {
         Ok(var_addr)

--- a/src/hint_processor/builtin_hint_processor/keccak_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/keccak_utils.rs
@@ -78,7 +78,7 @@ pub fn unsafe_keccak(
             offset: data.offset + word_i,
         };
 
-        let word = vm.get_integer(&word_addr)?;
+        let word = vm.get_integer(word_addr)?;
         let n_bytes = cmp::min(16, u64_length - byte_i);
 
         if word.is_negative() || word.as_ref() >= &Felt::one().shl(8 * (n_bytes as u32)) {
@@ -102,8 +102,8 @@ pub fn unsafe_keccak(
     let high = Felt::from_bytes_be(&hashed[..16]);
     let low = Felt::from_bytes_be(&hashed[16..32]);
 
-    vm.insert_value(&high_addr, &high)?;
-    vm.insert_value(&low_addr, &low)?;
+    vm.insert_value(high_addr, &high)?;
+    vm.insert_value(low_addr, &low)?;
     Ok(())
 }
 
@@ -145,7 +145,7 @@ pub fn unsafe_keccak_finalize(
 
     // in the KeccakState struct, the field `end_ptr` is the second one, so this variable should be get from
     // the memory cell contiguous to the one where KeccakState is pointing to.
-    let end_ptr = vm.get_relocatable(&Relocatable {
+    let end_ptr = vm.get_relocatable(Relocatable {
         segment_index: keccak_state_ptr.segment_index,
         offset: keccak_state_ptr.offset + 1,
     })?;
@@ -190,8 +190,8 @@ pub fn unsafe_keccak_finalize(
     let high = Felt::from_bytes_be(&hashed[..16]);
     let low = Felt::from_bytes_be(&hashed[16..32]);
 
-    vm.insert_value(&high_addr, &high)?;
-    vm.insert_value(&low_addr, &low)?;
+    vm.insert_value(high_addr, &high)?;
+    vm.insert_value(low_addr, &low)?;
     Ok(())
 }
 

--- a/src/hint_processor/builtin_hint_processor/math_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/math_utils.rs
@@ -118,10 +118,10 @@ pub fn assert_le_felt(
     let (q_0, r_0) = (lengths_and_indices[0].0).div_mod_floor(prime_over_3_high);
     let (q_1, r_1) = (lengths_and_indices[1].0).div_mod_floor(prime_over_2_high);
 
-    vm.insert_value(&(&range_check_ptr + 1_i32), q_0)?;
-    vm.insert_value(&range_check_ptr, r_0)?;
-    vm.insert_value(&(&range_check_ptr + 3_i32), q_1)?;
-    vm.insert_value(&(&range_check_ptr + 2_i32), r_1)?;
+    vm.insert_value(range_check_ptr + 1_i32, q_0)?;
+    vm.insert_value(range_check_ptr, r_0)?;
+    vm.insert_value(range_check_ptr + 3_i32, q_1)?;
+    vm.insert_value(range_check_ptr + 2_i32, r_1)?;
     Ok(())
 }
 
@@ -306,7 +306,7 @@ pub fn split_int(
     if &res > bound {
         return Err(HintError::SplitIntLimbOutOfRange(res));
     }
-    vm.insert_value(&output, res).map_err(HintError::Internal)
+    vm.insert_value(output, res).map_err(HintError::Internal)
 }
 
 //from starkware.cairo.common.math_utils import is_positive

--- a/src/hint_processor/builtin_hint_processor/pow_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/pow_utils.rs
@@ -22,7 +22,7 @@ pub fn pow(
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError> {
     let prev_locs_addr = get_relocatable_from_var_name("prev_locs", vm, ids_data, ap_tracking)?;
-    let prev_locs_exp = vm.get_integer(&(&prev_locs_addr + 4_i32))?;
+    let prev_locs_exp = vm.get_integer(prev_locs_addr + 4_i32)?;
     let locs_bit = prev_locs_exp.is_odd();
     insert_value_from_var_name("locs", Felt::new(locs_bit as u8), vm, ids_data, ap_tracking)?;
     Ok(())

--- a/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
@@ -39,7 +39,7 @@ pub fn nondet_bigint3(
         .into_iter()
         .map(|n| MaybeRelocatable::from(Felt::new(n)))
         .collect();
-    vm.write_arg(&res_reloc, &arg)
+    vm.write_arg(res_reloc, &arg)
         .map_err(VirtualMachineError::MemoryError)?;
     Ok(())
 }
@@ -53,8 +53,8 @@ pub fn bigint_to_uint256(
     constants: &HashMap<String, Felt>,
 ) -> Result<(), HintError> {
     let x_struct = get_relocatable_from_var_name("x", vm, ids_data, ap_tracking)?;
-    let d0 = vm.get_integer(&x_struct)?;
-    let d1 = vm.get_integer(&(&x_struct + 1_i32))?;
+    let d0 = vm.get_integer(x_struct)?;
+    let d1 = vm.get_integer(x_struct + 1_i32)?;
     let d0 = d0.as_ref();
     let d1 = d1.as_ref();
     let base_86 = constants

--- a/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
@@ -85,12 +85,12 @@ pub fn compute_doubling_slope(
     let point_reloc = get_relocatable_from_var_name("point", vm, ids_data, ap_tracking)?;
 
     let (x_d0, x_d1, x_d2, y_d0, y_d1, y_d2) = (
-        vm.get_integer(&point_reloc)?,
-        vm.get_integer(&(&point_reloc + 1i32))?,
-        vm.get_integer(&(&point_reloc + 2i32))?,
-        vm.get_integer(&(&point_reloc + 3i32))?,
-        vm.get_integer(&(&point_reloc + 4i32))?,
-        vm.get_integer(&(&point_reloc + 5i32))?,
+        vm.get_integer(point_reloc)?,
+        vm.get_integer(point_reloc + 1i32)?,
+        vm.get_integer(point_reloc + 2i32)?,
+        vm.get_integer(point_reloc + 3i32)?,
+        vm.get_integer(point_reloc + 4i32)?,
+        vm.get_integer(point_reloc + 5i32)?,
     );
 
     let value = ec_double_slope(
@@ -138,24 +138,24 @@ pub fn compute_slope(
     let point0_reloc = get_relocatable_from_var_name("point0", vm, ids_data, ap_tracking)?;
 
     let (point0_x_d0, point0_x_d1, point0_x_d2, point0_y_d0, point0_y_d1, point0_y_d2) = (
-        vm.get_integer(&point0_reloc)?,
-        vm.get_integer(&(&point0_reloc + 1i32))?,
-        vm.get_integer(&(&point0_reloc + 2i32))?,
-        vm.get_integer(&(&point0_reloc + 3i32))?,
-        vm.get_integer(&(&point0_reloc + 4i32))?,
-        vm.get_integer(&(&point0_reloc + 5i32))?,
+        vm.get_integer(point0_reloc)?,
+        vm.get_integer(point0_reloc + 1i32)?,
+        vm.get_integer(point0_reloc + 2i32)?,
+        vm.get_integer(point0_reloc + 3i32)?,
+        vm.get_integer(point0_reloc + 4i32)?,
+        vm.get_integer(point0_reloc + 5i32)?,
     );
 
     //ids.point1
     let point1_reloc = get_relocatable_from_var_name("point1", vm, ids_data, ap_tracking)?;
 
     let (point1_x_d0, point1_x_d1, point1_x_d2, point1_y_d0, point1_y_d1, point1_y_d2) = (
-        vm.get_integer(&point1_reloc)?,
-        vm.get_integer(&(&point1_reloc + 1i32))?,
-        vm.get_integer(&(&point1_reloc + 2i32))?,
-        vm.get_integer(&(&point1_reloc + 3i32))?,
-        vm.get_integer(&(&point1_reloc + 4i32))?,
-        vm.get_integer(&(&point1_reloc + 5i32))?,
+        vm.get_integer(point1_reloc)?,
+        vm.get_integer(point1_reloc + 1i32)?,
+        vm.get_integer(point1_reloc + 2i32)?,
+        vm.get_integer(point1_reloc + 3i32)?,
+        vm.get_integer(point1_reloc + 4i32)?,
+        vm.get_integer(point1_reloc + 5i32)?,
     );
 
     let value = line_slope(
@@ -220,21 +220,21 @@ pub fn ec_double_assign_new_x(
     let slope_reloc = get_relocatable_from_var_name("slope", vm, ids_data, ap_tracking)?;
 
     let (slope_d0, slope_d1, slope_d2) = (
-        vm.get_integer(&slope_reloc)?,
-        vm.get_integer(&(&slope_reloc + 1_i32))?,
-        vm.get_integer(&(&slope_reloc + 2_i32))?,
+        vm.get_integer(slope_reloc)?,
+        vm.get_integer(slope_reloc + 1_i32)?,
+        vm.get_integer(slope_reloc + 2_i32)?,
     );
 
     //ids.point
     let point_reloc = get_relocatable_from_var_name("point", vm, ids_data, ap_tracking)?;
 
     let (x_d0, x_d1, x_d2, y_d0, y_d1, y_d2) = (
-        vm.get_integer(&point_reloc)?,
-        vm.get_integer(&(&point_reloc + 1i32))?,
-        vm.get_integer(&(&point_reloc + 2i32))?,
-        vm.get_integer(&(&point_reloc + 3i32))?,
-        vm.get_integer(&(&point_reloc + 4i32))?,
-        vm.get_integer(&(&point_reloc + 5i32))?,
+        vm.get_integer(point_reloc)?,
+        vm.get_integer(point_reloc + 1i32)?,
+        vm.get_integer(point_reloc + 2i32)?,
+        vm.get_integer(point_reloc + 3i32)?,
+        vm.get_integer(point_reloc + 4i32)?,
+        vm.get_integer(point_reloc + 5i32)?,
     );
 
     let slope = pack(slope_d0.as_ref(), slope_d1.as_ref(), slope_d2.as_ref());
@@ -312,30 +312,30 @@ pub fn fast_ec_add_assign_new_x(
     let slope_reloc = get_relocatable_from_var_name("slope", vm, ids_data, ap_tracking)?;
 
     let (slope_d0, slope_d1, slope_d2) = (
-        vm.get_integer(&slope_reloc)?,
-        vm.get_integer(&(&slope_reloc + 1i32))?,
-        vm.get_integer(&(&slope_reloc + 2i32))?,
+        vm.get_integer(slope_reloc)?,
+        vm.get_integer(slope_reloc + 1i32)?,
+        vm.get_integer(slope_reloc + 2i32)?,
     );
 
     //ids.point0
     let point0_reloc = get_relocatable_from_var_name("point0", vm, ids_data, ap_tracking)?;
 
     let (point0_x_d0, point0_x_d1, point0_x_d2, point0_y_d0, point0_y_d1, point0_y_d2) = (
-        vm.get_integer(&point0_reloc)?,
-        vm.get_integer(&(&point0_reloc + 1i32))?,
-        vm.get_integer(&(&point0_reloc + 2i32))?,
-        vm.get_integer(&(&point0_reloc + 3i32))?,
-        vm.get_integer(&(&point0_reloc + 4i32))?,
-        vm.get_integer(&(&point0_reloc + 5i32))?,
+        vm.get_integer(point0_reloc)?,
+        vm.get_integer(point0_reloc + 1i32)?,
+        vm.get_integer(point0_reloc + 2i32)?,
+        vm.get_integer(point0_reloc + 3i32)?,
+        vm.get_integer(point0_reloc + 4i32)?,
+        vm.get_integer(point0_reloc + 5i32)?,
     );
 
     //ids.point1.x
     let point1_reloc = get_relocatable_from_var_name("point1", vm, ids_data, ap_tracking)?;
 
     let (point1_x_d0, point1_x_d1, point1_x_d2) = (
-        vm.get_integer(&point1_reloc)?,
-        vm.get_integer(&(&point1_reloc + 1i32))?,
-        vm.get_integer(&(&point1_reloc + 2i32))?,
+        vm.get_integer(point1_reloc)?,
+        vm.get_integer(point1_reloc + 1i32)?,
+        vm.get_integer(point1_reloc + 2i32)?,
     );
 
     let slope = pack(slope_d0.as_ref(), slope_d1.as_ref(), slope_d2.as_ref());

--- a/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
@@ -77,16 +77,16 @@ pub fn pack_from_var_name(
 ) -> Result<BigInt, HintError> {
     let to_pack = get_relocatable_from_var_name(name, vm, ids_data, ap_tracking)?;
 
-    let d0 = vm.get_integer(&to_pack)?;
-    let d1 = vm.get_integer(&(&to_pack + 1_usize))?;
-    let d2 = vm.get_integer(&(&to_pack + 2_usize))?;
+    let d0 = vm.get_integer(to_pack)?;
+    let d1 = vm.get_integer(to_pack + 1_usize)?;
+    let d2 = vm.get_integer(to_pack + 2_usize)?;
     Ok(pack(d0.as_ref(), d1.as_ref(), d2.as_ref()))
 }
 
 pub fn pack_from_relocatable(rel: Relocatable, vm: &VirtualMachine) -> Result<BigInt, HintError> {
-    let d0 = vm.get_integer(&rel)?;
-    let d1 = vm.get_integer(&(&rel + 1_usize))?;
-    let d2 = vm.get_integer(&(&rel + 2_usize))?;
+    let d0 = vm.get_integer(rel)?;
+    let d1 = vm.get_integer(rel + 1_usize)?;
+    let d2 = vm.get_integer(rel + 2_usize)?;
 
     Ok(pack(d0.as_ref(), d1.as_ref(), d2.as_ref()))
 }

--- a/src/hint_processor/builtin_hint_processor/sha256_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/sha256_utils.rs
@@ -56,7 +56,7 @@ pub fn sha256_main(
     let mut message: Vec<u8> = Vec::with_capacity(4 * SHA256_INPUT_CHUNK_SIZE_FELTS);
 
     for i in 0..SHA256_INPUT_CHUNK_SIZE_FELTS {
-        let input_element = vm.get_integer(&(input_ptr + i))?;
+        let input_element = vm.get_integer(input_ptr + i)?;
         let bytes = felt_to_u32(input_element.as_ref())?.to_be_bytes();
         message.extend(bytes);
     }
@@ -73,7 +73,7 @@ pub fn sha256_main(
 
     let output_base = get_ptr_from_var_name("output", vm, ids_data, ap_tracking)?;
 
-    vm.write_arg(&output_base, &output)
+    vm.write_arg(output_base, &output)
         .map_err(VirtualMachineError::MemoryError)?;
     Ok(())
 }
@@ -109,7 +109,7 @@ pub fn sha256_finalize(
         padding.extend_from_slice(output.as_slice());
     }
 
-    vm.write_arg(&sha256_ptr_end, &padding)
+    vm.write_arg(sha256_ptr_end, &padding)
         .map_err(VirtualMachineError::MemoryError)?;
     Ok(())
 }

--- a/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/squash_dict_utils.rs
@@ -66,7 +66,7 @@ pub fn squash_dict_inner_first_iteration(
     exec_scopes.insert_value("current_access_indices", current_access_indices);
     exec_scopes.insert_value("current_access_index", first_val.clone());
     //Insert current_accesss_index into range_check_ptr
-    vm.insert_value(&range_check_ptr, first_val)
+    vm.insert_value(range_check_ptr, first_val)
         .map_err(HintError::Internal)
 }
 
@@ -142,7 +142,7 @@ pub fn squash_dict_inner_continue_loop(
     //loop_temps.delta_minus1 = loop_temps + 3 as it is the fourth field of the struct
     //Insert loop_temps.delta_minus1 into memory
     let should_continue_addr = loop_temps_addr + 3_i32;
-    vm.insert_value(&should_continue_addr, should_continue)
+    vm.insert_value(should_continue_addr, should_continue)
         .map_err(HintError::Internal)
 }
 
@@ -267,7 +267,7 @@ pub fn squash_dict(
     for i in 0..n_accesses_usize {
         let key_addr = address + DICT_ACCESS_SIZE * i;
         let key = vm
-            .get_integer(&key_addr)
+            .get_integer(key_addr)
             .map_err(|_| VirtualMachineError::ExpectedInteger(MaybeRelocatable::from(key_addr)))?;
         access_indices
             .entry(key.into_owned())

--- a/src/hint_processor/builtin_hint_processor/uint256_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/uint256_utils.rs
@@ -32,10 +32,10 @@ pub fn uint256_add(
     let shift = Felt::new(1_u32) << 128_u32;
     let a_relocatable = get_relocatable_from_var_name("a", vm, ids_data, ap_tracking)?;
     let b_relocatable = get_relocatable_from_var_name("b", vm, ids_data, ap_tracking)?;
-    let a_low = vm.get_integer(&a_relocatable)?;
-    let a_high = vm.get_integer(&(a_relocatable + 1_usize))?;
-    let b_low = vm.get_integer(&b_relocatable)?;
-    let b_high = vm.get_integer(&(b_relocatable + 1_usize))?;
+    let a_low = vm.get_integer(a_relocatable)?;
+    let a_high = vm.get_integer(a_relocatable + 1_usize)?;
+    let b_low = vm.get_integer(b_relocatable)?;
+    let b_high = vm.get_integer(b_relocatable + 1_usize)?;
     let a_low = a_low.as_ref();
     let a_high = a_high.as_ref();
     let b_low = b_low.as_ref();
@@ -104,8 +104,8 @@ pub fn uint256_sqrt(
 ) -> Result<(), HintError> {
     let n_addr = get_relocatable_from_var_name("n", vm, ids_data, ap_tracking)?;
     let root_addr = get_relocatable_from_var_name("root", vm, ids_data, ap_tracking)?;
-    let n_low = vm.get_integer(&n_addr)?;
-    let n_high = vm.get_integer(&(n_addr + 1_usize))?;
+    let n_low = vm.get_integer(n_addr)?;
+    let n_high = vm.get_integer(n_addr + 1_usize)?;
     let n_low = n_low.as_ref();
     let n_high = n_high.as_ref();
 
@@ -126,8 +126,8 @@ pub fn uint256_sqrt(
             &root
         )));
     }
-    vm.insert_value(&root_addr, Felt::new(root))?;
-    vm.insert_value(&(root_addr + 1_i32), Felt::zero())
+    vm.insert_value(root_addr, Felt::new(root))?;
+    vm.insert_value(root_addr + 1_i32, Felt::zero())
         .map_err(HintError::Internal)
 }
 
@@ -141,7 +141,7 @@ pub fn uint256_signed_nn(
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError> {
     let a_addr = get_relocatable_from_var_name("a", vm, ids_data, ap_tracking)?;
-    let a_high = vm.get_integer(&(a_addr + 1_usize))?;
+    let a_high = vm.get_integer(a_addr + 1_usize)?;
     //Main logic
     //memory[ap] = 1 if 0 <= (ids.a.high % PRIME) < 2 ** 127 else 0
     let result: Felt = if !a_high.is_negative() && a_high.as_ref() <= &Felt::new(i128::MAX) {
@@ -175,10 +175,10 @@ pub fn uint256_unsigned_div_rem(
     let quotient_addr = get_relocatable_from_var_name("quotient", vm, ids_data, ap_tracking)?;
     let remainder_addr = get_relocatable_from_var_name("remainder", vm, ids_data, ap_tracking)?;
 
-    let a_low = vm.get_integer(&a_addr)?;
-    let a_high = vm.get_integer(&(a_addr + 1_usize))?;
-    let div_low = vm.get_integer(&div_addr)?;
-    let div_high = vm.get_integer(&(div_addr + 1_usize))?;
+    let a_low = vm.get_integer(a_addr)?;
+    let a_high = vm.get_integer(a_addr + 1_usize)?;
+    let div_low = vm.get_integer(div_addr)?;
+    let div_high = vm.get_integer(div_addr + 1_usize)?;
     let a_low = a_low.as_ref();
     let a_high = a_high.as_ref();
     let div_low = div_low.as_ref();
@@ -206,13 +206,13 @@ pub fn uint256_unsigned_div_rem(
     let remainder_high = remainder.shr(128);
 
     //Insert ids.quotient.low
-    vm.insert_value(&quotient_addr, quotient_low)?;
+    vm.insert_value(quotient_addr, quotient_low)?;
     //Insert ids.quotient.high
-    vm.insert_value(&(quotient_addr + 1_i32), quotient_high)?;
+    vm.insert_value(quotient_addr + 1_i32, quotient_high)?;
     //Insert ids.remainder.low
-    vm.insert_value(&remainder_addr, remainder_low)?;
+    vm.insert_value(remainder_addr, remainder_low)?;
     //Insert ids.remainder.high
-    vm.insert_value(&(remainder_addr + 1_i32), remainder_high)?;
+    vm.insert_value(remainder_addr + 1_i32, remainder_high)?;
     Ok(())
 }
 

--- a/src/hint_processor/builtin_hint_processor/usort.rs
+++ b/src/hint_processor/builtin_hint_processor/usort.rs
@@ -48,7 +48,7 @@ pub fn usort_body(
     let mut positions_dict: HashMap<Felt, Vec<u64>> = HashMap::new();
     let mut output: Vec<Felt> = Vec::new();
     for i in 0..input_len_u64 {
-        let val = vm.get_integer(&(input_ptr + i as usize))?.into_owned();
+        let val = vm.get_integer(input_ptr + i as usize)?.into_owned();
         if let Err(output_index) = output.binary_search(&val) {
             output.insert(output_index, val.clone());
         }
@@ -65,11 +65,11 @@ pub fn usort_body(
     let output_len = output.len();
 
     for (i, sorted_element) in output.into_iter().enumerate() {
-        vm.insert_value(&(output_base + i), sorted_element)?;
+        vm.insert_value(output_base + i, sorted_element)?;
     }
 
     for (i, repetition_amount) in multiplicities.into_iter().enumerate() {
-        vm.insert_value(&(multiplicities_base + i), Felt::new(repetition_amount))?;
+        vm.insert_value(multiplicities_base + i, Felt::new(repetition_amount))?;
     }
 
     insert_value_from_var_name(

--- a/src/hint_processor/hint_processor_utils.rs
+++ b/src/hint_processor/hint_processor_utils.rs
@@ -23,7 +23,7 @@ pub fn insert_value_from_reference(
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError> {
     let var_addr = compute_addr_from_reference(hint_reference, vm, ap_tracking)?;
-    vm.insert_value(&var_addr, value)
+    vm.insert_value(var_addr, value)
         .map_err(HintError::Internal)
 }
 
@@ -41,7 +41,7 @@ pub fn get_integer_from_reference<'a>(
     }
 
     let var_addr = compute_addr_from_reference(hint_reference, vm, ap_tracking)?;
-    vm.get_integer(&var_addr).map_err(HintError::Internal)
+    vm.get_integer(var_addr).map_err(HintError::Internal)
 }
 
 ///Returns the Relocatable value stored in the given ids variable
@@ -52,7 +52,7 @@ pub fn get_ptr_from_reference(
 ) -> Result<Relocatable, HintError> {
     let var_addr = compute_addr_from_reference(hint_reference, vm, ap_tracking)?;
     if hint_reference.dereference {
-        Ok(vm.get_relocatable(&var_addr)?)
+        Ok(vm.get_relocatable(var_addr)?)
     } else {
         Ok(var_addr)
     }
@@ -124,7 +124,7 @@ pub fn compute_addr_from_reference(
 }
 
 fn apply_ap_tracking_correction(
-    ap: &Relocatable,
+    ap: Relocatable,
     ref_ap_tracking: &ApTracking,
     hint_ap_tracking: &ApTracking,
 ) -> Result<Relocatable, HintError> {
@@ -174,7 +174,7 @@ fn get_offset_value_reference(
             .as_ref()
             .ok_or(HintError::NoneApTrackingData)?;
 
-        apply_ap_tracking_correction(&vm.get_ap(), var_ap_trackig, hint_ap_tracking)?
+        apply_ap_tracking_correction(vm.get_ap(), var_ap_trackig, hint_ap_tracking)?
     };
 
     if offset.is_negative() && base_addr.offset < offset.unsigned_abs() as usize {
@@ -324,7 +324,7 @@ mod tests {
         hint_ap_tracking.group = 1;
 
         assert_matches!(
-            apply_ap_tracking_correction(&relocatable!(1, 0), &ref_ap_tracking, &hint_ap_tracking),
+            apply_ap_tracking_correction(relocatable!(1, 0), &ref_ap_tracking, &hint_ap_tracking),
             Ok(relocatable!(1, 0))
         );
     }
@@ -337,7 +337,7 @@ mod tests {
         hint_ap_tracking.group = 2;
 
         assert_matches!(
-            apply_ap_tracking_correction(&relocatable!(1, 0), &ref_ap_tracking, &hint_ap_tracking),
+            apply_ap_tracking_correction(relocatable!(1, 0), &ref_ap_tracking, &hint_ap_tracking),
             Err(HintError::InvalidTrackingGroup(1, 2))
         );
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -28,7 +28,7 @@ pub fn is_subsequence<T: PartialEq>(subsequence: &[T], mut sequence: &[T]) -> bo
     true
 }
 
-pub fn from_relocatable_to_indexes(relocatable: &Relocatable) -> (usize, usize) {
+pub fn from_relocatable_to_indexes(relocatable: Relocatable) -> (usize, usize) {
     if relocatable.segment_index.is_negative() {
         (
             -(relocatable.segment_index + 1) as usize,
@@ -450,7 +450,7 @@ pub mod test_utils {
 
     macro_rules! dict_manager {
         ($exec_scopes:expr, $tracker_num:expr, $( ($key:expr, $val:expr )),* ) => {
-            let mut tracker = DictTracker::new_empty(&relocatable!($tracker_num, 0));
+            let mut tracker = DictTracker::new_empty(relocatable!($tracker_num, 0));
             $(
             tracker.insert_value(&MaybeRelocatable::from($key), &MaybeRelocatable::from($val));
             )*
@@ -459,7 +459,7 @@ pub mod test_utils {
             $exec_scopes.insert_value("dict_manager", Rc::new(RefCell::new(dict_manager)))
         };
         ($exec_scopes:expr, $tracker_num:expr) => {
-            let  tracker = DictTracker::new_empty(&relocatable!($tracker_num, 0));
+            let  tracker = DictTracker::new_empty(relocatable!($tracker_num, 0));
             let mut dict_manager = DictManager::new();
             dict_manager.trackers.insert(2, tracker);
             $exec_scopes.insert_value("dict_manager", Rc::new(RefCell::new(dict_manager)))
@@ -470,7 +470,7 @@ pub mod test_utils {
 
     macro_rules! dict_manager_default {
         ($exec_scopes:expr, $tracker_num:expr,$default:expr, $( ($key:expr, $val:expr )),* ) => {
-            let mut tracker = DictTracker::new_default_dict(&relocatable!($tracker_num, 0), &MaybeRelocatable::from($default), None);
+            let mut tracker = DictTracker::new_default_dict(relocatable!($tracker_num, 0), &MaybeRelocatable::from($default), None);
             $(
             tracker.insert_value(&MaybeRelocatable::from($key), &MaybeRelocatable::from($val));
             )*
@@ -479,7 +479,7 @@ pub mod test_utils {
             $exec_scopes.insert_value("dict_manager", Rc::new(RefCell::new(dict_manager)))
         };
         ($exec_scopes:expr, $tracker_num:expr,$default:expr) => {
-            let tracker = DictTracker::new_default_dict(&relocatable!($tracker_num, 0), &MaybeRelocatable::from($default), None);
+            let tracker = DictTracker::new_default_dict(relocatable!($tracker_num, 0), &MaybeRelocatable::from($default), None);
             let mut dict_manager = DictManager::new();
             dict_manager.trackers.insert(2, tracker);
             $exec_scopes.insert_value("dict_manager", Rc::new(RefCell::new(dict_manager)))
@@ -753,7 +753,7 @@ mod test {
 
     #[test]
     fn check_dictionary_pass() {
-        let mut tracker = DictTracker::new_empty(&relocatable!(2, 0));
+        let mut tracker = DictTracker::new_empty(relocatable!(2, 0));
         tracker.insert_value(
             &MaybeRelocatable::from(Felt::new(5)),
             &MaybeRelocatable::from(Felt::new(10)),
@@ -771,7 +771,7 @@ mod test {
     #[test]
     #[should_panic]
     fn check_dictionary_fail() {
-        let mut tracker = DictTracker::new_empty(&relocatable!(2, 0));
+        let mut tracker = DictTracker::new_empty(relocatable!(2, 0));
         tracker.insert_value(
             &MaybeRelocatable::from(Felt::new(5)),
             &MaybeRelocatable::from(Felt::new(10)),
@@ -788,7 +788,7 @@ mod test {
 
     #[test]
     fn check_dict_ptr_pass() {
-        let tracker = DictTracker::new_empty(&relocatable!(2, 0));
+        let tracker = DictTracker::new_empty(relocatable!(2, 0));
         let mut dict_manager = DictManager::new();
         dict_manager.trackers.insert(2, tracker);
         let mut exec_scopes = ExecutionScopes::new();
@@ -802,7 +802,7 @@ mod test {
     #[test]
     #[should_panic]
     fn check_dict_ptr_fail() {
-        let tracker = DictTracker::new_empty(&relocatable!(2, 0));
+        let tracker = DictTracker::new_empty(relocatable!(2, 0));
         let mut dict_manager = DictManager::new();
         dict_manager.trackers.insert(2, tracker);
         let mut exec_scopes = ExecutionScopes::new();
@@ -815,7 +815,7 @@ mod test {
 
     #[test]
     fn dict_manager_macro() {
-        let tracker = DictTracker::new_empty(&relocatable!(2, 0));
+        let tracker = DictTracker::new_empty(relocatable!(2, 0));
         let mut dict_manager = DictManager::new();
         dict_manager.trackers.insert(2, tracker);
         let mut exec_scopes = ExecutionScopes::new();
@@ -829,7 +829,7 @@ mod test {
     #[test]
     fn dict_manager_default_macro() {
         let tracker = DictTracker::new_default_dict(
-            &relocatable!(2, 0),
+            relocatable!(2, 0),
             &MaybeRelocatable::from(Felt::new(17)),
             None,
         );
@@ -856,9 +856,9 @@ mod test {
         let reloc_1 = relocatable!(1, 5);
         let reloc_2 = relocatable!(0, 5);
         let reloc_3 = relocatable!(-1, 5);
-        assert_eq!((1, 5), from_relocatable_to_indexes(&reloc_1));
-        assert_eq!((0, 5), from_relocatable_to_indexes(&reloc_2));
-        assert_eq!((0, 5), from_relocatable_to_indexes(&reloc_3));
+        assert_eq!((1, 5), from_relocatable_to_indexes(reloc_1));
+        assert_eq!((0, 5), from_relocatable_to_indexes(reloc_2));
+        assert_eq!((0, 5), from_relocatable_to_indexes(reloc_3));
     }
 
     #[test]

--- a/src/vm/context/run_context.rs
+++ b/src/vm/context/run_context.rs
@@ -22,8 +22,8 @@ impl RunContext {
     pub fn get_fp(&self) -> Relocatable {
         Relocatable::from((1, self.fp))
     }
-    pub fn get_pc(&self) -> &Relocatable {
-        &self.pc
+    pub fn get_pc(&self) -> Relocatable {
+        self.pc
     }
 
     pub fn compute_dst_addr(

--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -71,7 +71,7 @@ impl BitwiseBuiltinRunner {
 
     pub fn deduce_memory_cell(
         &self,
-        address: &Relocatable,
+        address: Relocatable,
         memory: &Memory,
     ) -> Result<Option<MaybeRelocatable>, RunnerError> {
         let index = address.offset % self.cells_per_instance as usize;
@@ -197,7 +197,7 @@ impl BitwiseBuiltinRunner {
                 .map_err(|_| RunnerError::NoStopPointer(BITWISE_BUILTIN_NAME))?;
             let stop_pointer = segments
                 .memory
-                .get_relocatable(&stop_pointer_addr)
+                .get_relocatable(stop_pointer_addr)
                 .map_err(|_| RunnerError::NoStopPointer(BITWISE_BUILTIN_NAME))?;
             if self.base != stop_pointer.segment_index {
                 return Err(RunnerError::InvalidStopPointerIndex(
@@ -457,7 +457,7 @@ mod tests {
     fn deduce_memory_cell_bitwise_for_preset_memory_valid_and() {
         let memory = memory![((0, 5), 10), ((0, 6), 12), ((0, 7), 0)];
         let builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default(), true);
-        let result = builtin.deduce_memory_cell(&Relocatable::from((0, 7)), &memory);
+        let result = builtin.deduce_memory_cell(Relocatable::from((0, 7)), &memory);
         assert_eq!(result, Ok(Some(MaybeRelocatable::from(Felt::new(8)))));
     }
 
@@ -465,7 +465,7 @@ mod tests {
     fn deduce_memory_cell_bitwise_for_preset_memory_valid_xor() {
         let memory = memory![((0, 5), 10), ((0, 6), 12), ((0, 8), 0)];
         let builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default(), true);
-        let result = builtin.deduce_memory_cell(&Relocatable::from((0, 8)), &memory);
+        let result = builtin.deduce_memory_cell(Relocatable::from((0, 8)), &memory);
         assert_eq!(result, Ok(Some(MaybeRelocatable::from(Felt::new(6)))));
     }
 
@@ -473,7 +473,7 @@ mod tests {
     fn deduce_memory_cell_bitwise_for_preset_memory_valid_or() {
         let memory = memory![((0, 5), 10), ((0, 6), 12), ((0, 9), 0)];
         let builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default(), true);
-        let result = builtin.deduce_memory_cell(&Relocatable::from((0, 9)), &memory);
+        let result = builtin.deduce_memory_cell(Relocatable::from((0, 9)), &memory);
         assert_eq!(result, Ok(Some(MaybeRelocatable::from(Felt::new(14)))));
     }
 
@@ -481,7 +481,7 @@ mod tests {
     fn deduce_memory_cell_bitwise_for_preset_memory_incorrect_offset() {
         let memory = memory![((0, 3), 10), ((0, 4), 12), ((0, 5), 0)];
         let builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default(), true);
-        let result = builtin.deduce_memory_cell(&Relocatable::from((0, 5)), &memory);
+        let result = builtin.deduce_memory_cell(Relocatable::from((0, 5)), &memory);
         assert_eq!(result, Ok(None));
     }
 
@@ -489,7 +489,7 @@ mod tests {
     fn deduce_memory_cell_bitwise_for_preset_memory_no_values_to_operate() {
         let memory = memory![((0, 5), 12), ((0, 7), 0)];
         let builtin = BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default(), true);
-        let result = builtin.deduce_memory_cell(&Relocatable::from((0, 5)), &memory);
+        let result = builtin.deduce_memory_cell(Relocatable::from((0, 5)), &memory);
         assert_eq!(result, Ok(None));
     }
 

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -136,7 +136,7 @@ impl EcOpBuiltinRunner {
 
     pub fn deduce_memory_cell(
         &self,
-        address: &Relocatable,
+        address: Relocatable,
         memory: &Memory,
     ) -> Result<Option<MaybeRelocatable>, RunnerError> {
         //Constant values declared here
@@ -290,7 +290,7 @@ impl EcOpBuiltinRunner {
                 .map_err(|_| RunnerError::NoStopPointer(EC_OP_BUILTIN_NAME))?;
             let stop_pointer = segments
                 .memory
-                .get_relocatable(&stop_pointer_addr)
+                .get_relocatable(stop_pointer_addr)
                 .map_err(|_| RunnerError::NoStopPointer(EC_OP_BUILTIN_NAME))?;
             if self.base != stop_pointer.segment_index {
                 return Err(RunnerError::InvalidStopPointerIndex(
@@ -773,7 +773,7 @@ mod tests {
         ];
         let builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
 
-        let result = builtin.deduce_memory_cell(&Relocatable::from((3, 6)), &memory);
+        let result = builtin.deduce_memory_cell(Relocatable::from((3, 6)), &memory);
         assert_eq!(
             result,
             Ok(Some(MaybeRelocatable::from(felt_str!(
@@ -817,7 +817,7 @@ mod tests {
         ];
 
         let builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
-        let result = builtin.deduce_memory_cell(&Relocatable::from((3, 6)), &memory);
+        let result = builtin.deduce_memory_cell(Relocatable::from((3, 6)), &memory);
         assert_eq!(result, Ok(None));
     }
 
@@ -863,7 +863,7 @@ mod tests {
         ];
         let builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
 
-        let result = builtin.deduce_memory_cell(&Relocatable::from((3, 3)), &memory);
+        let result = builtin.deduce_memory_cell(Relocatable::from((3, 3)), &memory);
         assert_eq!(result, Ok(None));
     }
 
@@ -904,7 +904,7 @@ mod tests {
         let builtin = EcOpBuiltinRunner::new(&EcOpInstanceDef::default(), true);
 
         assert_eq!(
-            builtin.deduce_memory_cell(&Relocatable::from((3, 6)), &memory),
+            builtin.deduce_memory_cell(Relocatable::from((3, 6)), &memory),
             Err(RunnerError::ExpectedInteger(MaybeRelocatable::from((3, 3))))
         );
     }

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -70,14 +70,14 @@ impl HashBuiltinRunner {
 
     pub fn deduce_memory_cell(
         &self,
-        address: &Relocatable,
+        address: Relocatable,
         memory: &Memory,
     ) -> Result<Option<MaybeRelocatable>, RunnerError> {
         if address
             .offset
             .mod_floor(&(self.cells_per_instance as usize))
             != 2
-            || self.verified_addresses.borrow().contains(address)
+            || self.verified_addresses.borrow().contains(&address)
         {
             return Ok(None);
         };
@@ -94,7 +94,7 @@ impl HashBuiltinRunner {
             num_a.as_ref().map(|x| x.as_ref().map(|x| x.as_ref())),
             num_b.as_ref().map(|x| x.as_ref().map(|x| x.as_ref())),
         ) {
-            self.verified_addresses.borrow_mut().push(*address);
+            self.verified_addresses.borrow_mut().push(address);
 
             //Convert MaybeRelocatable to FieldElement
             let a_string = num_a.to_str_radix(10);
@@ -188,7 +188,7 @@ impl HashBuiltinRunner {
                 .map_err(|_| RunnerError::NoStopPointer(EC_OP_BUILTIN_NAME))?;
             let stop_pointer = segments
                 .memory
-                .get_relocatable(&stop_pointer_addr)
+                .get_relocatable(stop_pointer_addr)
                 .map_err(|_| RunnerError::NoStopPointer(EC_OP_BUILTIN_NAME))?;
             if self.base != stop_pointer.segment_index {
                 return Err(RunnerError::InvalidStopPointerIndex(
@@ -432,7 +432,7 @@ mod tests {
         let memory = memory![((0, 3), 32), ((0, 4), 72), ((0, 5), 0)];
         let builtin = HashBuiltinRunner::new(8, true);
 
-        let result = builtin.deduce_memory_cell(&Relocatable::from((0, 5)), &memory);
+        let result = builtin.deduce_memory_cell(Relocatable::from((0, 5)), &memory);
         assert_eq!(
             result,
             Ok(Some(MaybeRelocatable::from(felt_str!(
@@ -449,7 +449,7 @@ mod tests {
     fn deduce_memory_cell_pedersen_for_preset_memory_incorrect_offset() {
         let memory = memory![((0, 4), 32), ((0, 5), 72), ((0, 6), 0)];
         let builtin = HashBuiltinRunner::new(8, true);
-        let result = builtin.deduce_memory_cell(&Relocatable::from((0, 6)), &memory);
+        let result = builtin.deduce_memory_cell(Relocatable::from((0, 6)), &memory);
         assert_eq!(result, Ok(None));
     }
 
@@ -457,7 +457,7 @@ mod tests {
     fn deduce_memory_cell_pedersen_for_preset_memory_no_values_to_hash() {
         let memory = memory![((0, 4), 72), ((0, 5), 0)];
         let builtin = HashBuiltinRunner::new(8, true);
-        let result = builtin.deduce_memory_cell(&Relocatable::from((0, 5)), &memory);
+        let result = builtin.deduce_memory_cell(Relocatable::from((0, 5)), &memory);
         assert_eq!(result, Ok(None));
     }
 
@@ -466,7 +466,7 @@ mod tests {
         let memory = memory![((0, 3), 32), ((0, 4), 72), ((0, 5), 0)];
         let mut builtin = HashBuiltinRunner::new(8, true);
         builtin.verified_addresses = RefCell::new(vec![Relocatable::from((0, 5))]);
-        let result = builtin.deduce_memory_cell(&Relocatable::from((0, 5)), &memory);
+        let result = builtin.deduce_memory_cell(Relocatable::from((0, 5)), &memory);
         assert_eq!(result, Ok(None));
     }
 

--- a/src/vm/runners/builtin_runner/keccak.rs
+++ b/src/vm/runners/builtin_runner/keccak.rs
@@ -101,7 +101,7 @@ impl KeccakBuiltinRunner {
 
         if let Some((i, bits)) = self.state_rep.iter().enumerate().next() {
             let val = memory
-                .get_integer(&(first_input_addr + i))
+                .get_integer(first_input_addr + i)
                 .map_err(|_| RunnerError::ExpectedInteger((first_input_addr + i).into()))?;
 
             if val.as_ref() >= &(Felt::one() << *bits) {

--- a/src/vm/runners/builtin_runner/keccak.rs
+++ b/src/vm/runners/builtin_runner/keccak.rs
@@ -72,7 +72,7 @@ impl KeccakBuiltinRunner {
 
     pub fn deduce_memory_cell(
         &self,
-        address: &Relocatable,
+        address: Relocatable,
         memory: &Memory,
     ) -> Result<Option<MaybeRelocatable>, RunnerError> {
         let index = address.offset % self.cells_per_instance as usize;
@@ -214,7 +214,7 @@ impl KeccakBuiltinRunner {
                 .map_err(|_| RunnerError::NoStopPointer(KECCAK_BUILTIN_NAME))?;
             let stop_pointer = segments
                 .memory
-                .get_relocatable(&stop_pointer_addr)
+                .get_relocatable(stop_pointer_addr)
                 .map_err(|_| RunnerError::NoStopPointer(KECCAK_BUILTIN_NAME))?;
             if self.base != stop_pointer.segment_index {
                 return Err(RunnerError::InvalidStopPointerIndex(
@@ -586,7 +586,7 @@ mod tests {
         ];
         let builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::default(), true);
 
-        let result = builtin.deduce_memory_cell(&Relocatable::from((0, 25)), &memory);
+        let result = builtin.deduce_memory_cell(Relocatable::from((0, 25)), &memory);
         assert_eq!(
             result,
             Ok(Some(MaybeRelocatable::from(Felt::new(
@@ -605,7 +605,7 @@ mod tests {
             ((0, 8), 52)
         ];
         let builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::default(), true);
-        let result = builtin.deduce_memory_cell(&Relocatable::from((0, 1)), &memory);
+        let result = builtin.deduce_memory_cell(Relocatable::from((0, 1)), &memory);
         assert_eq!(result, Ok(None));
     }
 
@@ -613,7 +613,7 @@ mod tests {
     fn deduce_memory_cell_offset_lt_input_cell_length_none() {
         let memory = memory![((0, 4), 32)];
         let builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::default(), true);
-        let result = builtin.deduce_memory_cell(&Relocatable::from((0, 2)), &memory);
+        let result = builtin.deduce_memory_cell(Relocatable::from((0, 2)), &memory);
         assert_eq!(result, Ok(None));
     }
 
@@ -646,7 +646,7 @@ mod tests {
 
         builtin.verified_addresses.push(Relocatable::from((0, 16)));
 
-        let result = builtin.deduce_memory_cell(&Relocatable::from((0, 25)), &memory);
+        let result = builtin.deduce_memory_cell(Relocatable::from((0, 25)), &memory);
         assert_eq!(result, Ok(None));
     }
 
@@ -659,7 +659,7 @@ mod tests {
         builtin.n_input_cells = 0;
         builtin.cells_per_instance = 100;
 
-        let result = builtin.deduce_memory_cell(&Relocatable::from((0, 99)), &memory);
+        let result = builtin.deduce_memory_cell(Relocatable::from((0, 99)), &memory);
 
         assert_eq!(result, Err(RunnerError::NonRelocatableAddress));
     }
@@ -670,7 +670,7 @@ mod tests {
 
         let builtin = KeccakBuiltinRunner::new(&KeccakInstanceDef::default(), true);
 
-        let result = builtin.deduce_memory_cell(&Relocatable::from((0, 15)), &memory);
+        let result = builtin.deduce_memory_cell(Relocatable::from((0, 15)), &memory);
 
         assert_eq!(result, Ok(None));
     }
@@ -703,7 +703,7 @@ mod tests {
         let keccak_instance = KeccakInstanceDef::new(2048, vec![1; 8]);
         let builtin = KeccakBuiltinRunner::new(&keccak_instance, true);
 
-        let result = builtin.deduce_memory_cell(&Relocatable::from((0, 25)), &memory);
+        let result = builtin.deduce_memory_cell(Relocatable::from((0, 25)), &memory);
 
         assert_eq!(
             result,

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -157,7 +157,7 @@ impl BuiltinRunner {
 
     pub fn deduce_memory_cell(
         &self,
-        address: &Relocatable,
+        address: Relocatable,
         memory: &Memory,
     ) -> Result<Option<MaybeRelocatable>, RunnerError> {
         match *self {
@@ -354,7 +354,7 @@ impl BuiltinRunner {
                 let offset = cells_per_instance * i + j;
                 if let None | Some(None) = builtin_segment.get(offset) {
                     vm.verify_auto_deductions_for_addr(
-                        &Relocatable::from((builtin_segment_index as isize, offset)),
+                        Relocatable::from((builtin_segment_index as isize, offset)),
                         self,
                     )?;
                 }

--- a/src/vm/runners/builtin_runner/output.rs
+++ b/src/vm/runners/builtin_runner/output.rs
@@ -45,7 +45,7 @@ impl OutputBuiltinRunner {
 
     pub fn deduce_memory_cell(
         &self,
-        _address: &Relocatable,
+        _address: Relocatable,
         _memory: &Memory,
     ) -> Result<Option<MaybeRelocatable>, RunnerError> {
         Ok(None)
@@ -95,7 +95,7 @@ impl OutputBuiltinRunner {
                 .map_err(|_| RunnerError::NoStopPointer(OUTPUT_BUILTIN_NAME))?;
             let stop_pointer = segments
                 .memory
-                .get_relocatable(&stop_pointer_addr)
+                .get_relocatable(stop_pointer_addr)
                 .map_err(|_| RunnerError::NoStopPointer(OUTPUT_BUILTIN_NAME))?;
             if self.base != stop_pointer.segment_index {
                 return Err(RunnerError::InvalidStopPointerIndex(
@@ -404,7 +404,7 @@ mod tests {
         let pointer = Relocatable::from((2, 2));
 
         assert_eq!(
-            builtin.deduce_memory_cell(&pointer, &vm.segments.memory),
+            builtin.deduce_memory_cell(pointer, &vm.segments.memory),
             Ok(None)
         );
     }

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -87,9 +87,9 @@ impl RangeCheckBuiltinRunner {
 
     pub fn add_validation_rule(&self, memory: &mut Memory) -> Result<(), RunnerError> {
         let rule: ValidationRule = ValidationRule(Box::new(
-            |memory: &Memory, address: &Relocatable| -> Result<Vec<Relocatable>, MemoryError> {
+            |memory: &Memory, address: Relocatable| -> Result<Vec<Relocatable>, MemoryError> {
                 if let MaybeRelocatable::Int(ref num) = memory
-                    .get(address)?
+                    .get(&address)?
                     .ok_or(MemoryError::FoundNonInt)?
                     .into_owned()
                 {
@@ -114,7 +114,7 @@ impl RangeCheckBuiltinRunner {
 
     pub fn deduce_memory_cell(
         &self,
-        _address: &Relocatable,
+        _address: Relocatable,
         _memory: &Memory,
     ) -> Result<Option<MaybeRelocatable>, RunnerError> {
         Ok(None)
@@ -219,7 +219,7 @@ impl RangeCheckBuiltinRunner {
                 .map_err(|_| RunnerError::NoStopPointer(RANGE_CHECK_BUILTIN_NAME))?;
             let stop_pointer = segments
                 .memory
-                .get_relocatable(&stop_pointer_addr)
+                .get_relocatable(stop_pointer_addr)
                 .map_err(|_| RunnerError::NoStopPointer(RANGE_CHECK_BUILTIN_NAME))?;
             if self.base != stop_pointer.segment_index {
                 return Err(RunnerError::InvalidStopPointerIndex(

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -439,8 +439,7 @@ impl CairoRunner {
         // Mark all addresses from the program segment as accessed
         let prog_segment_index = self
             .program_base
-            .as_ref()
-            .unwrap_or(&Relocatable::from((0, 0)))
+            .unwrap_or(Relocatable::from((0, 0)))
             .segment_index;
 
         let initial_accessed_addresses = (0..self.program.data.len())
@@ -802,9 +801,9 @@ impl CairoRunner {
         let mut relocated_trace = Vec::<RelocatedTraceEntry>::with_capacity(trace.len());
         for entry in trace {
             relocated_trace.push(RelocatedTraceEntry {
-                pc: relocate_trace_register(&entry.pc, relocation_table)?,
-                ap: relocate_trace_register(&entry.ap, relocation_table)?,
-                fp: relocate_trace_register(&entry.fp, relocation_table)?,
+                pc: relocate_trace_register(entry.pc, relocation_table)?,
+                ap: relocate_trace_register(entry.ap, relocation_table)?,
+                fp: relocate_trace_register(entry.fp, relocation_table)?,
             })
         }
         self.relocated_trace = Some(relocated_trace);
@@ -908,7 +907,7 @@ impl CairoRunner {
             let value = vm
                 .segments
                 .memory
-                .get_integer(&(base, i).into())
+                .get_integer((base, i).into())
                 .map_err(|_| RunnerError::MemoryGet((base, i).into()))?
                 .to_bigint();
             writeln!(stdout, "{value}").map_err(|_| RunnerError::WriteFail)?;

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -439,7 +439,7 @@ impl CairoRunner {
         // Mark all addresses from the program segment as accessed
         let prog_segment_index = self
             .program_base
-            .unwrap_or(Relocatable::from((0, 0)))
+            .unwrap_or_else(|| Relocatable::from((0, 0)))
             .segment_index;
 
         let initial_accessed_addresses = (0..self.program.data.len())

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -892,14 +892,14 @@ impl CairoRunner {
         };
 
         let segment_used_sizes = vm.segments.compute_effective_sizes();
-        let segment_index: usize = builtin.base();
+        let segment_index = builtin.base();
         #[allow(deprecated)]
         for i in 0..segment_used_sizes[segment_index] {
             let value = vm
                 .segments
                 .memory
-                .get_integer((base, i).into())
-                .map_err(|_| RunnerError::MemoryGet((base, i).into()))?
+                .get_integer((segment_index as isize, i).into())
+                .map_err(|_| RunnerError::MemoryGet((segment_index as isize, i).into()))?
                 .to_bigint();
             writeln!(stdout, "{value}").map_err(|_| RunnerError::WriteFail)?;
         }

--- a/src/vm/trace/mod.rs
+++ b/src/vm/trace/mod.rs
@@ -17,7 +17,7 @@ pub fn get_perm_range_check_limits(
     trace
         .iter()
         .try_fold(None, |offsets: Option<(isize, isize)>, trace| {
-            let instruction = memory.get_integer(&trace.pc)?;
+            let instruction = memory.get_integer(trace.pc)?;
             let immediate =
                 memory.get::<Relocatable>(&(trace.pc.segment_index, trace.pc.offset + 1).into())?;
 

--- a/src/vm/trace/trace_entry.rs
+++ b/src/vm/trace/trace_entry.rs
@@ -19,7 +19,7 @@ pub struct RelocatedTraceEntry {
 }
 
 pub fn relocate_trace_register(
-    value: &Relocatable,
+    value: Relocatable,
     relocation_table: &Vec<usize>,
 ) -> Result<usize, TraceError> {
     let segment_index: usize = value.segment_index.try_into().map_err(|_| {
@@ -44,7 +44,7 @@ mod tests {
         };
         let relocation_table = vec![1, 2, 5];
         assert_eq!(
-            relocate_trace_register(&value, &relocation_table).unwrap(),
+            relocate_trace_register(value, &relocation_table).unwrap(),
             12
         );
     }
@@ -56,7 +56,7 @@ mod tests {
             offset: 7,
         };
         let relocation_table = vec![1, 2];
-        let error = relocate_trace_register(&value, &relocation_table);
+        let error = relocate_trace_register(value, &relocation_table);
         assert_eq!(error, Err(TraceError::NoRelocationFound));
         assert_eq!(
             error.unwrap_err().to_string(),
@@ -70,7 +70,7 @@ mod tests {
             segment_index: -2,
             offset: 7,
         };
-        let error = relocate_trace_register(&value, &Vec::new());
+        let error = relocate_trace_register(value, &Vec::new());
         assert_eq!(
             error,
             Err(TraceError::MemoryError(

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -12,7 +12,7 @@ use std::{
 };
 pub struct ValidationRule(
     #[allow(clippy::type_complexity)]
-    pub  Box<dyn Fn(&Memory, &Relocatable) -> Result<Vec<Relocatable>, MemoryError>>,
+    pub  Box<dyn Fn(&Memory, Relocatable) -> Result<Vec<Relocatable>, MemoryError>>,
 );
 
 pub struct Memory {
@@ -41,14 +41,13 @@ impl Memory {
     pub fn insert<'a, K: 'a, V: 'a>(&mut self, key: &'a K, val: &'a V) -> Result<(), MemoryError>
     where
         Relocatable: TryFrom<&'a K>,
-        MaybeRelocatable: From<&'a K>,
         MaybeRelocatable: From<&'a V>,
     {
         let relocatable: Relocatable = key
             .try_into()
             .map_err(|_| MemoryError::AddressNotRelocatable)?;
         let val = MaybeRelocatable::from(val);
-        let (value_index, value_offset) = from_relocatable_to_indexes(&relocatable);
+        let (value_index, value_offset) = from_relocatable_to_indexes(relocatable);
 
         let data = if relocatable.segment_index.is_negative() {
             &mut self.temp_data
@@ -81,7 +80,7 @@ impl Memory {
                 }
             }
         };
-        self.validate_memory_cell(&relocatable)
+        self.validate_memory_cell(relocatable)
     }
 
     /// Retrieve a value from memory (either normal or temporary) and apply relocation rules
@@ -101,7 +100,7 @@ impl Memory {
         } else {
             &self.data
         };
-        let (i, j) = from_relocatable_to_indexes(&relocatable);
+        let (i, j) = from_relocatable_to_indexes(relocatable);
         if data.len() > i && data[i].len() > j {
             if let Some(ref element) = data[i][j] {
                 return Ok(Some(self.relocate_value(element)));
@@ -113,7 +112,7 @@ impl Memory {
 
     // Version of Memory.relocate_value() that doesn't require a self reference
     fn relocate_address(
-        addr: &Relocatable,
+        addr: Relocatable,
         relocation_rules: &HashMap<usize, Relocatable>,
     ) -> MaybeRelocatable {
         let segment_idx = addr.segment_index;
@@ -138,7 +137,7 @@ impl Memory {
             for value in segment.iter_mut() {
                 match value {
                     Some(MaybeRelocatable::RelocatableValue(addr)) if addr.segment_index < 0 => {
-                        *value = Some(Memory::relocate_address(addr, &self.relocation_rules));
+                        *value = Some(Memory::relocate_address(*addr, &self.relocation_rules));
                     }
                     _ => {}
                 }
@@ -200,8 +199,8 @@ impl Memory {
     //Gets the value from memory address.
     //If the value is an MaybeRelocatable::Int(Bigint) return &Bigint
     //else raises Err
-    pub fn get_integer(&self, key: &Relocatable) -> Result<Cow<Felt>, VirtualMachineError> {
-        match self.get(key).map_err(VirtualMachineError::MemoryError)? {
+    pub fn get_integer(&self, key: Relocatable) -> Result<Cow<Felt>, VirtualMachineError> {
+        match self.get(&key).map_err(VirtualMachineError::MemoryError)? {
             Some(Cow::Borrowed(MaybeRelocatable::Int(int))) => Ok(Cow::Borrowed(int)),
             Some(Cow::Owned(MaybeRelocatable::Int(int))) => Ok(Cow::Owned(int)),
             _ => Err(VirtualMachineError::ExpectedInteger(
@@ -210,8 +209,8 @@ impl Memory {
         }
     }
 
-    pub fn get_relocatable(&self, key: &Relocatable) -> Result<Relocatable, VirtualMachineError> {
-        match self.get(key).map_err(VirtualMachineError::MemoryError)? {
+    pub fn get_relocatable(&self, key: Relocatable) -> Result<Relocatable, VirtualMachineError> {
+        match self.get(&key).map_err(VirtualMachineError::MemoryError)? {
             Some(Cow::Borrowed(MaybeRelocatable::RelocatableValue(rel))) => Ok(*rel),
             Some(Cow::Owned(MaybeRelocatable::RelocatableValue(rel))) => Ok(rel),
             _ => Err(VirtualMachineError::ExpectedRelocatable(
@@ -222,10 +221,10 @@ impl Memory {
 
     pub fn insert_value<T: Into<MaybeRelocatable>>(
         &mut self,
-        key: &Relocatable,
+        key: Relocatable,
         val: T,
     ) -> Result<(), VirtualMachineError> {
-        self.insert(key, &val.into())
+        self.insert(&key, &val.into())
             .map_err(VirtualMachineError::MemoryError)
     }
 
@@ -233,8 +232,8 @@ impl Memory {
         self.validation_rules.insert(segment_index, rule);
     }
 
-    fn validate_memory_cell(&mut self, addr: &Relocatable) -> Result<(), MemoryError> {
-        if !self.validated_addresses.contains(addr) {
+    fn validate_memory_cell(&mut self, addr: Relocatable) -> Result<(), MemoryError> {
+        if !self.validated_addresses.contains(&addr) {
             if let Some(rule) = addr
                 .segment_index
                 .to_usize()
@@ -252,7 +251,7 @@ impl Memory {
                 for offset in 0..self.data[*index].len() {
                     let addr = Relocatable::from((*index as isize, offset));
                     if !self.validated_addresses.contains(&addr) {
-                        self.validated_addresses.extend(rule.0(self, &addr)?);
+                        self.validated_addresses.extend(rule.0(self, addr)?);
                     }
                 }
             }
@@ -293,13 +292,13 @@ impl Memory {
 
     pub fn get_integer_range(
         &self,
-        addr: &Relocatable,
+        addr: Relocatable,
         size: usize,
     ) -> Result<Vec<Cow<Felt>>, VirtualMachineError> {
         let mut values = Vec::new();
 
         for i in 0..size {
-            values.push(self.get_integer(&(addr + i))?);
+            values.push(self.get_integer(addr + i)?);
         }
 
         Ok(values)
@@ -724,7 +723,7 @@ mod memory_tests {
         let memory = memory![((0, 0), 10)];
         assert_eq!(
             memory
-                .get_integer(&Relocatable::from((0, 0)))
+                .get_integer(Relocatable::from((0, 0)))
                 .unwrap()
                 .as_ref(),
             &Felt::new(10)
@@ -743,7 +742,7 @@ mod memory_tests {
             )
             .unwrap();
         assert_matches!(
-            segments.memory.get_integer(&Relocatable::from((0, 0))),
+            segments.memory.get_integer(Relocatable::from((0, 0))),
             Err(VirtualMachineError::ExpectedInteger(
                 e
             )) if e == MaybeRelocatable::from((0, 0))
@@ -1322,11 +1321,11 @@ mod memory_tests {
             .unwrap();
 
         assert_eq!(
-            Memory::relocate_address(&(-1, 0).into(), &memory.relocation_rules),
+            Memory::relocate_address((-1, 0).into(), &memory.relocation_rules),
             MaybeRelocatable::RelocatableValue((2, 0).into()),
         );
         assert_eq!(
-            Memory::relocate_address(&(-2, 1).into(), &memory.relocation_rules),
+            Memory::relocate_address((-2, 1).into(), &memory.relocation_rules),
             MaybeRelocatable::RelocatableValue((2, 3).into()),
         );
     }
@@ -1335,11 +1334,11 @@ mod memory_tests {
     fn relocate_address_no_rules() {
         let memory = Memory::new();
         assert_eq!(
-            Memory::relocate_address(&(-1, 0).into(), &memory.relocation_rules),
+            Memory::relocate_address((-1, 0).into(), &memory.relocation_rules),
             MaybeRelocatable::RelocatableValue((-1, 0).into()),
         );
         assert_eq!(
-            Memory::relocate_address(&(-2, 1).into(), &memory.relocation_rules),
+            Memory::relocate_address((-2, 1).into(), &memory.relocation_rules),
             MaybeRelocatable::RelocatableValue((-2, 1).into()),
         );
     }
@@ -1348,11 +1347,11 @@ mod memory_tests {
     fn relocate_address_real_addr() {
         let memory = Memory::new();
         assert_eq!(
-            Memory::relocate_address(&(1, 0).into(), &memory.relocation_rules),
+            Memory::relocate_address((1, 0).into(), &memory.relocation_rules),
             MaybeRelocatable::RelocatableValue((1, 0).into()),
         );
         assert_eq!(
-            Memory::relocate_address(&(1, 1).into(), &memory.relocation_rules),
+            Memory::relocate_address((1, 1).into(), &memory.relocation_rules),
             MaybeRelocatable::RelocatableValue((1, 1).into()),
         );
     }

--- a/src/vm/vm_memory/memory_segments.rs
+++ b/src/vm/vm_memory/memory_segments.rs
@@ -119,11 +119,11 @@ impl MemorySegmentManager {
             Ok(value.clone())
         } else if let Some(value) = arg.downcast_ref::<Vec<MaybeRelocatable>>() {
             let base = self.add();
-            self.write_arg(&base, value)?;
+            self.write_arg(base, value)?;
             Ok(base.into())
         } else if let Some(value) = arg.downcast_ref::<Vec<Relocatable>>() {
             let base = self.add();
-            self.write_arg(&base, value)?;
+            self.write_arg(base, value)?;
             Ok(base.into())
         } else {
             Err(VirtualMachineError::NotImplemented)
@@ -155,7 +155,7 @@ impl MemorySegmentManager {
 
     pub fn write_arg(
         &mut self,
-        ptr: &Relocatable,
+        ptr: Relocatable,
         arg: &dyn Any,
     ) -> Result<MaybeRelocatable, MemoryError> {
         if let Some(vector) = arg.downcast_ref::<Vec<MaybeRelocatable>>() {
@@ -202,7 +202,7 @@ impl MemorySegmentManager {
 
         let mut accessed_offsets_sets = HashMap::new();
         for addr in accessed_addresses {
-            let (index, offset) = from_relocatable_to_indexes(&addr);
+            let (index, offset) = from_relocatable_to_indexes(addr);
             let (segment_size, offset_set) = match accessed_offsets_sets.get_mut(&index) {
                 Some(x) => x,
                 None => {
@@ -489,7 +489,7 @@ mod tests {
             segments.add();
         }
 
-        let exec = segments.write_arg(&ptr, &data);
+        let exec = segments.write_arg(ptr, &data);
 
         assert_eq!(exec, Ok(MaybeRelocatable::from((1, 3))));
         assert_eq!(
@@ -515,7 +515,7 @@ mod tests {
             segments.add();
         }
 
-        let exec = segments.write_arg(&ptr, &data);
+        let exec = segments.write_arg(ptr, &data);
 
         assert_eq!(exec, Ok(MaybeRelocatable::from((1, 3))));
         assert_eq!(


### PR DESCRIPTION
Since `Relocatable` implements `Copy`, there is no need to hold references to it
