### PR TITLE
Recalibrate benchmarks for quick profiling

### DIFF
--- a/cairo_programs/benchmarks/blake2s_integration_benchmark.cairo
+++ b/cairo_programs/benchmarks/blake2s_integration_benchmark.cairo
@@ -2,7 +2,7 @@ from blake2s_integration_tests import run_tests
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
 
 func main{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}() {
-    run_tests(100);
+    run_tests(300);
 
     return ();
 }

--- a/cairo_programs/benchmarks/compare_arrays_200000.cairo
+++ b/cairo_programs/benchmarks/compare_arrays_200000.cairo
@@ -23,7 +23,7 @@ func fill_array(array: felt*, base: felt, step: felt, array_length: felt, iterat
 
 func main() {
     alloc_locals;
-    tempvar array_length = 50000;
+    tempvar array_length = 250000;
     let (array_a: felt*) = alloc();
     let (array_b: felt*) = alloc();
     fill_array(array_a, 7, 3, array_length, 0);

--- a/cairo_programs/benchmarks/dict_integration_benchmark.cairo
+++ b/cairo_programs/benchmarks/dict_integration_benchmark.cairo
@@ -1,7 +1,7 @@
 from dict_integration_tests import run_tests
 
 func main{range_check_ptr: felt}() {
-    run_tests(100);
+    run_tests(200);
 
     return ();
 }

--- a/cairo_programs/benchmarks/factorial_multirun.cairo
+++ b/cairo_programs/benchmarks/factorial_multirun.cairo
@@ -7,21 +7,11 @@ func factorial(n) -> (result: felt) {
     return (n * a,);
 }
 
-// factorial(n), t + 1 times
-func factorial_wrapper(n, t) {
-    factorial(n);
-    if (t != 0) {
-        factorial_wrapper(n, t - 1);
-    }
-    return ();
-}
-
 func main() {
     // Make sure the factorial(10) == 3628800
     let (y) = factorial(10);
     y = 3628800;
 
-    // factorial(10000), 11 times
-    factorial_wrapper(10000, 10);
+    factorial(2000000);
     return ();
 }

--- a/cairo_programs/benchmarks/fibonacci_1000_multirun.cairo
+++ b/cairo_programs/benchmarks/fibonacci_1000_multirun.cairo
@@ -1,17 +1,6 @@
 func main() {
-    fib_wrapper(50);
-    ret;
-}
+    fib(1, 1, 1500000);
 
-func fib_wrapper(n) {
-    // Call fib(1, 1, 1000).
-    let result: felt = fib(1, 1, 1000);
-
-    // Make sure the 1000th Fibonacci number is 222450955505511890955301767713383614666194461405743219770606958667979327682.
-    assert result = 222450955505511890955301767713383614666194461405743219770606958667979327682;
-    if (n != 0) {
-        fib_wrapper(n - 1);
-    }
     ret;
 }
 

--- a/cairo_programs/benchmarks/integration_builtins.cairo
+++ b/cairo_programs/benchmarks/integration_builtins.cairo
@@ -79,7 +79,7 @@ func main{
 }() {
     let num_a = 123568;
     let num_b = 5673940;
-    builtins_wrapper_iter(num_a, num_b, 1000);
+    builtins_wrapper_iter(num_a, num_b, 10000);
 
     return ();
 }

--- a/cairo_programs/benchmarks/keccak_integration_benchmark.cairo
+++ b/cairo_programs/benchmarks/keccak_integration_benchmark.cairo
@@ -2,6 +2,6 @@ from keccak_integration_tests import run_test
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
 
 func main{range_check_ptr: felt, bitwise_ptr: BitwiseBuiltin*}() -> () {
-    run_test(100);
+    run_test(300);
     return ();
 }

--- a/cairo_programs/benchmarks/linear_search.cairo
+++ b/cairo_programs/benchmarks/linear_search.cairo
@@ -25,11 +25,11 @@ func main() {
     alloc_locals;
     let (felt_array: felt*) = alloc();
 
-    fill_array(felt_array, 10001, 0);
+    fill_array(felt_array, 400001, 0);
 
-    let (index_1) = search(10000, felt_array, 0, 10001);
-    assert index_1 = 10000;
-    let (index_2) = search(5000, felt_array, 0, 10001);
-    assert index_2 = 5000;
+    let (index_1) = search(400000, felt_array, 0, 400001);
+    assert index_1 = 400000;
+    let (index_2) = search(200000, felt_array, 0, 400001);
+    assert index_2 = 200000;
     ret;
 }

--- a/cairo_programs/benchmarks/math_cmp_and_pow_integration_benchmark.cairo
+++ b/cairo_programs/benchmarks/math_cmp_and_pow_integration_benchmark.cairo
@@ -1,6 +1,6 @@
 from math_cmp_and_pow_integration_tests import run_tests
 
 func main{range_check_ptr}() -> () {
-    run_tests(100);
+    run_tests(30000);
     return ();
 }

--- a/cairo_programs/benchmarks/math_integration_benchmark.cairo
+++ b/cairo_programs/benchmarks/math_integration_benchmark.cairo
@@ -1,6 +1,16 @@
 from math_integration_tests import run_tests
 
-func main{range_check_ptr}() -> () {
+func repeat{range_check_ptr}(n) -> () {
+    if (n == 0) {
+        return ();
+    }
     run_tests(1000);
+    return repeat(n - 1);
+}
+
+func main{range_check_ptr}() -> () {
+    //FIXME: there seems to be a bug that causes failures for bigger values.
+    //For now just run these several times instead.
+    repeat(8);
     return ();
 }

--- a/cairo_programs/benchmarks/memory_integration_benchmark.cairo
+++ b/cairo_programs/benchmarks/memory_integration_benchmark.cairo
@@ -1,6 +1,6 @@
 from memory_integration_tests import run_tests
 
 func main() -> () {
-    run_tests(100, 100);
+    run_tests(200, 300);
     return ();
 }

--- a/cairo_programs/benchmarks/operations_with_data_structures_benchmarks.cairo
+++ b/cairo_programs/benchmarks/operations_with_data_structures_benchmarks.cairo
@@ -2,6 +2,6 @@ from operations_with_data_structures import run_tests
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
 
 func main{range_check_ptr: felt, bitwise_ptr: BitwiseBuiltin*}() {
-    run_tests(0, 300);
+    run_tests(0, 500);
     return ();
 }

--- a/cairo_programs/benchmarks/secp_integration_benchmark.cairo
+++ b/cairo_programs/benchmarks/secp_integration_benchmark.cairo
@@ -1,6 +1,6 @@
 from secp_integration_tests import run_tests
 
 func main{range_check_ptr}() {
-    run_tests(0, 4);
+    run_tests(0, 10);
     return ();
 }

--- a/cairo_programs/benchmarks/set_integration_benchmark.cairo
+++ b/cairo_programs/benchmarks/set_integration_benchmark.cairo
@@ -1,6 +1,6 @@
 from set_integration_tests import run_tests
 
 func main{range_check_ptr}() -> () {
-    run_tests(1000);
+    run_tests(8000);
     return ();
 }

--- a/cairo_programs/benchmarks/uint256_integration_benchmark.cairo
+++ b/cairo_programs/benchmarks/uint256_integration_benchmark.cairo
@@ -2,6 +2,6 @@ from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
 from uint256_integration_tests import run_tests
 
 func main{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}() -> () {
-    run_tests(1000);
+    run_tests(4000);
     return ();
 }


### PR DESCRIPTION
Adjust some parameters in cairo benchmark programs to get their runtime in the range of 1-2s to help more quickly test optimizations and profile execution.
These times are not optimal for comparing with CPython and PyPy, as it doesn't give PyPy enough warmup time. A later PR may address this by improving parameterization and separating tests for it with largar parameters.