### PR TITLE
Conversion improvements for Felt252

### DIFF
--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -795,6 +795,10 @@ impl<'a, const PH: u128, const PL: u128> BitXor for &'a FeltBigInt<PH, PL> {
 }
 
 impl<const PH: u128, const PL: u128> ToPrimitive for FeltBigInt<PH, PL> {
+    fn to_u128(&self) -> Option<u128> {
+        self.val.to_u128()
+    }
+
     fn to_u64(&self) -> Option<u64> {
         self.val.to_u64()
     }

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -907,9 +907,11 @@ mod test {
         #[test]
         #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         fn to_le_bytes(ref x in FELT_PATTERN) {
-            let x = &Felt252::from_bytes_le(x.as_bytes());
-            let bytes = x.to_le_bytes();
-            let y = &Felt252::from_bytes_le(&bytes);
+            let x = &Felt252::from_bytes_be(x.as_bytes());
+            let mut bytes = x.to_le_bytes();
+            // Convert to big endian for test
+            bytes.reverse();
+            let y = &Felt252::from_bytes_be(&bytes);
             prop_assert!(x == y);
         }
 
@@ -919,7 +921,7 @@ mod test {
             let x = &Felt252::parse_bytes(x.as_bytes(), 16).unwrap();
             let y = x.to_u128();
             prop_assert!(y.is_some());
-            prop_assert!(x.to_string() == y.to_string());
+            prop_assert!(x.to_string() == y.unwrap().to_string());
         }
 
         #[test]

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -926,7 +926,7 @@ mod test {
 
         #[test]
         #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-        fn to_u128_out_of_range(ref x in "([1-9a-f][0-9a-f]{32,63})") {
+        fn to_u128_out_of_range(ref x in "([1-9a-f][0-9a-f]{32,40})") {
             let x = &Felt252::parse_bytes(x.as_bytes(), 16).unwrap();
             let y = x.to_u128();
             prop_assert!(y.is_none());

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -926,7 +926,7 @@ mod test {
 
         #[test]
         #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-        fn to_u128_out_of_range(ref x in "([1-9a-f][0-9a-f]{32,})") {
+        fn to_u128_out_of_range(ref x in "([1-9a-f][0-9a-f]{32,63})") {
             let x = &Felt252::parse_bytes(x.as_bytes(), 16).unwrap();
             let y = x.to_u128();
             prop_assert!(y.is_none());

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -169,19 +169,9 @@ impl Felt252 {
     }
 
     pub fn to_be_bytes(&self) -> [u8; 32] {
-        let mut res = [0u8; 32];
-        let mut iter = self.iter_u64_digits();
-        let (d0, d1, d2, d3) = (
-            iter.next().unwrap_or_default().to_be_bytes(),
-            iter.next().unwrap_or_default().to_be_bytes(),
-            iter.next().unwrap_or_default().to_be_bytes(),
-            iter.next().unwrap_or_default().to_be_bytes(),
-        );
-        res[..8].copy_from_slice(&d3);
-        res[8..16].copy_from_slice(&d2);
-        res[16..24].copy_from_slice(&d1);
-        res[24..].copy_from_slice(&d0);
-        res
+        let mut bytes = self.to_le_bytes();
+        bytes.reverse();
+        bytes
     }
 
     #[cfg(any(feature = "std", feature = "alloc"))]


### PR DESCRIPTION
- New `fn to_be_bytes(&self) -> [u8; 32]` method
- New `fn to_u128(&self) -> Option<u128>` method
- Unroll `to_le_bytes` for more obvious reading
- Proptests for all three methods

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
