### PR TITLE
Keep `Arc<Program>` in `CairoRunner`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "paste",
- "rustc_version",
+ "rustc_version 0.3.3",
  "zeroize",
 ]
 
@@ -233,11 +233,13 @@ dependencies = [
 name = "cairo-vm-cli"
 version = "0.3.0-rc1"
 dependencies = [
+ "assert_matches",
  "bincode",
  "cairo-vm",
  "clap 3.2.23",
  "mimalloc",
  "nom",
+ "rstest",
  "thiserror",
 ]
 
@@ -552,6 +554,101 @@ name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.13",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
+name = "futures-util"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -890,6 +987,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "plotters"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1101,12 +1210,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de1bb486a691878cd320c2f0d319ba91eeaa2e894066d8b5f8f117c000e9d962"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version 0.4.0",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290ca1a1c8ca7edb7c3283bd44dc35dd54fdec6253a3912e201ba1072018fca8"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.0",
+ "syn 1.0.109",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
 dependencies = [
- "semver",
+ "semver 0.11.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver 1.0.17",
 ]
 
 [[package]]
@@ -1182,6 +1326,12 @@ checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
  "semver-parser",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "semver-parser"
@@ -1261,6 +1411,15 @@ checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
 dependencies = [
  "digest 0.10.6",
  "keccak",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/bench/criterion_benchmark.rs
+++ b/bench/criterion_benchmark.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use cairo_vm::{
     cairo_run,
     hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor,
+    types::program::Program,
 };
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
@@ -42,13 +43,12 @@ pub fn criterion_benchmarks(c: &mut Criterion) {
     };
     for benchmark_name in build_bench_strings() {
         let file_content = std::fs::read(Path::new(&benchmark_name.1)).unwrap();
+        let program =
+            Program::from_bytes(file_content.as_slice(), Some(cairo_run_config.entrypoint))
+                .unwrap();
         c.bench_function(&benchmark_name.0, |b| {
             b.iter(|| {
-                cairo_run::cairo_run(
-                    black_box(&file_content),
-                    &cairo_run_config,
-                    &mut hint_executor,
-                )
+                cairo_run::cairo_run(black_box(&program), &cairo_run_config, &mut hint_executor)
             })
         });
     }

--- a/bench/iai_benchmark.rs
+++ b/bench/iai_benchmark.rs
@@ -10,6 +10,7 @@ use iai::{black_box, main};
 use cairo_vm::{
     cairo_run::*,
     hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor,
+    types::program::Program,
 };
 
 // Copied from the CLI
@@ -71,8 +72,10 @@ macro_rules! iai_bench_expand_prog {
                 stringify!($val),
                 ".json"
             ));
+            let program =
+                Program::from_bytes(program.as_slice(), Some(cairo_run_config.entrypoint)).unwrap();
             let (runner, mut vm) =
-                cairo_run(black_box(program), &cairo_run_config, &mut hint_executor)
+                cairo_run(black_box(&program), &cairo_run_config, &mut hint_executor)
                     .expect("cairo_run failed");
 
             let trace_file = File::create("/dev/null").expect("open trace file");

--- a/cairo-vm-cli/Cargo.toml
+++ b/cairo-vm-cli/Cargo.toml
@@ -11,6 +11,10 @@ mimalloc = { version = "0.1.29", default-features = false, optional = true }
 nom = "7"
 thiserror = { version = "1.0.32" }
 
+[dev-dependencies]
+assert_matches = "1.5.0"
+rstest = "0.17.0"
+
 [features]
 default = ["with_mimalloc"]
 with_mimalloc = ["cairo-vm/with_mimalloc", "mimalloc"]

--- a/cairo-vm-cli/src/main.rs
+++ b/cairo-vm-cli/src/main.rs
@@ -249,11 +249,30 @@ mod tests {
         assert_matches!(run(args.into_iter()), Ok(_));
     }
 
-    #[rstest]
-    #[case(["cairo-vm-cli", "../missing/program.json"].as_slice())]
-    fn test_run_missing_file(#[case] args: &[&str]) {
-        let args = args.into_iter().cloned().map(String::from);
+    #[test]
+    fn test_run_missing_program() {
+        let args = ["cairo-vm-cli", "../missing/program.json"]
+            .into_iter()
+            .map(String::from);
         assert_matches!(run(args), Err(Error::IO(_)));
+    }
+
+    #[rstest]
+    #[case("../cairo_programs/manually_compiled/invalid_even_length_hex.json")]
+    #[case("../cairo_programs/manually_compiled/invalid_memory.json")]
+    #[case("../cairo_programs/manually_compiled/invalid_odd_length_hex.json")]
+    #[case("../cairo_programs/manually_compiled/no_data_program.json")]
+    #[case("../cairo_programs/manually_compiled/no_main_program.json")]
+    fn test_run_bad_file(#[case] program: &str) {
+        let args = ["cairo-vm-cli", program].into_iter().map(String::from);
+        assert_matches!(run(args), Err(Error::Runner(_)));
+    }
+
+    //Since the functionality here is trivial, I just call the function
+    //to fool Codecov.
+    #[test]
+    fn test_main() {
+        assert!(main().is_err());
     }
 
     #[test]

--- a/src/cairo_run.rs
+++ b/src/cairo_run.rs
@@ -1,5 +1,6 @@
 use crate::{
     hint_processor::hint_processor_definition::HintProcessor,
+    stdlib::sync::Arc,
     types::program::Program,
     vm::{
         errors::{cairo_run_errors::CairoRunError, vm_exception::VmException},
@@ -45,13 +46,14 @@ pub fn cairo_run(
     hint_executor: &mut dyn HintProcessor,
 ) -> Result<(CairoRunner, VirtualMachine), CairoRunError> {
     let program = Program::from_bytes(program_content, Some(cairo_run_config.entrypoint))?;
+    let program = Arc::new(program);
 
     let secure_run = cairo_run_config
         .secure_run
         .unwrap_or(!cairo_run_config.proof_mode);
 
     let mut cairo_runner = CairoRunner::new(
-        &program,
+        program,
         cairo_run_config.layout,
         cairo_run_config.proof_mode,
     )?;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -3,6 +3,7 @@ use crate::stdlib::prelude::*;
 use crate::{
     cairo_run::{cairo_run, CairoRunConfig},
     hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor,
+    types::program::Program,
     vm::trace::trace_entry::TraceEntry,
 };
 
@@ -48,7 +49,9 @@ pub(self) fn run_program(
         trace_enabled: true,
         ..Default::default()
     };
-    let res = cairo_run(data, &cairo_run_config, &mut hint_executor);
+    let program =
+        Program::from_bytes(data, Some(cairo_run_config.entrypoint)).expect("Program load failed");
+    let res = cairo_run(&program, &cairo_run_config, &mut hint_executor);
     if let Some(error) = error {
         assert!(res.is_err());
         assert!(res.err().unwrap().to_string().contains(error));

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -220,24 +220,19 @@ pub mod test_utils {
     }
     pub(crate) use vm_with_range_check;
 
-    pub(crate) use crate::stdlib::sync::Arc;
     macro_rules! cairo_runner {
-        ($program:expr) => {{
-            let program = Arc::new($program.clone());
-            CairoRunner::new(program, "all_cairo", false).unwrap()
-        }};
-        ($program:expr, $layout:expr) => {{
-            let program = Arc::new($program.clone());
-            CairoRunner::new(program, $layout, false).unwrap()
-        }};
-        ($program:expr, $layout:expr, $proof_mode:expr) => {{
-            let program = Arc::new($program.clone());
-            CairoRunner::new(program, $layout, $proof_mode).unwrap()
-        }};
-        ($program:expr, $layout:expr, $proof_mode:expr) => {{
-            let program = Arc::new($program.clone());
-            CairoRunner::new(program, $layout.to_string(), proof_mode).unwrap()
-        }};
+        ($program:expr) => {
+            CairoRunner::new(&$program, "all_cairo", false).unwrap()
+        };
+        ($program:expr, $layout:expr) => {
+            CairoRunner::new(&$program, $layout, false).unwrap()
+        };
+        ($program:expr, $layout:expr, $proof_mode:expr) => {
+            CairoRunner::new(&$program, $layout, $proof_mode).unwrap()
+        };
+        ($program:expr, $layout:expr, $proof_mode:expr) => {
+            CairoRunner::new(&$program, $layout.to_string(), proof_mode).unwrap()
+        };
     }
     pub(crate) use cairo_runner;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -220,19 +220,24 @@ pub mod test_utils {
     }
     pub(crate) use vm_with_range_check;
 
+    pub(crate) use crate::stdlib::sync::Arc;
     macro_rules! cairo_runner {
-        ($program:expr) => {
-            CairoRunner::new(&$program, "all_cairo", false).unwrap()
-        };
-        ($program:expr, $layout:expr) => {
-            CairoRunner::new(&$program, $layout, false).unwrap()
-        };
-        ($program:expr, $layout:expr, $proof_mode:expr) => {
-            CairoRunner::new(&$program, $layout, $proof_mode).unwrap()
-        };
-        ($program:expr, $layout:expr, $proof_mode:expr) => {
-            CairoRunner::new(&program, $layout.to_string(), proof_mode).unwrap()
-        };
+        ($program:expr) => {{
+            let program = Arc::new($program.clone());
+            CairoRunner::new(program, "all_cairo", false).unwrap()
+        }};
+        ($program:expr, $layout:expr) => {{
+            let program = Arc::new($program.clone());
+            CairoRunner::new(program, $layout, false).unwrap()
+        }};
+        ($program:expr, $layout:expr, $proof_mode:expr) => {{
+            let program = Arc::new($program.clone());
+            CairoRunner::new(program, $layout, $proof_mode).unwrap()
+        }};
+        ($program:expr, $layout:expr, $proof_mode:expr) => {{
+            let program = Arc::new($program.clone());
+            CairoRunner::new(program, $layout.to_string(), proof_mode).unwrap()
+        }};
     }
     pub(crate) use cairo_runner;
 

--- a/src/vm/runners/builtin_runner/ec_op.rs
+++ b/src/vm/runners/builtin_runner/ec_op.rs
@@ -1002,6 +1002,8 @@ mod tests {
             layout: "all_cairo",
             ..crate::cairo_run::CairoRunConfig::default()
         };
+        let program =
+            &Program::from_bytes(program.as_slice(), Some(cairo_run_config.entrypoint)).unwrap();
         let result = crate::cairo_run::cairo_run(
             program,
             &cairo_run_config,
@@ -1027,6 +1029,8 @@ mod tests {
             layout: "all_cairo",
             ..crate::cairo_run::CairoRunConfig::default()
         };
+        let program =
+            &Program::from_bytes(program.as_slice(), Some(cairo_run_config.entrypoint)).unwrap();
         let result = crate::cairo_run::cairo_run(
             program,
             &cairo_run_config,

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -654,7 +654,7 @@ impl<'a> CairoRunner<'a> {
         }
 
         let diluted_units = diluted_pool_instance.units_per_step as usize * vm.current_step;
-        let unused_diluted_units = diluted_units - used_units_by_builtins;
+        let unused_diluted_units = diluted_units.saturating_sub(used_units_by_builtins);
 
         let diluted_usage_upper_bound = 1usize << diluted_pool_instance.n_bits;
         if unused_diluted_units < diluted_usage_upper_bound {

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -4142,10 +4142,8 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn set_entrypoint_main_default() {
-        let program = program!();
-        let mut cairo_runner = cairo_runner!(program);
-
-        Arc::get_mut(&mut cairo_runner.program).unwrap().identifiers = [(
+        let mut program = program!();
+        program.identifiers = [(
             "__main__.main",
             Identifier {
                 pc: Some(0),
@@ -4160,6 +4158,8 @@ mod tests {
         .map(|(k, v)| (k.to_string(), v))
         .collect();
 
+        let mut cairo_runner = cairo_runner!(program);
+
         cairo_runner
             .set_entrypoint(None)
             .expect("Call to `set_entrypoint()` failed.");
@@ -4169,10 +4169,8 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn set_entrypoint_main() {
-        let program = program!();
-        let mut cairo_runner = cairo_runner!(program);
-
-        Arc::get_mut(&mut cairo_runner.program).unwrap().identifiers = [
+        let mut program = program!();
+        program.identifiers = [
             (
                 "__main__.main",
                 Identifier {
@@ -4200,6 +4198,8 @@ mod tests {
         .map(|(k, v)| (k.to_string(), v))
         .collect();
 
+        let mut cairo_runner = cairo_runner!(program);
+
         cairo_runner
             .set_entrypoint(Some("alternate_main"))
             .expect("Call to `set_entrypoint()` failed.");
@@ -4210,10 +4210,8 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn set_entrypoint_main_non_existent() {
-        let program = program!();
-        let mut cairo_runner = cairo_runner!(program);
-
-        Arc::get_mut(&mut cairo_runner.program).unwrap().identifiers = [(
+        let mut program = program!();
+        program.identifiers = [(
             "__main__.main",
             Identifier {
                 pc: Some(0),
@@ -4227,6 +4225,8 @@ mod tests {
         .into_iter()
         .map(|(k, v)| (k.to_string(), v))
         .collect();
+
+        let mut cairo_runner = cairo_runner!(program);
 
         cairo_runner
             .set_entrypoint(Some("nonexistent_main"))


### PR DESCRIPTION
Rather than owning, the `Program` is typically read only, so this allows caching it and avoids deep copying of a big object. This copy turned out to be a bottleneck when using the crate for executing a single program many times.
The change needs no new tests as it's mostly internal. It does change the signature of `CairoRunner::new()` to receive the `Program`.