### PR TITLE
Fix relative paths in `compare_vm_state` script

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         python-version: '3.9'
     - name: Install test dependencies
-      run: pip install ecdsa fastecdsa sympy cairo-lang
+      run: pip install ecdsa fastecdsa sympy typeguard==2.13.0 cairo-lang
     - name: Run benchmark
       run: make benchmark-action
     - name: Store benchmark result

--- a/.github/workflows/bench_pull_request.yml
+++ b/.github/workflows/bench_pull_request.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         python-version: '3.9'
     - name: Install test dependencies
-      run: pip install ecdsa fastecdsa sympy cairo-lang
+      run: pip install ecdsa fastecdsa sympy typeguard==2.13.0 cairo-lang
     - name: Run benchmark
       run: make benchmark-action
     - name: Store benchmark result

--- a/.github/workflows/iai_main.yml
+++ b/.github/workflows/iai_main.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: '3.9'
     - name: Install test dependencies
       run: |
-        pip install ecdsa fastecdsa sympy cairo-lang
+        pip install ecdsa fastecdsa sympy typeguard==2.13.0 cairo-lang
         sudo apt update
         sudo apt install -y valgrind
     - uses: actions/checkout@v3

--- a/.github/workflows/iai_pr.yml
+++ b/.github/workflows/iai_pr.yml
@@ -55,7 +55,7 @@ jobs:
         python-version: '3.9'
     - name: Install test dependencies
       run: |
-        pip install ecdsa fastecdsa sympy cairo-lang
+        pip install ecdsa fastecdsa sympy typeguard==2.13.0 cairo-lang
         sudo apt update
         sudo apt install -y valgrind
     - uses: actions/checkout@v3

--- a/.github/workflows/iai_pr.yml
+++ b/.github/workflows/iai_pr.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: '3.9'
     - name: Install test dependencies
       run: |
-        pip install ecdsa fastecdsa sympy cairo-lang
+        pip install ecdsa fastecdsa sympy typeguard==2.13.0 cairo-lang
         sudo apt update
         sudo apt install -y valgrind
     - uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,7 +63,7 @@ jobs:
     - name: Restore timestamps
       uses: chetan/git-restore-mtime-action@v1
     - name: Install dependencies
-      run: pip install ecdsa fastecdsa sympy cairo-lang
+      run: pip install ecdsa fastecdsa sympy typeguard==2.13.0 cairo-lang
     - name: Run tests
       run: make -j test
     - name: Run tests no_std

--- a/src/tests/compare_vm_state.sh
+++ b/src/tests/compare_vm_state.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-tests_path="../cairo_programs"
+tests_path="../../cairo_programs"
 exit_code=0
 trace=false
 memory=false
@@ -13,7 +13,7 @@ for i in $@; do
         ;;
         "memory") memory=true
         ;;
-        "proof_mode") tests_path="../cairo_programs/proof_programs"
+        "proof_mode") tests_path="../../cairo_programs"
         ;;
         *)
         ;;


### PR DESCRIPTION
After the wasm-nostd PR, the `test ` folder was moved to `src/test`, which means that if we run the script `compare_vm_state` from its containing folder, we need to look for the cairo programs in `"../../cairo_programs"` instead of the previous location `"../cairo_programs"`. This was not changed when the folder was moved, so the script failed silently when it could't find the cairo_programs folder.
`+` Temporarily pin `typeguard` dependency to avoid conflicts in CI due to unpinned dependency in cairo-lang