### PR TITLE
Test untested functions and traits of  `Felt`

### DIFF
--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -598,7 +598,7 @@ impl Integer for FeltBigInt<FIELD_HIGH, FIELD_LOW> {
     }
 
     fn divides(&self, other: &Self) -> bool {
-        self.is_multiple_of(&other)
+        self.is_multiple_of(other)
     }
 
     fn gcd(&self, other: &Self) -> Self {

--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -598,7 +598,7 @@ impl Integer for FeltBigInt<FIELD_HIGH, FIELD_LOW> {
     }
 
     fn divides(&self, other: &Self) -> bool {
-        self.val.is_multiple_of(&other.val)
+        self.is_multiple_of(&other)
     }
 
     fn gcd(&self, other: &Self) -> Self {

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -1074,7 +1074,7 @@ mod test {
     }
 
     #[test]
-    // Checks that the result of perfforming a bit and operation between zeroes is zero
+    // Checks that the result of performing a bit and operation between zeroes is zero
     fn bit_and_zeros_in_range() {
         let x = Felt::new(0);
         let y = Felt::new(0);
@@ -1130,5 +1130,34 @@ mod test {
         let felt_non_zero = Felt::new(3);
         assert!(felt_zero.is_zero());
         assert!(!felt_non_zero.is_zero())
+    }
+
+    #[test]
+    fn one_value() {
+        let one = BigUint::one();
+        let felt_one = Felt::one().to_biguint();
+        assert_eq!(one, felt_one)
+    }
+
+    #[test]
+    fn is_one() {
+        let felt_one = Felt::one();
+        let felt_non_one = Felt::new(8);
+        assert!(felt_one.is_one());
+        assert!(!felt_non_one.is_one())
+    }
+
+    /// Tests the multiplicative identity of the implementation of One trait for felts
+    ///
+    /// ```{.text}
+    /// a * 1 = a       ∀ a
+    /// 1 * a = a       ∀ a
+    /// ```
+    #[test]
+    fn one_multiplicative_identity() {
+        let one = Felt::one();
+        let felt = Felt::new(99);
+        assert_eq!(felt, &felt * &one);
+        assert_eq!(felt, &one * &felt)
     }
 }

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -1088,7 +1088,6 @@ mod test {
             let x = Felt::parse_bytes(x.as_bytes(), 10).unwrap();
             let y = Felt::parse_bytes(y.as_bytes(), 10).unwrap();
             prop_assert!(x.is_multiple_of(&y));
-            // prop_assert!(x.divides(&y));
         }
 
         #[test]
@@ -1146,6 +1145,7 @@ mod test {
             prop_assert_eq!(&x, &(&x * &one));
             prop_assert_eq!(&x, &(&one * &x));
         }
+
         #[test]
         fn non_zero_felt_is_always_positive(ref x in FELT_NON_ZERO_PATTERN) {
             let x = Felt::parse_bytes(x.as_bytes(), 10).unwrap();
@@ -1157,7 +1157,6 @@ mod test {
             let x = Felt::parse_bytes(x.as_bytes(), 10).unwrap();
             prop_assert!(!x.is_negative())
         }
-
 
         #[test]
         fn non_zero_felt_signum_is_always_one(ref x in FELT_NON_ZERO_PATTERN) {

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -1053,6 +1053,34 @@ mod test {
             let y = Felt::parse_bytes(y.as_bytes(), 10).unwrap();
             prop_assert!(x.is_multiple_of(&y));
         }
+
+        /// Tests the additive identity of the implementation of Zero trait for felts
+        ///
+        /// ```{.text}
+        /// x + 0 = x       ∀ x
+        /// 0 + x = x       ∀ x
+        #[test]
+        fn zero_additive_identity(ref x in "(0|[1-9][0-9]*)") {
+            let x = Felt::parse_bytes(x.as_bytes(), 10).unwrap();
+            let zero = Felt::zero();
+            prop_assert_eq!(&x, &(&x + &zero));
+            prop_assert_eq!(&x, &(&zero + &x))
+        }
+
+
+        /// Tests the multiplicative identity of the implementation of One trait for felts
+        ///
+        /// ```{.text}
+        /// x * 1 = x       ∀ x
+        /// 1 * x = x       ∀ x
+        /// ```
+        #[test]
+        fn one_multiplicative_identity(ref x in "(0|[1-9][0-9]*)") {
+            let x = Felt::parse_bytes(x.as_bytes(), 10).unwrap();
+            let one = Felt::one();
+            prop_assert_eq!(&x, &(&x * &one), "{}", x);
+            prop_assert_eq!(&x, &(&one * &x));
+        }
     }
 
     #[test]
@@ -1145,32 +1173,5 @@ mod test {
         let felt_non_one = Felt::new(8);
         assert!(felt_one.is_one());
         assert!(!felt_non_one.is_one())
-    }
-
-    /// Tests the additive identity of the implementation of Zero trait for felts
-    ///
-    /// ```{.text}
-    /// a + 0 = a       ∀ a
-    /// 1 + 0 = a       ∀ a
-    #[test]
-    fn zero_additive_identity() {
-        let zero = Felt::zero();
-        let felt = Felt::new(5);
-        assert_eq!(felt, &felt + &zero);
-        assert_eq!(felt, &zero + &felt)
-    }
-
-    /// Tests the multiplicative identity of the implementation of One trait for felts
-    ///
-    /// ```{.text}
-    /// a * 1 = a       ∀ a
-    /// 1 * a = a       ∀ a
-    /// ```
-    #[test]
-    fn one_multiplicative_identity() {
-        let one = Felt::one();
-        let felt = Felt::new(99);
-        assert_eq!(felt, &felt * &one);
-        assert_eq!(felt, &one * &felt)
     }
 }

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -1147,6 +1147,19 @@ mod test {
         assert!(!felt_non_one.is_one())
     }
 
+    /// Tests the additive identity of the implementation of Zero trait for felts
+    ///
+    /// ```{.text}
+    /// a + 0 = a       ∀ a
+    /// 1 + 0 = a       ∀ a
+    #[test]
+    fn zero_additive_identity() {
+        let zero = Felt::zero();
+        let felt = Felt::new(5);
+        assert_eq!(felt, &felt + &zero);
+        assert_eq!(felt, &zero + &felt)
+    }
+
     /// Tests the multiplicative identity of the implementation of One trait for felts
     ///
     /// ```{.text}

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -1059,12 +1059,13 @@ mod test {
         /// ```{.text}
         /// x + 0 = x       ∀ x
         /// 0 + x = x       ∀ x
+        /// ```
         #[test]
         fn zero_additive_identity(ref x in "(0|[1-9][0-9]*)") {
             let x = Felt::parse_bytes(x.as_bytes(), 10).unwrap();
             let zero = Felt::zero();
             prop_assert_eq!(&x, &(&x + &zero));
-            prop_assert_eq!(&x, &(&zero + &x))
+            prop_assert_eq!(&x, &(&zero + &x));
         }
 
 
@@ -1078,7 +1079,7 @@ mod test {
         fn one_multiplicative_identity(ref x in "(0|[1-9][0-9]*)") {
             let x = Felt::parse_bytes(x.as_bytes(), 10).unwrap();
             let one = Felt::one();
-            prop_assert_eq!(&x, &(&x * &one), "{}", x);
+            prop_assert_eq!(&x, &(&x * &one));
             prop_assert_eq!(&x, &(&one * &x));
         }
     }


### PR DESCRIPTION
## Description
Issue: #823

We added three tests for `num_traits::One`:

- [x] `one_value` to test `One::one`
- [x] `is_one` to test `One::is_zero`
- [x] `one_multiplicative_identity` to test the multiplicative identity:

```
x * 1 = x       ∀ x
1 * x = x       ∀ x
```
- [x] `zero_additive_identity` to test the additive identity: of `num_traits::Zero`:
``` 
x + 0 = x       ∀ x
0 + x = x       ∀ x
```

Tests for `num_traits::Signed` implementation
   
- [x] `felt_is_never_negative`
- [x] `non_zero_felt_is_always_positive`
- [x]  `non_zero_felt_signum_is_always_one`
- [x] `signum_of_zero_is_zero`
- [x]  `sub_abs`
- [x]  `abs`

Tests for `Integer`:
- [x] `divides_doesnt_panic`
- [x] `gcd_doesnt_panic`
- [x] `is_even_always_true`
- [x] `is_odd_always_false`

Tests for `FromPrimitive` and `ToPrimitive`:
- [x] `from_u64_and_to_u64_primitive`
- [x] `from_i64_and_to_i64_primitive`

Tests for:
- [x] `modpow_in_range`
- [x] `sqrt_in_range`
- [x] `sqrt_is_inv_square`

Tests for `Add`,  `AddAssign`,  `Add<u32>`, `Sub<u32>`, `Sub<usize>`:

- [x] `add_u32_in_range`
- [x] `add_u32_is_inv_sub`
- [x] `sub_u32_in_range`
- [x] `sub_u32_is_inv_add`
- [x] `sub_uszie_in_range`
- [x] `sub_usize_is_inv_add`
- [x] `add_in_range`
- [x] `add_is_inv_sub`
- [x] `add_assign_in_range`

We tested the reference variant for 

- [x] `sub_assign_in_range`
- [x] `neg_in_range`
- [x] `pow_in_range`

As a result of writing tests, we discoverd bugs and fixed the implementation of `is_even`, `is_odd` and `divides`

## Checklist
- [x] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
