### PR TITLE
Remove duplicate cli argument `trace`

### DIFF
--- a/cairo-vm-cli/src/main.rs
+++ b/cairo-vm-cli/src/main.rs
@@ -28,7 +28,6 @@ struct Args {
     print_output: bool,
     #[structopt(long = "--entrypoint", default_value = "main")]
     entrypoint: String,
-    trace: Option<PathBuf>,
     #[structopt(long = "--memory_file")]
     memory_file: Option<PathBuf>,
     #[clap(long = "--layout", default_value = "plain", validator=validate_layout)]


### PR DESCRIPTION
`trace` is duplicated from `trace_file` and serves no purpose

