### PR TITLE
Use `requirements.txt` in first job of `iai_pr` workflow

### DIFF
--- a/.github/workflows/iai_pr.yml
+++ b/.github/workflows/iai_pr.yml
@@ -24,7 +24,7 @@ jobs:
         ref: ${{ github.event.pull_request.base.sha }}
     - name: Install test dependencies
       run: |
-        pip install ecdsa fastecdsa sympy typeguard==2.13.0 cairo-lang==0.10.3
+        pip install -r requirements.txt
         sudo apt update
         sudo apt install -y valgrind
     - name: Initialize IAI cache for ${{ github.event.pull_request.base.sha }}


### PR DESCRIPTION
This change was omitted on the initial requirements.txt PR in order to not break the workflow
