### PR TITLE
Fix broken `compare_benchmarks` target

### DIFF
--- a/bench/run_benchmarks.sh
+++ b/bench/run_benchmarks.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-tests_path="cairo_programs/benchmarks"
+tests_path="../cairo_programs/benchmarks"
 
 set -e
 
@@ -11,5 +11,5 @@ for file in $(ls $tests_path | grep .cairo | sed -E 's/\.cairo//'); do
     hyperfine \
 	    -n "Cairo VM (CPython)" "PYENV_VERSION=3.7.12 cairo-run --layout all --program $tests_path/$file.json" \
 	    -n "Cairo VM (PyPy)" "PYENV_VERSION=pypy3.7-7.3.9 cairo-run --layout all --program $tests_path/$file.json" \
-	    -n "cairo-rs (Rust)" "../target/release/cairo-rs-run $tests_path/$file.json --layout all"
+	    -n "cairo-rs (Rust)" "../target/release/cairo-vm-cli $tests_path/$file.json --layout all"
 done


### PR DESCRIPTION
The `run_benchmarks` was still calling the old `cairo-rs `binary instead of `cairo-vm-cli` binary to run programs, also the relative path to `cairo_programs` was incorrect in the context of the makefile target
