### PR TITLE
Use mimalloc in benchmarks

### DIFF
--- a/bench/criterion_benchmark.rs
+++ b/bench/criterion_benchmark.rs
@@ -6,6 +6,13 @@ use cairo_vm::{
 };
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
+#[cfg(feature = "with_mimalloc")]
+use mimalloc::MiMalloc;
+
+#[cfg(feature = "with_mimalloc")]
+#[global_allocator]
+static ALLOC: MiMalloc = MiMalloc;
+
 const BENCH_NAMES: &[&str] = &[
     "compare_arrays_200000",
     "factorial_multirun",

--- a/bench/iai_benchmark.rs
+++ b/bench/iai_benchmark.rs
@@ -6,6 +6,13 @@ use cairo_vm::{
 };
 use iai::{black_box, main};
 
+#[cfg(feature = "with_mimalloc")]
+use mimalloc::MiMalloc;
+
+#[cfg(feature = "with_mimalloc")]
+#[global_allocator]
+static ALLOC: MiMalloc = MiMalloc;
+
 macro_rules! iai_bench_expand_prog {
     ($val: ident) => {
         fn $val() {


### PR DESCRIPTION
Benchmarks (criterion and iai) were running with mimalloc disabled. This should make them run faster.