### PR TITLE
Only relocate memory if `memory_file` is passed

### DIFF
--- a/cairo-vm-cli/src/main.rs
+++ b/cairo-vm-cli/src/main.rs
@@ -98,6 +98,7 @@ fn main() -> Result<(), Error> {
     let cairo_run_config = cairo_run::CairoRunConfig {
         entrypoint: &args.entrypoint,
         trace_enabled,
+        relocate_mem: args.memory_file.is_some(),
         layout: &args.layout,
         proof_mode: args.proof_mode,
         secure_run: args.secure_run,

--- a/src/cairo_run.rs
+++ b/src/cairo_run.rs
@@ -20,6 +20,7 @@ use thiserror_no_std::Error;
 pub struct CairoRunConfig<'a> {
     pub entrypoint: &'a str,
     pub trace_enabled: bool,
+    pub relocate_mem: bool,
     pub layout: &'a str,
     pub proof_mode: bool,
     pub secure_run: Option<bool>,
@@ -30,6 +31,7 @@ impl<'a> Default for CairoRunConfig<'a> {
         CairoRunConfig {
             entrypoint: "main",
             trace_enabled: false,
+            relocate_mem: false,
             layout: "plain",
             proof_mode: false,
             secure_run: None,
@@ -69,7 +71,7 @@ pub fn cairo_run(
     if secure_run {
         verify_secure_runner(&cairo_runner, true, &mut vm)?;
     }
-    cairo_runner.relocate(&mut vm)?;
+    cairo_runner.relocate(&mut vm, cairo_run_config.relocate_mem)?;
 
     Ok((cairo_runner, vm))
 }
@@ -173,7 +175,7 @@ mod tests {
         assert!(cairo_runner
             .run_until_pc(end, &mut vm, &mut hint_processor)
             .is_ok());
-        assert!(cairo_runner.relocate(&mut vm).is_ok());
+        assert!(cairo_runner.relocate(&mut vm, true).is_ok());
         // `main` returns without doing nothing, but `not_main` sets `[ap]` to `1`
         // Memory location was found empirically and simply hardcoded
         assert_eq!(cairo_runner.relocated_memory[2], Some(Felt252::new(123)));
@@ -241,7 +243,7 @@ mod tests {
         let (mut cairo_runner, mut vm) = cairo_runner_result.unwrap();
 
         // relocate memory so we can dump it to file
-        assert!(cairo_runner.relocate(&mut vm).is_ok());
+        assert!(cairo_runner.relocate(&mut vm, true).is_ok());
         assert!(vm.trace.is_some());
         assert!(cairo_runner.relocated_trace.is_some());
 
@@ -268,7 +270,7 @@ mod tests {
         let (mut cairo_runner, mut vm) = cairo_runner_result.unwrap();
 
         // relocate memory so we can dump it to file
-        assert!(cairo_runner.relocate(&mut vm).is_ok());
+        assert!(cairo_runner.relocate(&mut vm, true).is_ok());
 
         let mut buffer = [0; 120];
         let mut buff_writer = SliceWriter::new(&mut buffer);

--- a/src/tests/bitwise_test.rs
+++ b/src/tests/bitwise_test.rs
@@ -31,7 +31,11 @@ fn bitwise_integration_test() {
         Ok(()),
         "Execution failed"
     );
-    assert_matches!(cairo_runner.relocate(&mut vm, true), Ok(()), "Execution failed");
+    assert_matches!(
+        cairo_runner.relocate(&mut vm, true),
+        Ok(()),
+        "Execution failed"
+    );
 
     let python_vm_relocated_trace: Vec<RelocatedTraceEntry> = vec![
         RelocatedTraceEntry {

--- a/src/tests/bitwise_test.rs
+++ b/src/tests/bitwise_test.rs
@@ -31,7 +31,7 @@ fn bitwise_integration_test() {
         Ok(()),
         "Execution failed"
     );
-    assert_matches!(cairo_runner.relocate(&mut vm,), Ok(()), "Execution failed");
+    assert_matches!(cairo_runner.relocate(&mut vm, true), Ok(()), "Execution failed");
 
     let python_vm_relocated_trace: Vec<RelocatedTraceEntry> = vec![
         RelocatedTraceEntry {

--- a/src/tests/pedersen_test.rs
+++ b/src/tests/pedersen_test.rs
@@ -28,7 +28,7 @@ fn pedersen_integration_test() {
         cairo_runner.run_until_pc(end, &mut vm, &mut hint_processor),
         Ok(())
     );
-    assert!(cairo_runner.relocate(&mut vm) == Ok(()), "Execution failed");
+    assert!(cairo_runner.relocate(&mut vm, true) == Ok(()), "Execution failed");
 
     let python_vm_relocated_trace: Vec<RelocatedTraceEntry> = vec![
         RelocatedTraceEntry {

--- a/src/tests/pedersen_test.rs
+++ b/src/tests/pedersen_test.rs
@@ -28,7 +28,10 @@ fn pedersen_integration_test() {
         cairo_runner.run_until_pc(end, &mut vm, &mut hint_processor),
         Ok(())
     );
-    assert!(cairo_runner.relocate(&mut vm, true) == Ok(()), "Execution failed");
+    assert!(
+        cairo_runner.relocate(&mut vm, true) == Ok(()),
+        "Execution failed"
+    );
 
     let python_vm_relocated_trace: Vec<RelocatedTraceEntry> = vec![
         RelocatedTraceEntry {

--- a/src/tests/struct_test.rs
+++ b/src/tests/struct_test.rs
@@ -28,7 +28,10 @@ fn struct_integration_test() {
         Ok(()),
         "Execution failed"
     );
-    assert!(cairo_runner.relocate(&mut vm, true) == Ok(()), "Execution failed");
+    assert!(
+        cairo_runner.relocate(&mut vm, true) == Ok(()),
+        "Execution failed"
+    );
     let relocated_entry = RelocatedTraceEntry {
         pc: 1,
         ap: 4,

--- a/src/tests/struct_test.rs
+++ b/src/tests/struct_test.rs
@@ -28,7 +28,7 @@ fn struct_integration_test() {
         Ok(()),
         "Execution failed"
     );
-    assert!(cairo_runner.relocate(&mut vm) == Ok(()), "Execution failed");
+    assert!(cairo_runner.relocate(&mut vm, true) == Ok(()), "Execution failed");
     let relocated_entry = RelocatedTraceEntry {
         pc: 1,
         ap: 4,


### PR DESCRIPTION
This PR aims to avoid relocating the cairo memory if its not going to be outputted by the vm. If using the `cairo_run`, this can be customized via the `CairoRunConfig`

