### PR TITLE
Use `Relocatable` for `key` argument in `Memory.get()`

### DIFF
--- a/src/hint_processor/builtin_hint_processor/blake2s_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/blake2s_utils.rs
@@ -454,11 +454,7 @@ mod tests {
             ((2, 6), 0),
             ((2, 7), 0)
         ];
-        assert!(vm
-            .segments
-            .memory
-            .get(&MaybeRelocatable::from((2, 8)))
-            .is_none());
+        assert!(vm.segments.memory.get(Relocatable::from((2, 8))).is_none());
     }
 
     #[test]
@@ -487,11 +483,7 @@ mod tests {
             ((2, 6), 0),
             ((2, 7), 0)
         ];
-        assert!(vm
-            .segments
-            .memory
-            .get(&MaybeRelocatable::from((2, 8)))
-            .is_none());
+        assert!(vm.segments.memory.get(Relocatable::from((2, 8))).is_none());
     }
 
     #[test]
@@ -520,11 +512,7 @@ mod tests {
             ((2, 6), 0),
             ((2, 7), 0)
         ];
-        assert!(vm
-            .segments
-            .memory
-            .get(&MaybeRelocatable::from((2, 8)))
-            .is_none());
+        assert!(vm.segments.memory.get(Relocatable::from((2, 8))).is_none());
     }
 
     #[test]
@@ -553,10 +541,6 @@ mod tests {
             ((2, 6), 0),
             ((2, 7), 20)
         ];
-        assert!(vm
-            .segments
-            .memory
-            .get(&MaybeRelocatable::from((2, 8)))
-            .is_none());
+        assert!(vm.segments.memory.get(Relocatable::from((2, 8))).is_none());
     }
 }

--- a/src/hint_processor/builtin_hint_processor/dict_hint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/dict_hint_utils.rs
@@ -363,7 +363,7 @@ mod tests {
         assert_eq!(
             vm.segments
                 .memory
-                .get(&MaybeRelocatable::from((1, 1)))
+                .get(Relocatable::from((1, 1)))
                 .unwrap()
                 .as_ref(),
             &MaybeRelocatable::from(12)

--- a/src/hint_processor/builtin_hint_processor/set.rs
+++ b/src/hint_processor/builtin_hint_processor/set.rs
@@ -70,6 +70,7 @@ pub fn set_add(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::relocatable::Relocatable;
     use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
     use crate::{
         any_box,
@@ -140,7 +141,7 @@ mod tests {
         assert_eq!(
             vm.segments
                 .memory
-                .get(&MaybeRelocatable::from((1, 0)))
+                .get(Relocatable::from((1, 0)))
                 .unwrap()
                 .as_ref(),
             &MaybeRelocatable::Int(Felt252::zero())

--- a/src/hint_processor/hint_processor_utils.rs
+++ b/src/hint_processor/hint_processor_utils.rs
@@ -75,7 +75,7 @@ pub fn get_maybe_relocatable_from_reference(
     //Then calculate address
     let var_addr = compute_addr_from_reference(hint_reference, vm, ap_tracking)?;
     if hint_reference.dereference {
-        vm.get_maybe(&var_addr)
+        vm.get_maybe(var_addr)
     } else {
         Some(MaybeRelocatable::from(var_addr))
     }
@@ -169,7 +169,7 @@ fn get_offset_value_reference(
     }
 
     if *deref {
-        vm.get_maybe(&(base_addr + *offset).ok()?)
+        vm.get_maybe((base_addr + *offset).ok()?)
     } else {
         Some((base_addr + *offset).ok()?.into())
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -177,13 +177,13 @@ pub mod test_utils {
     macro_rules! check_memory_address {
         ($mem:expr, ($si:expr, $off:expr), ($sival:expr, $offval: expr)) => {
             assert_eq!(
-                $mem.get(&mayberelocatable!($si, $off)).unwrap().as_ref(),
+                $mem.get(($si, $off).into()).unwrap().as_ref(),
                 &mayberelocatable!($sival, $offval)
             )
         };
         ($mem:expr, ($si:expr, $off:expr), $val:expr) => {
             assert_eq!(
-                $mem.get(&mayberelocatable!($si, $off)).unwrap().as_ref(),
+                $mem.get(($si, $off).into()).unwrap().as_ref(),
                 &mayberelocatable!($val)
             )
         };

--- a/src/vm/runners/builtin_runner/bitwise.rs
+++ b/src/vm/runners/builtin_runner/bitwise.rs
@@ -80,8 +80,8 @@ impl BitwiseBuiltinRunner {
         let x_addr = Relocatable::from((address.segment_index, address.offset - index));
         let y_addr = (x_addr + 1_usize)?;
 
-        let num_x = memory.get(&x_addr);
-        let num_y = memory.get(&y_addr);
+        let num_x = memory.get(x_addr);
+        let num_y = memory.get(y_addr);
         if let (Some(MaybeRelocatable::Int(ref num_x)), Some(MaybeRelocatable::Int(ref num_y))) = (
             num_x.as_ref().map(|x| x.as_ref()),
             num_y.as_ref().map(|x| x.as_ref()),

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -158,7 +158,7 @@ impl EcOpBuiltinRunner {
         //If an input cell is not filled, return None
         let mut input_cells = Vec::<&Felt252>::with_capacity(self.n_input_cells as usize);
         for i in 0..self.n_input_cells as usize {
-            match memory.get(&(instance + i)?) {
+            match memory.get((instance + i)?) {
                 None => return Ok(None),
                 Some(addr) => {
                     input_cells.push(match addr {

--- a/src/vm/runners/builtin_runner/hash.rs
+++ b/src/vm/runners/builtin_runner/hash.rs
@@ -80,14 +80,14 @@ impl HashBuiltinRunner {
             return Ok(None);
         };
 
-        let num_a = memory.get(&MaybeRelocatable::RelocatableValue(Relocatable {
+        let num_a = memory.get(Relocatable {
             segment_index: address.segment_index,
             offset: address.offset - 1,
-        }));
-        let num_b = memory.get(&MaybeRelocatable::RelocatableValue(Relocatable {
+        });
+        let num_b = memory.get(Relocatable {
             segment_index: address.segment_index,
             offset: address.offset - 2,
-        }));
+        });
         if let (Some(MaybeRelocatable::Int(num_a)), Some(MaybeRelocatable::Int(num_b))) = (
             num_a.as_ref().map(|x| x.as_ref()),
             num_b.as_ref().map(|x| x.as_ref()),

--- a/src/vm/runners/builtin_runner/keccak.rs
+++ b/src/vm/runners/builtin_runner/keccak.rs
@@ -85,7 +85,7 @@ impl KeccakBuiltinRunner {
         let mut input_felts_u64 = vec![];
 
         for i in 0..self.n_input_cells {
-            let val = match memory.get(&(first_input_addr + i as usize)?) {
+            let val = match memory.get((first_input_addr + i as usize)?) {
                 Some(val) => val
                     .as_ref()
                     .get_int_ref()

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -1991,11 +1991,7 @@ mod tests {
             ((2, 0), 7),
             ((2, 1), 18446744073709551608_i128)
         );
-        assert!(vm
-            .segments
-            .memory
-            .get(&MaybeRelocatable::from((2, 2)))
-            .is_none());
+        assert!(vm.segments.memory.get(Relocatable::from((2, 2))).is_none());
     }
 
     #[test]
@@ -2104,11 +2100,7 @@ mod tests {
         assert_eq!(vm.builtin_runners[0].0, OUTPUT_BUILTIN_NAME);
         assert_eq!(vm.builtin_runners[0].1.base(), 2);
         check_memory!(vm.segments.memory, ((2, 0), 1), ((2, 1), 17));
-        assert!(vm
-            .segments
-            .memory
-            .get(&MaybeRelocatable::from((2, 2)))
-            .is_none());
+        assert!(vm.segments.memory.get(Relocatable::from((2, 2))).is_none());
     }
 
     #[test]
@@ -2253,22 +2245,14 @@ mod tests {
             ((3, 0), 7),
             ((3, 1), 18446744073709551608_i128)
         );
-        assert!(vm
-            .segments
-            .memory
-            .get(&MaybeRelocatable::from((2, 2)))
-            .is_none());
+        assert!(vm.segments.memory.get(Relocatable::from((2, 2))).is_none());
 
         //Check the output segment
         assert_eq!(vm.builtin_runners[0].0, OUTPUT_BUILTIN_NAME);
         assert_eq!(vm.builtin_runners[0].1.base(), 2);
 
         check_memory!(vm.segments.memory, ((2, 0), 7));
-        assert!(vm
-            .segments
-            .memory
-            .get(&(MaybeRelocatable::from((2, 1))))
-            .is_none());
+        assert!(vm.segments.memory.get(Relocatable::from((2, 1))).is_none());
     }
 
     #[test]

--- a/src/vm/trace/mod.rs
+++ b/src/vm/trace/mod.rs
@@ -5,7 +5,7 @@ use super::{
     vm_memory::memory::Memory,
 };
 use crate::stdlib::borrow::Cow;
-use crate::types::relocatable::{MaybeRelocatable, Relocatable};
+use crate::types::relocatable::MaybeRelocatable;
 use num_traits::ToPrimitive;
 
 pub mod trace_entry;
@@ -19,8 +19,7 @@ pub fn get_perm_range_check_limits(
         .iter()
         .try_fold(None, |offsets: Option<(isize, isize)>, trace| {
             let instruction = memory.get_integer(trace.pc)?;
-            let immediate =
-                memory.get::<Relocatable>(&(trace.pc.segment_index, trace.pc.offset + 1).into());
+            let immediate = memory.get((trace.pc.segment_index, trace.pc.offset + 1).into());
 
             let instruction = instruction
                 .to_i64()

--- a/src/vm/vm_memory/memory_segments.rs
+++ b/src/vm/vm_memory/memory_segments.rs
@@ -314,7 +314,7 @@ mod tests {
         let current_ptr = segments.load_data(ptr, &data).unwrap();
         assert_eq!(current_ptr, Relocatable::from((0, 1)));
         assert_eq!(
-            segments.memory.get(&ptr).unwrap().as_ref(),
+            segments.memory.get(ptr).unwrap().as_ref(),
             &MaybeRelocatable::from(Felt252::new(4))
         );
     }
@@ -334,13 +334,13 @@ mod tests {
         assert_eq!(current_ptr, Relocatable::from((0, 3)));
 
         assert_eq!(
-            segments.memory.get(&ptr).unwrap().as_ref(),
+            segments.memory.get(ptr).unwrap().as_ref(),
             &MaybeRelocatable::from(Felt252::new(4))
         );
         assert_eq!(
             segments
                 .memory
-                .get(&MaybeRelocatable::from((0, 1)))
+                .get(Relocatable::from((0, 1)))
                 .unwrap()
                 .as_ref(),
             &MaybeRelocatable::from(Felt252::new(5))
@@ -348,7 +348,7 @@ mod tests {
         assert_eq!(
             segments
                 .memory
-                .get(&MaybeRelocatable::from((0, 2)))
+                .get(Relocatable::from((0, 2)))
                 .unwrap()
                 .as_ref(),
             &MaybeRelocatable::from(Felt252::new(6))


### PR DESCRIPTION
Depends on #902 
(The functionality change is not linked, but as the modified tests overlap it is much easier to do it this way)
Status: Currently causes performance regressions, causes & alternatives are being investigated