### PR TITLE
Fix cairo constants being used in hints that import python constants

### DIFF
--- a/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -237,9 +237,7 @@ impl HintProcessor for BuiltinHintProcessor {
             hint_code::BLAKE2S_COMPUTE => {
                 compute_blake2s(vm, &hint_data.ids_data, &hint_data.ap_tracking)
             }
-            hint_code::VERIFY_ZERO => {
-                verify_zero(vm, &hint_data.ids_data, &hint_data.ap_tracking, constants)
-            }
+            hint_code::VERIFY_ZERO => verify_zero(vm, &hint_data.ids_data, &hint_data.ap_tracking),
             hint_code::NONDET_BIGINT3 => nondet_bigint3(
                 vm,
                 exec_scopes,
@@ -247,13 +245,9 @@ impl HintProcessor for BuiltinHintProcessor {
                 &hint_data.ap_tracking,
                 constants,
             ),
-            hint_code::REDUCE => reduce(
-                vm,
-                exec_scopes,
-                &hint_data.ids_data,
-                &hint_data.ap_tracking,
-                constants,
-            ),
+            hint_code::REDUCE => {
+                reduce(vm, exec_scopes, &hint_data.ids_data, &hint_data.ap_tracking)
+            }
             hint_code::BLAKE2S_FINALIZE => {
                 finalize_blake2s(vm, &hint_data.ids_data, &hint_data.ap_tracking)
             }
@@ -334,17 +328,11 @@ impl HintProcessor for BuiltinHintProcessor {
             hint_code::BIGINT_TO_UINT256 => {
                 bigint_to_uint256(vm, &hint_data.ids_data, &hint_data.ap_tracking, constants)
             }
-            hint_code::IS_ZERO_PACK => is_zero_pack(
-                vm,
-                exec_scopes,
-                &hint_data.ids_data,
-                &hint_data.ap_tracking,
-                constants,
-            ),
-            hint_code::IS_ZERO_NONDET => is_zero_nondet(vm, exec_scopes),
-            hint_code::IS_ZERO_ASSIGN_SCOPE_VARS => {
-                is_zero_assign_scope_variables(exec_scopes, constants)
+            hint_code::IS_ZERO_PACK => {
+                is_zero_pack(vm, exec_scopes, &hint_data.ids_data, &hint_data.ap_tracking)
             }
+            hint_code::IS_ZERO_NONDET => is_zero_nondet(vm, exec_scopes),
+            hint_code::IS_ZERO_ASSIGN_SCOPE_VARS => is_zero_assign_scope_variables(exec_scopes),
             hint_code::DIV_MOD_N_PACKED_DIVMOD => div_mod_n_packed_divmod(
                 vm,
                 exec_scopes,

--- a/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -334,9 +334,8 @@ impl HintProcessor for BuiltinHintProcessor {
                 exec_scopes,
                 &hint_data.ids_data,
                 &hint_data.ap_tracking,
-                constants,
             ),
-            hint_code::DIV_MOD_N_SAFE_DIV => div_mod_n_safe_div(exec_scopes, constants),
+            hint_code::DIV_MOD_N_SAFE_DIV => div_mod_n_safe_div(exec_scopes),
             hint_code::GET_POINT_FROM_X => get_point_from_x(
                 vm,
                 exec_scopes,

--- a/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -360,35 +360,19 @@ impl HintProcessor for BuiltinHintProcessor {
                 &hint_data.ap_tracking,
                 constants,
             ),
-            hint_code::EC_NEGATE => ec_negate(
-                vm,
-                exec_scopes,
-                &hint_data.ids_data,
-                &hint_data.ap_tracking,
-                constants,
-            ),
-            hint_code::EC_DOUBLE_SCOPE => compute_doubling_slope(
-                vm,
-                exec_scopes,
-                &hint_data.ids_data,
-                &hint_data.ap_tracking,
-                constants,
-            ),
-            hint_code::COMPUTE_SLOPE => compute_slope(
-                vm,
-                exec_scopes,
-                &hint_data.ids_data,
-                &hint_data.ap_tracking,
-                constants,
-            ),
-            hint_code::EC_DOUBLE_ASSIGN_NEW_X => ec_double_assign_new_x(
-                vm,
-                exec_scopes,
-                &hint_data.ids_data,
-                &hint_data.ap_tracking,
-                constants,
-            ),
-            hint_code::EC_DOUBLE_ASSIGN_NEW_Y => ec_double_assign_new_y(exec_scopes, constants),
+            hint_code::EC_NEGATE => {
+                ec_negate(vm, exec_scopes, &hint_data.ids_data, &hint_data.ap_tracking)
+            }
+            hint_code::EC_DOUBLE_SCOPE => {
+                compute_doubling_slope(vm, exec_scopes, &hint_data.ids_data, &hint_data.ap_tracking)
+            }
+            hint_code::COMPUTE_SLOPE => {
+                compute_slope(vm, exec_scopes, &hint_data.ids_data, &hint_data.ap_tracking)
+            }
+            hint_code::EC_DOUBLE_ASSIGN_NEW_X => {
+                ec_double_assign_new_x(vm, exec_scopes, &hint_data.ids_data, &hint_data.ap_tracking)
+            }
+            hint_code::EC_DOUBLE_ASSIGN_NEW_Y => ec_double_assign_new_y(exec_scopes),
             hint_code::KECCAK_WRITE_ARGS => {
                 keccak_write_args(vm, &hint_data.ids_data, &hint_data.ap_tracking)
             }
@@ -424,9 +408,8 @@ impl HintProcessor for BuiltinHintProcessor {
                 exec_scopes,
                 &hint_data.ids_data,
                 &hint_data.ap_tracking,
-                constants,
             ),
-            hint_code::FAST_EC_ADD_ASSIGN_NEW_Y => fast_ec_add_assign_new_y(exec_scopes, constants),
+            hint_code::FAST_EC_ADD_ASSIGN_NEW_Y => fast_ec_add_assign_new_y(exec_scopes),
             hint_code::EC_MUL_INNER => {
                 ec_mul_inner(vm, &hint_data.ids_data, &hint_data.ap_tracking)
             }

--- a/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -238,13 +238,9 @@ impl HintProcessor for BuiltinHintProcessor {
                 compute_blake2s(vm, &hint_data.ids_data, &hint_data.ap_tracking)
             }
             hint_code::VERIFY_ZERO => verify_zero(vm, &hint_data.ids_data, &hint_data.ap_tracking),
-            hint_code::NONDET_BIGINT3 => nondet_bigint3(
-                vm,
-                exec_scopes,
-                &hint_data.ids_data,
-                &hint_data.ap_tracking,
-                constants,
-            ),
+            hint_code::NONDET_BIGINT3 => {
+                nondet_bigint3(vm, exec_scopes, &hint_data.ids_data, &hint_data.ap_tracking)
+            }
             hint_code::REDUCE => {
                 reduce(vm, exec_scopes, &hint_data.ids_data, &hint_data.ap_tracking)
             }

--- a/src/hint_processor/builtin_hint_processor/math_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/math_utils.rs
@@ -65,15 +65,29 @@ pub fn is_nn_out_of_range(
     };
     insert_value_into_ap(vm, value)
 }
-//Implements hint:from starkware.cairo.common.math_utils import assert_integer
-//        assert_integer(ids.a)
-//        assert_integer(ids.b)
-//        a = ids.a % PRIME
-//        b = ids.b % PRIME
-//        assert a <= b, f'a = {a} is not less than or equal to b = {b}.'
-//        ids.small_inputs = int(
-//            a < range_check_builtin.bound and (b - a) < range_check_builtin.bound)
+/* Implements hint:from starkware.cairo.common.math_utils import assert_integer
+%{
+    import itertools
 
+    from starkware.cairo.common.math_utils import assert_integer
+    assert_integer(ids.a)
+    assert_integer(ids.b)
+    a = ids.a % PRIME
+    b = ids.b % PRIME
+    assert a <= b, f'a = {a} is not less than or equal to b = {b}.'
+
+    # Find an arc less than PRIME / 3, and another less than PRIME / 2.
+    lengths_and_indices = [(a, 0), (b - a, 1), (PRIME - 1 - b, 2)]
+    lengths_and_indices.sort()
+    assert lengths_and_indices[0][0] <= PRIME // 3 and lengths_and_indices[1][0] <= PRIME // 2
+    excluded = lengths_and_indices[2][1]
+
+    memory[ids.range_check_ptr + 1], memory[ids.range_check_ptr + 0] = (
+        divmod(lengths_and_indices[0][0], ids.PRIME_OVER_3_HIGH))
+    memory[ids.range_check_ptr + 3], memory[ids.range_check_ptr + 2] = (
+        divmod(lengths_and_indices[1][0], ids.PRIME_OVER_2_HIGH))
+%}
+*/
 pub fn assert_le_felt(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,

--- a/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/bigint_utils.rs
@@ -66,14 +66,13 @@ pub fn nondet_bigint3(
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
-    constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
     let res_reloc = get_relocatable_from_var_name("res", vm, ids_data, ap_tracking)?;
     let value = exec_scopes
         .get_ref::<num_bigint::BigInt>("value")?
         .to_biguint()
         .ok_or(HintError::BigIntToBigUintFail)?;
-    let arg: Vec<MaybeRelocatable> = split(&value, constants)?
+    let arg: Vec<MaybeRelocatable> = split(&value)?
         .into_iter()
         .map(|n| MaybeRelocatable::from(Felt252::new(n)))
         .collect();

--- a/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
@@ -304,28 +304,7 @@ mod tests {
         let ids_data = ids_data!["point"];
         let mut exec_scopes = ExecutionScopes::new();
         //Execute the hint
-        assert_matches!(
-            run_hint!(
-                vm,
-                ids_data,
-                hint_code,
-                &mut exec_scopes,
-                &[(
-                    SECP_REM,
-                    Felt252::one().shl(32_u32)
-                        + Felt252::one().shl(9_u32)
-                        + Felt252::one().shl(8_u32)
-                        + Felt252::one().shl(7_u32)
-                        + Felt252::one().shl(6_u32)
-                        + Felt252::one().shl(4_u32)
-                        + Felt252::one()
-                )]
-                .into_iter()
-                .map(|(k, v)| (k.to_string(), v))
-                .collect()
-            ),
-            Ok(())
-        );
+        assert_matches!(run_hint!(vm, ids_data, hint_code, &mut exec_scopes), Ok(()));
         //Check 'value' is defined in the vm scope
         assert_matches!(
             exec_scopes.get::<BigInt>("value"),
@@ -356,28 +335,7 @@ mod tests {
         let mut exec_scopes = ExecutionScopes::new();
 
         //Execute the hint
-        assert_matches!(
-            run_hint!(
-                vm,
-                ids_data,
-                hint_code,
-                &mut exec_scopes,
-                &[(
-                    SECP_REM,
-                    Felt252::one().shl(32_u32)
-                        + Felt252::one().shl(9_u32)
-                        + Felt252::one().shl(8_u32)
-                        + Felt252::one().shl(7_u32)
-                        + Felt252::one().shl(6_u32)
-                        + Felt252::one().shl(4_u32)
-                        + Felt252::one()
-                )]
-                .into_iter()
-                .map(|(k, v)| (k.to_string(), v))
-                .collect()
-            ),
-            Ok(())
-        );
+        assert_matches!(run_hint!(vm, ids_data, hint_code, &mut exec_scopes), Ok(()));
         check_scope!(
             &exec_scopes,
             [
@@ -428,28 +386,7 @@ mod tests {
         let mut exec_scopes = ExecutionScopes::new();
 
         //Execute the hint
-        assert_matches!(
-            run_hint!(
-                vm,
-                ids_data,
-                hint_code,
-                &mut exec_scopes,
-                &[(
-                    SECP_REM,
-                    Felt252::one().shl(32_u32)
-                        + Felt252::one().shl(9_u32)
-                        + Felt252::one().shl(8_u32)
-                        + Felt252::one().shl(7_u32)
-                        + Felt252::one().shl(6_u32)
-                        + Felt252::one().shl(4_u32)
-                        + Felt252::one()
-                )]
-                .into_iter()
-                .map(|(k, v)| (k.to_string(), v))
-                .collect()
-            ),
-            Ok(())
-        );
+        assert_matches!(run_hint!(vm, ids_data, hint_code, &mut exec_scopes), Ok(()));
         check_scope!(
             &exec_scopes,
             [
@@ -497,28 +434,7 @@ mod tests {
         let mut exec_scopes = ExecutionScopes::new();
 
         //Execute the hint
-        assert_matches!(
-            run_hint!(
-                vm,
-                ids_data,
-                hint_code,
-                &mut exec_scopes,
-                &[(
-                    SECP_REM,
-                    Felt252::one().shl(32_u32)
-                        + Felt252::one().shl(9_u32)
-                        + Felt252::one().shl(8_u32)
-                        + Felt252::one().shl(7_u32)
-                        + Felt252::one().shl(6_u32)
-                        + Felt252::one().shl(4_u32)
-                        + Felt252::one()
-                )]
-                .into_iter()
-                .map(|(k, v)| (k.to_string(), v))
-                .collect()
-            ),
-            Ok(())
-        );
+        assert_matches!(run_hint!(vm, ids_data, hint_code, &mut exec_scopes), Ok(()));
 
         check_scope!(
             &exec_scopes,
@@ -582,25 +498,7 @@ mod tests {
         ];
         //Execute the hint
         assert_matches!(
-            run_hint!(
-                vm,
-                HashMap::new(),
-                hint_code,
-                &mut exec_scopes,
-                &[(
-                    SECP_REM,
-                    Felt252::one().shl(32_u32)
-                        + Felt252::one().shl(9_u32)
-                        + Felt252::one().shl(8_u32)
-                        + Felt252::one().shl(7_u32)
-                        + Felt252::one().shl(6_u32)
-                        + Felt252::one().shl(4_u32)
-                        + Felt252::one()
-                )]
-                .into_iter()
-                .map(|(k, v)| (k.to_string(), v))
-                .collect()
-            ),
+            run_hint!(vm, HashMap::new(), hint_code, &mut exec_scopes),
             Ok(())
         );
 
@@ -659,28 +557,7 @@ mod tests {
         let mut exec_scopes = ExecutionScopes::new();
 
         //Execute the hint
-        assert_matches!(
-            run_hint!(
-                vm,
-                ids_data,
-                hint_code,
-                &mut exec_scopes,
-                &[(
-                    SECP_REM,
-                    Felt252::one().shl(32_u32)
-                        + Felt252::one().shl(9_u32)
-                        + Felt252::one().shl(8_u32)
-                        + Felt252::one().shl(7_u32)
-                        + Felt252::one().shl(6_u32)
-                        + Felt252::one().shl(4_u32)
-                        + Felt252::one()
-                )]
-                .into_iter()
-                .map(|(k, v)| (k.to_string(), v))
-                .collect()
-            ),
-            Ok(())
-        );
+        assert_matches!(run_hint!(vm, ids_data, hint_code, &mut exec_scopes), Ok(()));
 
         check_scope!(
             &exec_scopes,
@@ -732,25 +609,7 @@ mod tests {
 
         //Execute the hint
         assert_matches!(
-            run_hint!(
-                vm,
-                HashMap::new(),
-                hint_code,
-                &mut exec_scopes,
-                &[(
-                    SECP_REM,
-                    Felt252::one().shl(32_u32)
-                        + Felt252::one().shl(9_u32)
-                        + Felt252::one().shl(8_u32)
-                        + Felt252::one().shl(7_u32)
-                        + Felt252::one().shl(6_u32)
-                        + Felt252::one().shl(4_u32)
-                        + Felt252::one()
-                )]
-                .into_iter()
-                .map(|(k, v)| (k.to_string(), v))
-                .collect()
-            ),
+            run_hint!(vm, HashMap::new(), hint_code, &mut exec_scopes),
             Ok(())
         );
 

--- a/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/field_utils.rs
@@ -1,11 +1,8 @@
-use crate::stdlib::{collections::HashMap, ops::Shl, prelude::*};
+use crate::stdlib::{collections::HashMap, prelude::*};
 
 use crate::{
     hint_processor::{
-        builtin_hint_processor::{
-            hint_utils::{insert_value_from_var_name, insert_value_into_ap},
-            secp::secp_utils::SECP_REM,
-        },
+        builtin_hint_processor::hint_utils::{insert_value_from_var_name, insert_value_into_ap},
         hint_processor_definition::HintReference,
     },
     math_utils::div_mod,
@@ -18,6 +15,7 @@ use num_bigint::BigInt;
 use num_integer::Integer;
 use num_traits::{One, Zero};
 
+use super::secp_utils::SECP_P;
 use super::{bigint_utils::BigInt3, secp_utils::pack};
 
 /*
@@ -34,17 +32,9 @@ pub fn verify_zero(
     vm: &mut VirtualMachine,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
-    constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    #[allow(deprecated)]
-    let secp_p = BigInt::one().shl(256_u32)
-        - constants
-            .get(SECP_REM)
-            .ok_or(HintError::MissingConstant(SECP_REM))?
-            .to_bigint();
-
     let val = pack(BigInt3::from_var_name("val", vm, ids_data, ap_tracking)?);
-    let (q, r) = val.div_rem(&secp_p);
+    let (q, r) = val.div_rem(&SECP_P);
     if !r.is_zero() {
         return Err(HintError::SecpVerifyZero(val));
     }
@@ -65,17 +55,9 @@ pub fn reduce(
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
-    constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    #[allow(deprecated)]
-    let secp_p = num_bigint::BigInt::one().shl(256_u32)
-        - constants
-            .get(SECP_REM)
-            .ok_or(HintError::MissingConstant(SECP_REM))?
-            .to_bigint();
-
     let value = pack(BigInt3::from_var_name("x", vm, ids_data, ap_tracking)?);
-    exec_scopes.insert_value("value", value.mod_floor(&secp_p));
+    exec_scopes.insert_value("value", value.mod_floor(&SECP_P));
     Ok(())
 }
 
@@ -92,17 +74,9 @@ pub fn is_zero_pack(
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
-    constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    #[allow(deprecated)]
-    let secp_p = BigInt::one().shl(256_u32)
-        - constants
-            .get(SECP_REM)
-            .ok_or(HintError::MissingConstant(SECP_REM))?
-            .to_bigint();
-
     let x_packed = pack(BigInt3::from_var_name("x", vm, ids_data, ap_tracking)?);
-    let x = x_packed.mod_floor(&secp_p);
+    let x = x_packed.mod_floor(&SECP_P);
     exec_scopes.insert_value("x", x);
     Ok(())
 }
@@ -139,21 +113,11 @@ Implements hint:
     value = x_inv = div_mod(1, x, SECP_P)
 %}
 */
-pub fn is_zero_assign_scope_variables(
-    exec_scopes: &mut ExecutionScopes,
-    constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
-    #[allow(deprecated)]
-    let secp_p = BigInt::one().shl(256_u32)
-        - constants
-            .get(SECP_REM)
-            .ok_or(HintError::MissingConstant(SECP_REM))?
-            .to_bigint();
-
+pub fn is_zero_assign_scope_variables(exec_scopes: &mut ExecutionScopes) -> Result<(), HintError> {
     //Get `x` variable from vm scope
     let x = exec_scopes.get::<BigInt>("x")?;
 
-    let value = div_mod(&BigInt::one(), &x, &secp_p);
+    let value = div_mod(&BigInt::one(), &x, &SECP_P);
     exec_scopes.insert_value("value", value.clone());
     exec_scopes.insert_value("x_inv", value);
     Ok(())
@@ -199,25 +163,7 @@ mod tests {
         vm.segments = segments![((1, 4), 0), ((1, 5), 0), ((1, 6), 0)];
         //Execute the hint
         assert_matches!(
-            run_hint!(
-                vm,
-                ids_data,
-                hint_code,
-                exec_scopes_ref!(),
-                &[(
-                    SECP_REM,
-                    Felt252::one().shl(32_u32)
-                        + Felt252::one().shl(9_u32)
-                        + Felt252::one().shl(8_u32)
-                        + Felt252::one().shl(7_u32)
-                        + Felt252::one().shl(6_u32)
-                        + Felt252::one().shl(4_u32)
-                        + Felt252::one()
-                )]
-                .into_iter()
-                .map(|(k, v)| (k.to_string(), v))
-                .collect()
-            ),
+            run_hint!(vm, ids_data, hint_code, exec_scopes_ref!()),
             Ok(())
         );
         //Check hint memory inserts
@@ -242,20 +188,7 @@ mod tests {
                 vm,
                 ids_data,
                 hint_code,
-                exec_scopes_ref!(),
-                &[(
-                    SECP_REM,
-                    Felt252::one().shl(32_u32)
-                        + Felt252::one().shl(9_u32)
-                        + Felt252::one().shl(8_u32)
-                        + Felt252::one().shl(7_u32)
-                        + Felt252::one().shl(6_u32)
-                        + Felt252::one().shl(4_u32)
-                        + Felt252::one()
-                )]
-                .into_iter()
-                .map(|(k, v)| (k.to_string(), v))
-                .collect()
+                exec_scopes_ref!()
             ),
             Err(HintError::SecpVerifyZero(x)) if x == bigint_str!(
                 "897946605976106752944343961220884287276604954404454400"
@@ -282,20 +215,7 @@ mod tests {
                         vm,
                         ids_data,
                         hint_code,
-                        exec_scopes_ref!(),
-                        &[(
-                            SECP_REM,
-                            Felt252::one().shl(32_u32)
-                                + Felt252::one().shl(9_u32)
-                                + Felt252::one().shl(8_u32)
-                                + Felt252::one().shl(7_u32)
-                                + Felt252::one().shl(6_u32)
-                                + Felt252::one().shl(4_u32)
-                                + Felt252::one()
-                        )]
-                        .into_iter()
-                        .map(|(k, v)| (k.to_string(), v))
-                        .collect()
+                        exec_scopes_ref!()
                     ),
                     Err(HintError::Memory(
                         MemoryError::InconsistentMemory(
@@ -331,28 +251,7 @@ mod tests {
 
         let mut exec_scopes = ExecutionScopes::new();
         //Execute the hint
-        assert_matches!(
-            run_hint!(
-                vm,
-                ids_data,
-                hint_code,
-                &mut exec_scopes,
-                &[(
-                    SECP_REM,
-                    Felt252::one().shl(32_u32)
-                        + Felt252::one().shl(9_u32)
-                        + Felt252::one().shl(8_u32)
-                        + Felt252::one().shl(7_u32)
-                        + Felt252::one().shl(6_u32)
-                        + Felt252::one().shl(4_u32)
-                        + Felt252::one()
-                )]
-                .into_iter()
-                .map(|(k, v)| (k.to_string(), v))
-                .collect()
-            ),
-            Ok(())
-        );
+        assert_matches!(run_hint!(vm, ids_data, hint_code, &mut exec_scopes), Ok(()));
 
         //Check 'value' is defined in the vm scope
         assert_matches!(
@@ -382,20 +281,7 @@ mod tests {
                 vm,
                 ids_data,
                 hint_code,
-                exec_scopes_ref!(),
-                &[(
-                    SECP_REM,
-                    Felt252::one().shl(32_u32)
-                        + Felt252::one().shl(9_u32)
-                        + Felt252::one().shl(8_u32)
-                        + Felt252::one().shl(7_u32)
-                        + Felt252::one().shl(6_u32)
-                        + Felt252::one().shl(4_u32)
-                        + Felt252::one()
-                )]
-                .into_iter()
-                .map(|(k, v)| (k.to_string(), v))
-                .collect()
+                exec_scopes_ref!()
             ),
             Err(HintError::IdentifierHasNoMember(x, y
             )) if x == "x" && y == "d0"
@@ -423,28 +309,7 @@ mod tests {
         let mut exec_scopes = ExecutionScopes::new();
 
         //Execute the hint
-        assert_matches!(
-            run_hint!(
-                vm,
-                ids_data,
-                hint_code,
-                &mut exec_scopes,
-                &[(
-                    SECP_REM,
-                    Felt252::one().shl(32_u32)
-                        + Felt252::one().shl(9_u32)
-                        + Felt252::one().shl(8_u32)
-                        + Felt252::one().shl(7_u32)
-                        + Felt252::one().shl(6_u32)
-                        + Felt252::one().shl(4_u32)
-                        + Felt252::one()
-                )]
-                .into_iter()
-                .map(|(k, v)| (k.to_string(), v))
-                .collect()
-            ),
-            Ok(())
-        );
+        assert_matches!(run_hint!(vm, ids_data, hint_code, &mut exec_scopes), Ok(()));
 
         //Check 'x' is defined in the vm scope
         check_scope!(
@@ -478,20 +343,7 @@ mod tests {
                 vm,
                 ids_data,
                 hint_code,
-                exec_scopes_ref!(),
-                &[(
-                    SECP_REM,
-                    Felt252::one().shl(32_u32)
-                        + Felt252::one().shl(9_u32)
-                        + Felt252::one().shl(8_u32)
-                        + Felt252::one().shl(7_u32)
-                        + Felt252::one().shl(6_u32)
-                        + Felt252::one().shl(4_u32)
-                        + Felt252::one()
-                )]
-                .into_iter()
-                .map(|(k, v)| (k.to_string(), v))
-                .collect()
+                exec_scopes_ref!()
             ),
             Err(HintError::IdentifierHasNoMember(x, y
             )) if x == "x" && y == "d0"
@@ -620,25 +472,7 @@ mod tests {
         );
         //Execute the hint
         assert_matches!(
-            run_hint!(
-                vm,
-                HashMap::new(),
-                hint_code,
-                &mut exec_scopes,
-                &[(
-                    SECP_REM,
-                    Felt252::one().shl(32_u32)
-                        + Felt252::one().shl(9_u32)
-                        + Felt252::one().shl(8_u32)
-                        + Felt252::one().shl(7_u32)
-                        + Felt252::one().shl(6_u32)
-                        + Felt252::one().shl(4_u32)
-                        + Felt252::one()
-                )]
-                .into_iter()
-                .map(|(k, v)| (k.to_string(), v))
-                .collect()
-            ),
+            run_hint!(vm, HashMap::new(), hint_code, &mut exec_scopes),
             Ok(())
         );
 
@@ -671,20 +505,7 @@ mod tests {
                 vm,
                 HashMap::new(),
                 hint_code,
-                exec_scopes_ref!(),
-                &[(
-                    SECP_REM,
-                    Felt252::one().shl(32_u32)
-                        + Felt252::one().shl(9_u32)
-                        + Felt252::one().shl(8_u32)
-                        + Felt252::one().shl(7_u32)
-                        + Felt252::one().shl(6_u32)
-                        + Felt252::one().shl(4_u32)
-                        + Felt252::one()
-                )]
-                .into_iter()
-                .map(|(k, v)| (k.to_string(), v))
-                .collect()
+                exec_scopes_ref!()
             ),
             Err(HintError::VariableNotInScopeError(x)) if x == *"x".to_string()
         );

--- a/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
@@ -1,8 +1,12 @@
+use core::str::FromStr;
+
 use crate::stdlib::{collections::HashMap, ops::Shl, prelude::*};
 
 use crate::vm::errors::hint_errors::HintError;
 use felt::Felt252;
 
+use lazy_static::lazy_static;
+use num_bigint::BigInt;
 use num_traits::Zero;
 
 use super::bigint_utils::BigInt3;
@@ -17,6 +21,14 @@ pub const P0: &str = "starkware.cairo.common.cairo_secp.constants.P0";
 pub const P1: &str = "starkware.cairo.common.cairo_secp.constants.P1";
 pub const P2: &str = "starkware.cairo.common.cairo_secp.constants.P2";
 pub const SECP_REM: &str = "starkware.cairo.common.cairo_secp.constants.SECP_REM";
+// Constants in package "starkware.cairo.common.cairo_secp.secp_utils"
+lazy_static! {
+    //SECP_P = 2**256 - 2**32 - 2**9 - 2**8 - 2**7 - 2**6 - 2**4 - 1
+    pub(crate) static ref SECP_P: BigInt = BigInt::from_str(
+        "115792089237316195423570985008687907853269984665640564039457584007908834671663"
+    )
+    .unwrap();
+}
 
 /*
 Takes a 256-bit integer and returns its canonical representation as:

--- a/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
@@ -36,6 +36,11 @@ lazy_static! {
     pub(crate) static ref BASE_MINUS_ONE: BigUint = BigUint::from_str(
         "77371252455336267181195263"
     ).unwrap();
+    // N = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+    pub(crate) static ref N: BigInt = BigInt::from_str(
+        "115792089237316195423570985008687907852837564279074904382605163141518161494337"
+    )
+.unwrap();
 }
 
 /*

--- a/src/hint_processor/builtin_hint_processor/secp/signature.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/signature.rs
@@ -107,6 +107,7 @@ pub fn get_point_from_x(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::stdlib::string::ToString;
     use crate::types::errors::math_errors::MathError;
     use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
     use crate::{
@@ -184,7 +185,16 @@ mod tests {
         vm.run_context.fp = 1;
         let ids_data = non_continuous_ids_data![("v", -1), ("x_cube", 0)];
         assert_matches!(
-            run_hint!(vm, ids_data, hint_code, exec_scopes_ref!()),
+            run_hint!(
+                vm,
+                ids_data,
+                hint_code,
+                exec_scopes_ref!(),
+                &[(BETA, Felt252::new(7)),]
+                    .into_iter()
+                    .map(|(k, v)| (k.to_string(), v))
+                    .collect()
+            ),
             Ok(())
         )
     }
@@ -204,7 +214,19 @@ mod tests {
         vm.run_context.fp = 2;
 
         let ids_data = ids_data!["v", "x_cube"];
-        assert_matches!(run_hint!(vm, ids_data, hint_code, &mut exec_scopes), Ok(()));
+        assert_matches!(
+            run_hint!(
+                vm,
+                ids_data,
+                hint_code,
+                &mut exec_scopes,
+                &[(BETA, Felt252::new(7)),]
+                    .into_iter()
+                    .map(|(k, v)| (k.to_string(), v))
+                    .collect()
+            ),
+            Ok(())
+        );
 
         check_scope!(
             &exec_scopes,


### PR DESCRIPTION
Some hints from cairo_scept import python constants, and have intead been using cairo constants