### PR TITLE
Get rid of uninformative `FailedToComputeOperands` error

### DIFF
--- a/src/vm/errors/hint_errors.rs
+++ b/src/vm/errors/hint_errors.rs
@@ -10,8 +10,12 @@ use super::{exec_scope_errors::ExecScopeError, vm_errors::VirtualMachineError};
 pub enum HintError {
     #[error("HintProcessor failed retrieve the compiled data necessary for hint execution")]
     WrongHintData,
-    #[error("Failed to get ids for hint execution")]
-    FailedToGetIds,
+    #[error("Unknown identifier {0}")]
+    UnknownIdentifier(String),
+    #[error("Expected ids.{0} to be an Integer value")]
+    IdentifierNotInteger(String),
+    #[error("Expected ids.{0} to be a Relocatable value")]
+    IdentifierNotRelocatable(String),
     #[error("Tried to compute an address but there was no register in the reference.")]
     NoRegisterInReference,
     #[error("Custom Hint Error: {0}")]


### PR DESCRIPTION
Currently, when retrieving ids values from memory, all internal memory errors get replaced by the `FailedToComputeOperands` error, which doesnt give us much information about what went wrong.
This PR aims to remove this error, and replace it with variants that state which is the identifier that couldnt be computed.
Also, methods reflecting internal computation of ids values and addresses will have their return values changed to Option<>, as their errors arent and wont be used