### PR TITLE
Use `$crate` instead of name literal on `felt_str` macro

### DIFF
--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -95,10 +95,10 @@ pub(crate) trait FeltOps {
 #[macro_export]
 macro_rules! felt_str {
     ($val: expr) => {
-        felt::Felt252::parse_bytes($val.as_bytes(), 10_u32).expect("Couldn't parse bytes")
+        $crate::Felt252::parse_bytes($val.as_bytes(), 10_u32).expect("Couldn't parse bytes")
     };
     ($val: expr, $opt: expr) => {
-        felt::Felt252::parse_bytes($val.as_bytes(), $opt as u32).expect("Couldn't parse bytes")
+        $crate::Felt252::parse_bytes($val.as_bytes(), $opt as u32).expect("Couldn't parse bytes")
     };
 }
 


### PR DESCRIPTION
# Use `$crate` instead of name literal on `felt_str` macro

## Description

When using a name different than `felt` on crate import, we can't use the `felt_str` macro without an additional `use felt;` statement.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
