### PR TITLE
Convert unchanged inner_rc_bound to constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* perf: make `inner_rc_bound` a constant, improving performance of the range-check builtin
+
 #### [0.5.1] - 2023-6-7
 
 * fix: fix overflow for `QUAD_BIT` and `DI_BIT` hints [#1209](https://github.com/lambdaclass/cairo-rs/pull/1209)

--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -732,7 +732,7 @@ impl<const PH: u128, const PL: u128> Shr<u32> for FeltBigInt<PH, PL> {
     type Output = Self;
     fn shr(self, other: u32) -> Self::Output {
         FeltBigInt {
-            val: self.val.shr(other).mod_floor(&CAIRO_PRIME_BIGUINT),
+            val: self.val.shr(other),
         }
     }
 }

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -27,6 +27,9 @@ const _INNER_RC_BOUND: u64 = 1u64 << INNER_RC_BOUND_SHIFT;
 const INNER_RC_BOUND_SHIFT: u64 = 16;
 const INNER_RC_BOUND_MASK: u64 = u16::MAX as u64;
 
+// TODO: use constant instead of receiving as false parameter
+const N_PARTS: u64 = 8;
+
 #[derive(Debug, Clone)]
 pub struct RangeCheckBuiltinRunner {
     ratio: Option<u32>,
@@ -88,13 +91,12 @@ impl RangeCheckBuiltinRunner {
                 let num = memory
                     .get_integer(address)
                     .map_err(|_| MemoryError::RangeCheckFoundNonInt(Box::new(address)))?;
-                if &Felt252::zero() <= num.as_ref() && num.as_ref() < &Felt252::one().shl(128_usize)
-                {
+                if num.bits() < N_PARTS * INNER_RC_BOUND_SHIFT {
                     Ok(vec![address.to_owned()])
                 } else {
                     Err(MemoryError::RangeCheckNumOutOfBounds(Box::new((
                         num.into_owned(),
-                        Felt252::one().shl(128_usize),
+                        Felt252::one().shl((N_PARTS * INNER_RC_BOUND_SHIFT) as u32),
                     ))))
                 }
             },

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -91,7 +91,7 @@ impl RangeCheckBuiltinRunner {
                 let num = memory
                     .get_integer(address)
                     .map_err(|_| MemoryError::RangeCheckFoundNonInt(Box::new(address)))?;
-                if num.bits() < N_PARTS * INNER_RC_BOUND_SHIFT {
+                if num.bits() <= N_PARTS * INNER_RC_BOUND_SHIFT {
                     Ok(vec![address.to_owned()])
                 } else {
                     Err(MemoryError::RangeCheckNumOutOfBounds(Box::new((

--- a/src/vm/runners/builtin_runner/range_check.rs
+++ b/src/vm/runners/builtin_runner/range_check.rs
@@ -18,10 +18,14 @@ use crate::{
     },
 };
 use felt::Felt252;
-use num_integer::Integer;
-use num_traits::{One, ToPrimitive, Zero};
+use num_traits::{One, Zero};
 
 use super::RANGE_CHECK_BUILTIN_NAME;
+
+// NOTE: the current implementation is based on the bound 0x10000
+const _INNER_RC_BOUND: u64 = 1u64 << INNER_RC_BOUND_SHIFT;
+const INNER_RC_BOUND_SHIFT: u64 = 16;
+const INNER_RC_BOUND_MASK: u64 = u16::MAX as u64;
 
 #[derive(Debug, Clone)]
 pub struct RangeCheckBuiltinRunner {
@@ -30,7 +34,6 @@ pub struct RangeCheckBuiltinRunner {
     pub(crate) stop_ptr: Option<usize>,
     pub(crate) cells_per_instance: u32,
     pub(crate) n_input_cells: u32,
-    inner_rc_bound: usize,
     pub _bound: Option<Felt252>,
     pub(crate) included: bool,
     pub(crate) n_parts: u32,
@@ -39,8 +42,6 @@ pub struct RangeCheckBuiltinRunner {
 
 impl RangeCheckBuiltinRunner {
     pub fn new(ratio: Option<u32>, n_parts: u32, included: bool) -> RangeCheckBuiltinRunner {
-        let inner_rc_bound = 1_usize << 16;
-
         let bound = Felt252::one().shl(16 * n_parts);
         let _bound = if n_parts != 0 && bound.is_zero() {
             None
@@ -54,7 +55,6 @@ impl RangeCheckBuiltinRunner {
             stop_ptr: None,
             cells_per_instance: CELLS_PER_RANGE_CHECK,
             n_input_cells: CELLS_PER_RANGE_CHECK,
-            inner_rc_bound,
             _bound,
             included,
             n_parts,
@@ -121,27 +121,30 @@ impl RangeCheckBuiltinRunner {
     }
 
     pub fn get_range_check_usage(&self, memory: &Memory) -> Option<(usize, usize)> {
-        let mut rc_bounds: Option<(usize, usize)> = None;
         let range_check_segment = memory.data.get(self.base)?;
-        let inner_rc_bound = Felt252::new(self.inner_rc_bound);
-        for value in range_check_segment {
-            //Split val into n_parts parts.
-            let mut val = value.as_ref()?.get_value().get_int_ref()?.clone();
-            for _ in 0..self.n_parts {
-                let part_val = val.mod_floor(&inner_rc_bound).to_usize()?;
-                rc_bounds = Some(match rc_bounds {
-                    None => (part_val, part_val),
-                    Some((rc_min, rc_max)) => {
-                        let rc_min = min(rc_min, part_val);
-                        let rc_max = max(rc_max, part_val);
+        let mut rc_bounds =
+            (!range_check_segment.is_empty()).then_some((usize::MAX, usize::MIN))?;
 
-                        (rc_min, rc_max)
-                    }
+        // Split value into n_parts parts of less than _INNER_RC_BOUND size.
+        for value in range_check_segment {
+            rc_bounds = value
+                .as_ref()?
+                .get_value()
+                .get_int_ref()?
+                .to_le_digits()
+                // TODO: maybe skip leading zeros
+                .into_iter()
+                .flat_map(|digit| {
+                    (0..=3)
+                        .rev()
+                        .map(move |i| ((digit >> (i * INNER_RC_BOUND_SHIFT)) & INNER_RC_BOUND_MASK))
+                })
+                .take(self.n_parts as usize)
+                .fold(rc_bounds, |mm, x| {
+                    (min(mm.0, x as usize), max(mm.1, x as usize))
                 });
-                val = val.div_floor(&inner_rc_bound)
-            }
         }
-        rc_bounds
+        Some(rc_bounds)
     }
 
     pub fn get_used_instances(


### PR DESCRIPTION
Exploit the fact `inner_rc_bound` is always `u16::MAX` to avoid divisions and `Felt252` constructions, as well as a little bit of loop unrolling. This improves execution speed for proof mode. It makes no difference in non-proof executions.

There's a little bit of cleanup remaining, but it's mostly done.

inner-proof-blake2s_integration_benchmark.md
| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `inner proof` | 9.755 ± 0.087 | 9.697 | 9.907 | 1.00 |
| `base proof` | 10.213 ± 0.026 | 10.176 | 10.247 | 1.05 ± 0.01 |

inner-proof-compare_arrays_200000.md
| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `inner proof` | 2.838 ± 0.016 | 2.823 | 2.859 | 1.00 |
| `base proof` | 2.981 ± 0.022 | 2.966 | 3.020 | 1.05 ± 0.01 |

inner-proof-dict_integration_benchmark.md
| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `inner proof` | 1.837 ± 0.006 | 1.830 | 1.847 | 1.00 |
| `base proof` | 1.849 ± 0.006 | 1.840 | 1.854 | 1.01 ± 0.00 |

inner-proof-factorial_multirun.md
| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `inner proof` | 2.852 ± 0.005 | 2.843 | 2.857 | 1.00 |
| `base proof` | 2.938 ± 0.025 | 2.915 | 2.974 | 1.03 ± 0.01 |

inner-proof-fibonacci_1000_multirun.md
| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `inner proof` | 2.553 ± 0.003 | 2.548 | 2.557 | 1.00 |
| `base proof` | 2.657 ± 0.007 | 2.650 | 2.669 | 1.04 ± 0.00 |

inner-proof-find_element.md
| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `inner proof` | 1.534 ± 0.019 | 1.509 | 1.557 | 1.00 |
| `base proof` | 1.579 ± 0.003 | 1.577 | 1.583 | 1.03 ± 0.01 |

inner-proof-integration_builtins.md
| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `inner proof` | 9.167 ± 0.041 | 9.117 | 9.223 | 1.00 |
| `base proof` | 9.537 ± 0.102 | 9.447 | 9.657 | 1.04 ± 0.01 |

inner-proof-keccak_integration_benchmark.md
| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `inner proof` | 9.748 ± 0.042 | 9.712 | 9.821 | 1.00 |
| `base proof` | 10.271 ± 0.061 | 10.233 | 10.378 | 1.05 ± 0.01 |

inner-proof-linear_search.md
| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `inner proof` | 2.837 ± 0.013 | 2.821 | 2.855 | 1.00 |
| `base proof` | 2.936 ± 0.010 | 2.923 | 2.946 | 1.03 ± 0.01 |

inner-proof-math_cmp_and_pow_integration_benchmark.md
| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `inner proof` | 1.872 ± 0.009 | 1.859 | 1.880 | 1.00 |
| `base proof` | 1.883 ± 0.015 | 1.873 | 1.908 | 1.01 ± 0.01 |

inner-proof-math_integration_benchmark.md
| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `inner proof` | 1.829 ± 0.006 | 1.821 | 1.835 | 1.00 ± 0.00 |
| `base proof` | 1.828 ± 0.005 | 1.822 | 1.836 | 1.00 |

inner-proof-memory_integration_benchmark.md
| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `inner proof` | 1.548 ± 0.001 | 1.546 | 1.549 | 1.00 |
| `base proof` | 1.613 ± 0.022 | 1.599 | 1.651 | 1.04 ± 0.01 |

inner-proof-operations_with_data_structures_benchmarks.md
| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `inner proof` | 1.793 ± 0.010 | 1.783 | 1.805 | 1.00 ± 0.01 |
| `base proof` | 1.784 ± 0.002 | 1.781 | 1.787 | 1.00 |

inner-proof-pedersen.md

inner-proof-search_sorted_lower.md
| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `inner proof` | 773.4 ± 7.5 | 766.3 | 785.6 | 1.00 |
| `base proof` | 786.5 ± 2.7 | 783.2 | 789.4 | 1.02 ± 0.01 |

inner-proof-secp_integration_benchmark.md
| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `inner proof` | 2.249 ± 0.008 | 2.236 | 2.259 | 1.00 |
| `base proof` | 2.258 ± 0.005 | 2.254 | 2.265 | 1.00 ± 0.00 |

inner-proof-set_integration_benchmark.md
| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `inner proof` | 1.115 ± 0.005 | 1.109 | 1.120 | 1.00 |
| `base proof` | 1.128 ± 0.005 | 1.123 | 1.135 | 1.01 ± 0.01 |

inner-proof-uint256_integration_benchmark.md
| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `inner proof` | 5.758 ± 0.023 | 5.730 | 5.789 | 1.00 |
| `base proof` | 5.886 ± 0.055 | 5.848 | 5.982 | 1.02 ± 0.01 |