### PR TITLE
Validated as type

### DIFF
--- a/src/tests/memory_comparator.py
+++ b/src/tests/memory_comparator.py
@@ -34,12 +34,12 @@ def main():
     if cairo_mem != cairo_rs_mem:
         print(f'Mismatch between {filename1} (Cairo) and {filename2} (cairo_rs)')
         print('keys in Cairo but not cairo-rs:')
-        for k in cairo_mem:
+        for k, v in cairo_mem.items():
             if k in cairo_rs_mem:
                 continue
             print(f'{k}:{v}')
         print('keys in cairo_rs but not Cairo:')
-        for k in cairo_rs_mem:
+        for k, v in cairo_rs_mem.items():
             if k in cairo_mem:
                 continue
             print(f'{k}:{v}')

--- a/src/types/relocatable.rs
+++ b/src/types/relocatable.rs
@@ -23,6 +23,12 @@ pub enum MaybeRelocatable {
     Int(Felt252),
 }
 
+impl Default for MaybeRelocatable {
+    fn default() -> Self {
+        (0isize, 0usize).into()
+    }
+}
+
 impl From<(isize, usize)> for Relocatable {
     fn from(index_offset: (isize, usize)) -> Self {
         Relocatable {

--- a/src/vm/runners/builtin_runner/mod.rs
+++ b/src/vm/runners/builtin_runner/mod.rs
@@ -547,7 +547,6 @@ impl From<SegmentArenaBuiltinRunner> for BuiltinRunner {
 mod tests {
     use super::*;
     use crate::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor;
-    use crate::relocatable;
     use crate::serde::deserialize_program::BuiltinName;
     use crate::types::instance_definitions::ecdsa_instance_def::EcdsaInstanceDef;
     use crate::types::instance_definitions::keccak_instance_def::KeccakInstanceDef;
@@ -1349,10 +1348,7 @@ mod tests {
             BitwiseBuiltinRunner::new(&BitwiseInstanceDef::default(), true).into();
 
         let mut vm = vm!();
-        vm.segments
-            .memory
-            .validated_addresses
-            .extend(&[relocatable!(0, 2)]);
+        vm.segments.memory.mark_as_valid((0, 2).into());
 
         vm.segments.memory = memory![
             ((0, 0), (0, 0)),

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -1556,17 +1556,15 @@ mod tests {
             .data
             .iter()
             .enumerate()
-            .flat_map(|(si, s)| (0..s.len()).map(move |off| Relocatable::from((si as isize, off))))
-            .filter(|addr| ![Relocatable::from((2, 0)), Relocatable::from((2, 1))].contains(addr))
+            .flat_map(|(si, s)| (0..s.len()).map(move |off| (si as isize, off).into()))
+            .filter(|addr| ![(2, 0).into(), (2, 1).into()].contains(addr))
             .for_each(|addr| assert!(!vm.segments.memory.is_valid(addr)));
         vm.segments
             .memory
             .temp_data
             .iter()
             .enumerate()
-            .flat_map(|(si, s)| {
-                (0..s.len()).map(move |off| Relocatable::from((-(si as isize) - 1, off)))
-            })
+            .flat_map(|(si, s)| (0..s.len()).map(move |off| (-(si as isize) - 1, off).into()))
             .for_each(|addr| assert!(!vm.segments.memory.is_valid(addr)));
     }
 

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -1557,7 +1557,7 @@ mod tests {
             .iter()
             .enumerate()
             .flat_map(|(si, s)| (0..s.len()).map(move |off| Relocatable::from((si as isize, off))))
-            .filter(|addr| ![Relocatable::from((2, 0)), Relocatable::from((2, 1))].contains(&addr))
+            .filter(|addr| ![Relocatable::from((2, 0)), Relocatable::from((2, 1))].contains(addr))
             .for_each(|addr| assert!(!vm.segments.memory.is_valid(addr)));
         vm.segments
             .memory

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -1547,17 +1547,9 @@ mod tests {
         assert_eq!(vm.builtin_runners[0].name(), RANGE_CHECK_BUILTIN_NAME);
         assert_eq!(vm.builtin_runners[0].base(), 2);
         cairo_runner.initialize_vm(&mut vm).unwrap();
-        assert!(vm
-            .segments
-            .memory
-            .validated_addresses
-            .contains(&Relocatable::from((2, 0))));
-        assert!(vm
-            .segments
-            .memory
-            .validated_addresses
-            .contains(&Relocatable::from((2, 1))));
-        assert_eq!(vm.segments.memory.validated_addresses.len(), 2);
+        assert!(vm.segments.memory.is_valid((2, 0).into()));
+        assert!(vm.segments.memory.is_valid((2, 1).into()));
+        //assert_eq!(vm.segments.memory.validated_addresses.len(), 2);
     }
 
     #[test]

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -1558,14 +1558,14 @@ mod tests {
             .enumerate()
             .flat_map(|(si, s)| (0..s.len()).map(move |off| (si as isize, off).into()))
             .filter(|addr| ![(2, 0).into(), (2, 1).into()].contains(addr))
-            .for_each(|addr| assert!(!vm.segments.memory.is_valid(addr)));
+            .for_each(|addr| assert!(!vm.segments.memory.is_valid(addr), "{addr:?}"));
         vm.segments
             .memory
             .temp_data
             .iter()
             .enumerate()
             .flat_map(|(si, s)| (0..s.len()).map(move |off| (-(si as isize) - 1, off).into()))
-            .for_each(|addr| assert!(!vm.segments.memory.is_valid(addr)));
+            .for_each(|addr| assert!(!vm.segments.memory.is_valid(addr), "{addr:?}"));
     }
 
     #[test]

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -638,6 +638,18 @@ mod test {
         memory.mark_as_valid(key);
         assert!(is_accessed(&memory, key));
         assert!(is_valid(&memory, key));
+        let key = (-1, 1).into();
+        let val: Relocatable = (2, 3).into();
+        memory.insert(key, &val).unwrap();
+        assert_eq!(
+            memory.get(&key).unwrap().as_ref(),
+            &MaybeRelocatable::from((2, 3))
+        );
+        assert!(!is_accessed(&memory, key));
+        assert!(!is_valid(&memory, key));
+        memory.mark_as_valid(key);
+        assert!(!is_accessed(&memory, key));
+        assert!(!is_valid(&memory, key));
     }
 
     #[test]

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -638,6 +638,7 @@ mod test {
         memory.mark_as_valid(key);
         assert!(is_accessed(&memory, key));
         assert!(is_valid(&memory, key));
+        memory.temp_data.push(Vec::new());
         let key = (-1, 1).into();
         let val: Relocatable = (2, 3).into();
         memory.insert(key, &val).unwrap();

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -42,12 +42,9 @@ impl MemoryCell {
     }
 
     pub fn mark_accessed(&mut self) {
-        match self {
-            Written(x) => {
-                *self = Accessed(take(x));
-            }
-            _ => (),
-        }
+        if let Written(x) = self {
+            *self = Accessed(take(x));
+        };
     }
 
     pub fn is_accessed(&self) -> bool {

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -642,6 +642,23 @@ mod test {
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn memory_cell_state_none_is_never_accessed_or_valid() {
+        let key = Relocatable::from((0, 3));
+        let val = MaybeRelocatable::from(Felt252::new(5));
+        let mut memory = Memory::new();
+        memory.data.push(Vec::new());
+        memory.insert(key, &val).unwrap();
+        let key = (0, 1).into();
+        memory.mark_as_accessed(key);
+        assert!(!is_accessed(&memory, key));
+        assert!(!is_valid(&memory, key));
+        memory.mark_as_valid(key);
+        assert!(!is_accessed(&memory, key));
+        assert!(!is_valid(&memory, key));
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn memory_cell_state_missing_key_is_never_accessed_or_valid() {
         let key = Relocatable::from((0, 0));
         let val = MaybeRelocatable::from(Felt252::new(5));

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -304,9 +304,8 @@ impl Memory {
 
     ///Applies validation_rules to the current memory
     pub fn validate_existing_memory(&mut self) -> Result<(), MemoryError> {
-        let mut validation_rules = Vec::new();
-        core::mem::swap(&mut self.validation_rules, &mut validation_rules);
-        for (index, rule) in validation_rules.iter().enumerate() {
+        let rules = core::mem::take(&mut self.validation_rules);
+        for (index, rule) in rules.iter().enumerate() {
             let Some(rule) = rule else {
                 continue;
             };
@@ -320,7 +319,7 @@ impl Memory {
                     .for_each(|addr| self.mark_as_valid(addr));
             }
         }
-        core::mem::swap(&mut self.validation_rules, &mut validation_rules);
+        self.validation_rules = rules;
         Ok(())
     }
 

--- a/src/vm/vm_memory/memory.rs
+++ b/src/vm/vm_memory/memory.rs
@@ -317,7 +317,7 @@ impl Memory {
             let mut validated = Vec::new();
             for offset in 0..segment.len() {
                 let addr = Relocatable::from((index as isize, offset));
-                validated = rule.0(self, addr)?;
+                validated.extend_from_slice(&rule.0(self, addr)?);
             }
             let segment = self
                 .data


### PR DESCRIPTION
Even with `BitVec`, marking and checking whether a cell is validated introduces significant overhead to several benchmarks.
This converts both validated and accessed state into part of the `MemoryCell` type, so marking and checking takes no extra space while being quick (two indexings in an array and a `match`) to perform.

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
