### PR TITLE
Extend IAI benchmark to include all serializations and proof mode

### DIFF
--- a/.github/workflows/iai_pr.yml
+++ b/.github/workflows/iai_pr.yml
@@ -70,4 +70,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-iai-benchmark-cache-
     - name: Run iai benchmarks
+      env:
+        RUST_BACKTRACE: 1
       run: make iai-benchmark-action

--- a/.github/workflows/iai_pr.yml
+++ b/.github/workflows/iai_pr.yml
@@ -70,6 +70,4 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-iai-benchmark-cache-
     - name: Run iai benchmarks
-      env:
-        RUST_BACKTRACE: 1
       run: make iai-benchmark-action

--- a/bench/iai_benchmark.rs
+++ b/bench/iai_benchmark.rs
@@ -17,22 +17,36 @@ macro_rules! iai_bench_expand_prog {
                 ..cairo_vm::cairo_run::CairoRunConfig::default()
             };
             let mut hint_executor = BuiltinHintProcessor::new_empty();
-            let path = Path::new(concat!(
+            let program_path = Path::new(concat!(
                 "cairo_programs/benchmarks/",
                 stringify!($val),
                 ".json"
             ));
+            // FIXME: this should discard writes, but opening /dev/null doesn't
+            // seem to be working in the CI
+            let trace_path = Path::new(concat!(
+                "cairo_programs/benchmarks/",
+                stringify!($val),
+                ".trace"
+            ));
+            let memory_path = Path::new(concat!(
+                "cairo_programs/benchmarks/",
+                stringify!($val),
+                ".memory"
+            ));
 
-            let runner = cairo_run(black_box(path), &cairo_run_config, &mut hint_executor)
-                .expect("cairo_run failed");
+            let runner = cairo_run(
+                black_box(program_path),
+                &cairo_run_config,
+                &mut hint_executor,
+            )
+            .expect("cairo_run failed");
 
-            let trace_path = Path::new("/dev/null");
             let relocated_trace = runner.relocated_trace.as_ref().expect("relocation failed");
 
             write_binary_trace(black_box(relocated_trace), black_box(&trace_path))
                 .expect("writing execution trace failed");
 
-            let memory_path = Path::new("/dev/null");
             write_binary_memory(black_box(&runner.relocated_memory), black_box(&memory_path))
                 .expect("writing relocated memory failed");
         }

--- a/bench/iai_benchmark.rs
+++ b/bench/iai_benchmark.rs
@@ -13,7 +13,7 @@ macro_rules! iai_bench_expand_prog {
                 trace_enabled: true,
                 layout: "all",
                 print_output: true,
-                //FIXME: proof mode fails the benchmark
+                //FIXME: we need to distinguish the proof compiled programs
                 //proof_mode: true,
                 secure_run: Some(true),
                 ..cairo_vm::cairo_run::CairoRunConfig::default()

--- a/bench/iai_benchmark.rs
+++ b/bench/iai_benchmark.rs
@@ -12,7 +12,9 @@ macro_rules! iai_bench_expand_prog {
             let cairo_run_config = cairo_vm::cairo_run::CairoRunConfig {
                 trace_enabled: true,
                 layout: "all",
-                proof_mode: true,
+                print_output: true,
+                //FIXME: proof mode fails the benchmark
+                //proof_mode: true,
                 secure_run: Some(true),
                 ..cairo_vm::cairo_run::CairoRunConfig::default()
             };
@@ -22,18 +24,8 @@ macro_rules! iai_bench_expand_prog {
                 stringify!($val),
                 ".json"
             ));
-            // FIXME: this should discard writes, but opening /dev/null doesn't
-            // seem to be working in the CI
-            let trace_path = Path::new(concat!(
-                "cairo_programs/benchmarks/",
-                stringify!($val),
-                ".trace"
-            ));
-            let memory_path = Path::new(concat!(
-                "cairo_programs/benchmarks/",
-                stringify!($val),
-                ".memory"
-            ));
+            let trace_path = Path::new("/dev/null");
+            let memory_path = Path::new("/dev/null");
 
             let runner = cairo_run(
                 black_box(program_path),

--- a/bench/iai_benchmark.rs
+++ b/bench/iai_benchmark.rs
@@ -23,16 +23,18 @@ macro_rules! iai_bench_expand_prog {
                 ".json"
             ));
 
-            let runner = cairo_run(black_box(path), &cairo_run_config, &mut hint_executor).unwrap();
+            let runner = cairo_run(black_box(path), &cairo_run_config, &mut hint_executor)
+                .expect("cairo_run failed");
 
             let trace_path = Path::new("/dev/null");
-            let relocated_trace = runner.relocated_trace.as_ref().unwrap();
+            let relocated_trace = runner.relocated_trace.as_ref().expect("relocation failed");
 
-            write_binary_trace(black_box(relocated_trace), black_box(&trace_path)).unwrap();
+            write_binary_trace(black_box(relocated_trace), black_box(&trace_path))
+                .expect("writing execution trace failed");
 
             let memory_path = Path::new("/dev/null");
             write_binary_memory(black_box(&runner.relocated_memory), black_box(&memory_path))
-                .unwrap();
+                .expect("writing relocated memory failed");
         }
     };
 }


### PR DESCRIPTION
IAI benchmarks were modeled after the Criterion benchmark. Those failed to consider the serialization times, which led to #770 causing unexpected slowdowns not being caught before merge.
This PR fixes that by including writing memory and trace files (to `/dev/null`) to consider that processing cost as well.
There's still a pending concern about syscalls. I'm not 100% sure Valgrind can take blocking operations into account for the estimation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
