### PR TITLE
feat: Implement hints on uint384 lib (Part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,109 @@
 
 #### Upcoming Changes
 
+* Implement hints on uint384 lib (Part 1) [#960](https://github.com/lambdaclass/cairo-rs/pull/960)
+
+    `BuiltinHintProcessor` now supports the following hint:
+
+    ```python
+        def split(num: int, num_bits_shift: int, length: int):
+        a = []
+        for _ in range(length):
+            a.append( num & ((1 << num_bits_shift) - 1) )
+            num = num >> num_bits_shift
+        return tuple(a)
+
+        def pack(z, num_bits_shift: int) -> int:
+            limbs = (z.d0, z.d1, z.d2)
+            return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))
+
+        a = pack(ids.a, num_bits_shift = 128)
+        div = pack(ids.div, num_bits_shift = 128)
+        quotient, remainder = divmod(a, div)
+
+        quotient_split = split(quotient, num_bits_shift=128, length=3)
+        assert len(quotient_split) == 3
+
+        ids.quotient.d0 = quotient_split[0]
+        ids.quotient.d1 = quotient_split[1]
+        ids.quotient.d2 = quotient_split[2]
+
+        remainder_split = split(remainder, num_bits_shift=128, length=3)
+        ids.remainder.d0 = remainder_split[0]
+        ids.remainder.d1 = remainder_split[1]
+        ids.remainder.d2 = remainder_split[2]
+    ```
+
+    ```python
+        ids.low = ids.a & ((1<<128) - 1)
+        ids.high = ids.a >> 128
+    ```
+
+    ```python
+            sum_d0 = ids.a.d0 + ids.b.d0
+        ids.carry_d0 = 1 if sum_d0 >= ids.SHIFT else 0
+        sum_d1 = ids.a.d1 + ids.b.d1 + ids.carry_d0
+        ids.carry_d1 = 1 if sum_d1 >= ids.SHIFT else 0
+        sum_d2 = ids.a.d2 + ids.b.d2 + ids.carry_d1
+        ids.carry_d2 = 1 if sum_d2 >= ids.SHIFT else 0
+    ```
+
+    ```python
+        def split(num: int, num_bits_shift: int, length: int):
+            a = []
+            for _ in range(length):
+                a.append( num & ((1 << num_bits_shift) - 1) )
+                num = num >> num_bits_shift
+            return tuple(a)
+
+        def pack(z, num_bits_shift: int) -> int:
+            limbs = (z.d0, z.d1, z.d2)
+            return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))
+
+        def pack2(z, num_bits_shift: int) -> int:
+            limbs = (z.b01, z.b23, z.b45)
+            return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))
+
+        a = pack(ids.a, num_bits_shift = 128)
+        div = pack2(ids.div, num_bits_shift = 128)
+        quotient, remainder = divmod(a, div)
+
+        quotient_split = split(quotient, num_bits_shift=128, length=3)
+        assert len(quotient_split) == 3
+
+        ids.quotient.d0 = quotient_split[0]
+        ids.quotient.d1 = quotient_split[1]
+        ids.quotient.d2 = quotient_split[2]
+
+        remainder_split = split(remainder, num_bits_shift=128, length=3)
+        ids.remainder.d0 = remainder_split[0]
+        ids.remainder.d1 = remainder_split[1]
+        ids.remainder.d2 = remainder_split[2]
+    ```
+
+    ```python
+        from starkware.python.math_utils import isqrt
+
+        def split(num: int, num_bits_shift: int, length: int):
+            a = []
+            for _ in range(length):
+                a.append( num & ((1 << num_bits_shift) - 1) )
+                num = num >> num_bits_shift
+            return tuple(a)
+
+        def pack(z, num_bits_shift: int) -> int:
+            limbs = (z.d0, z.d1, z.d2)
+            return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))
+
+        a = pack(ids.a, num_bits_shift=128)
+        root = isqrt(a)
+        assert 0 <= root < 2 ** 192
+        root_split = split(root, num_bits_shift=128, length=3)
+        ids.root.d0 = root_split[0]
+        ids.root.d1 = root_split[1]
+        ids.root.d2 = root_split[2]
+    ```
+
 * Move `Memory` into `MemorySegmentManager` [#830](https://github.com/lambdaclass/cairo-rs/pull/830)
     * Structural changes:
         * Remove `memory: Memory` field from `VirtualMachine`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Implement hints on uint384 lib (Part 1) [#960](https://github.com/lambdaclass/cairo-rs/pull/960)
 
-    `BuiltinHintProcessor` now supports the following hint:
+    `BuiltinHintProcessor` now supports the following hints:
 
     ```python
         def split(num: int, num_bits_shift: int, length: int):

--- a/cairo_programs/is_quad_residue_test.cairo
+++ b/cairo_programs/is_quad_residue_test.cairo
@@ -39,5 +39,5 @@ func main{output_ptr: felt*}() {
 
     check_quad_res(inputs, expected, 0);
 
-    return();
+    return ();
 }

--- a/cairo_programs/uint384.cairo
+++ b/cairo_programs/uint384.cairo
@@ -237,8 +237,8 @@ namespace uint384_lib {
 
 func main{range_check_ptr: felt}(){
     let a = Uint384(83434123481193248,82349321849739284, 839243219401320423);
-    let b = Uint384(9283430921839492319493, 313248123482483248, 3790328402913840);
-    let (quotient: Uint384, remainder: Uint384) = uint384_lib.unsigned_div_rem(a, b);
+    let div = Uint384(9283430921839492319493, 313248123482483248, 3790328402913840);
+    let (quotient: Uint384, remainder: Uint384) = uint384_lib.unsigned_div_rem(a, div);
     assert quotient.d0 = 221;
     assert quotient.d1 = 0;
     assert quotient.d2 = 0;

--- a/cairo_programs/uint384.cairo
+++ b/cairo_programs/uint384.cairo
@@ -99,7 +99,9 @@ namespace uint384_lib {
 
     // Adds two integers. Returns the result as a 384-bit integer and the (1-bit) carry.
     // Doesn't verify that the result is a proper Uint384, that's now the responsibility of the calling function
-    func _add_no_uint384_check{range_check_ptr}(a: Uint384, b: Uint384) -> (res: Uint384, carry: felt) {
+    func _add_no_uint384_check{range_check_ptr}(a: Uint384, b: Uint384) -> (
+        res: Uint384, carry: felt
+    ) {
         alloc_locals;
         local res: Uint384;
         local carry_d0: felt;
@@ -189,28 +191,34 @@ namespace uint384_lib {
         let (res10, carry) = split_64(a5 * b5 + carry);
 
         return (
-            low=Uint384(d0=res0 + HALF_SHIFT * res1, d1=res2 + HALF_SHIFT * res3, d2=res4 + HALF_SHIFT * res5),
-            high=Uint384(d0=res6 + HALF_SHIFT * res7, d1=res8 + HALF_SHIFT * res9, d2=res10 + HALF_SHIFT * carry),
+            low=Uint384(
+                d0=res0 + HALF_SHIFT * res1,
+                d1=res2 + HALF_SHIFT * res3,
+                d2=res4 + HALF_SHIFT * res5,
+            ),
+            high=Uint384(
+                d0=res6 + HALF_SHIFT * res7,
+                d1=res8 + HALF_SHIFT * res9,
+                d2=res10 + HALF_SHIFT * carry,
+            ),
         );
     }
-        func mul_expanded{range_check_ptr}(a: Uint384, b: Uint384_expand) -> (low: Uint384, high: Uint384) {
+    func mul_expanded{range_check_ptr}(a: Uint384, b: Uint384_expand) -> (
+        low: Uint384, high: Uint384
+    ) {
         let (a0, a1) = split_64(a.d0);
         let (a2, a3) = split_64(a.d1);
         let (a4, a5) = split_64(a.d2);
 
         let (res0, carry) = split_128(a1 * b.B0 + a0 * b.b01);
-        let (res2, carry) = split_128(
-	    a3 * b.B0 + a2 * b.b01 + a1 * b.b12 + a0 * b.b23 + carry,
-        );
+        let (res2, carry) = split_128(a3 * b.B0 + a2 * b.b01 + a1 * b.b12 + a0 * b.b23 + carry);
         let (res4, carry) = split_128(
-            a5 * b.B0 + a4 * b.b01 + a3 * b.b12 + a2 * b.b23 + a1 * b.b34 + a0 * b.b45 + carry,
+            a5 * b.B0 + a4 * b.b01 + a3 * b.b12 + a2 * b.b23 + a1 * b.b34 + a0 * b.b45 + carry
         );
         let (res6, carry) = split_128(
-            a5 * b.b12 + a4 * b.b23 + a3 * b.b34 + a2 * b.b45 + a1 * b.b5 + carry,
+            a5 * b.b12 + a4 * b.b23 + a3 * b.b34 + a2 * b.b45 + a1 * b.b5 + carry
         );
-        let (res8, carry) = split_128(
-            a5 * b.b34 + a4 * b.b45 + a3 * b.b5 + carry
-        );
+        let (res8, carry) = split_128(a5 * b.b34 + a4 * b.b45 + a3 * b.b5 + carry);
         // let (res10, carry) = split_64(a5 * b.b5 + carry)
 
         return (
@@ -219,7 +227,7 @@ namespace uint384_lib {
         );
     }
 
-        func mul_d{range_check_ptr}(a: Uint384, b: Uint384) -> (low: Uint384, high: Uint384) {
+    func mul_d{range_check_ptr}(a: Uint384, b: Uint384) -> (low: Uint384, high: Uint384) {
         alloc_locals;
         let (a0, a1) = split_64(a.d0);
         let (a2, a3) = split_64(a.d1);
@@ -228,23 +236,19 @@ namespace uint384_lib {
         let (b2, b3) = split_64(b.d1);
         let (b4, b5) = split_64(b.d2);
 
-	local B0 = b0*HALF_SHIFT;
-	local b12 = b1 + b2*HALF_SHIFT;
-	local b34 = b3 + b4*HALF_SHIFT;
+        local B0 = b0 * HALF_SHIFT;
+        local b12 = b1 + b2 * HALF_SHIFT;
+        local b34 = b3 + b4 * HALF_SHIFT;
 
         let (res0, carry) = split_128(a1 * B0 + a0 * b.d0);
-        let (res2, carry) = split_128(
-	    a3 * B0 + a2 * b.d0 + a1 * b12 + a0 * b.d1 + carry,
-        );
+        let (res2, carry) = split_128(a3 * B0 + a2 * b.d0 + a1 * b12 + a0 * b.d1 + carry);
         let (res4, carry) = split_128(
-            a5 * B0 + a4 * b.d0 + a3 * b12 + a2 * b.d1 + a1 * b34 + a0 * b.d2 + carry,
+            a5 * B0 + a4 * b.d0 + a3 * b12 + a2 * b.d1 + a1 * b34 + a0 * b.d2 + carry
         );
         let (res6, carry) = split_128(
-            a5 * b12 + a4 * b.d1 + a3 * b34 + a2 * b.d2 + a1 * b5 + carry,
+            a5 * b12 + a4 * b.d1 + a3 * b34 + a2 * b.d2 + a1 * b5 + carry
         );
-        let (res8, carry) = split_128(
-            a5 * b34 + a4 * b.d2 + a3 * b5 + carry
-        );
+        let (res8, carry) = split_128(a5 * b34 + a4 * b.d2 + a3 * b5 + carry);
         // let (res10, carry) = split_64(a5 * b5 + carry)
 
         return (
@@ -311,8 +315,8 @@ namespace uint384_lib {
             ids.remainder.d1 = remainder_split[1]
             ids.remainder.d2 = remainder_split[2]
         %}
-	check(quotient);
-	check(remainder);
+        check(quotient);
+        check(remainder);
         let (res_mul: Uint384, carry: Uint384) = mul_d(quotient, div);
         assert carry = Uint384(0, 0, 0);
 
@@ -325,7 +329,7 @@ namespace uint384_lib {
         return (quotient=quotient, remainder=remainder);
     }
 
-// Unsigned integer division between two integers. Returns the quotient and the remainder.
+    // Unsigned integer division between two integers. Returns the quotient and the remainder.
     func unsigned_div_rem_expanded{range_check_ptr}(a: Uint384, div: Uint384_expand) -> (
         quotient: Uint384, remainder: Uint384
     ) {
@@ -333,7 +337,7 @@ namespace uint384_lib {
         local quotient: Uint384;
         local remainder: Uint384;
 
-	let div2 = Uint384(div.b01,div.b23,div.b45);
+        let div2 = Uint384(div.b01, div.b23, div.b45);
 
         %{
             def split(num: int, num_bits_shift: int, length: int):
@@ -367,8 +371,8 @@ namespace uint384_lib {
             ids.remainder.d1 = remainder_split[1]
             ids.remainder.d2 = remainder_split[2]
         %}
-	check(quotient);
-	check(remainder);
+        check(quotient);
+        check(remainder);
         let (res_mul: Uint384, carry: Uint384) = mul_expanded(quotient, div);
         assert carry = Uint384(0, 0, 0);
 
@@ -381,34 +385,28 @@ namespace uint384_lib {
         return (quotient=quotient, remainder=remainder);
     }
 
-        func square_e{range_check_ptr}(a: Uint384) -> (low: Uint384, high: Uint384) {
+    func square_e{range_check_ptr}(a: Uint384) -> (low: Uint384, high: Uint384) {
         alloc_locals;
         let (a0, a1) = split_64(a.d0);
         let (a2, a3) = split_64(a.d1);
         let (a4, a5) = split_64(a.d2);
 
-	const HALF_SHIFT2 = 2*HALF_SHIFT;
-	local a0_2 = a0*2;
-	local a34 = a3 + a4*HALF_SHIFT2;
+        const HALF_SHIFT2 = 2 * HALF_SHIFT;
+        local a0_2 = a0 * 2;
+        local a34 = a3 + a4 * HALF_SHIFT2;
 
-        let (res0, carry) = split_128(a0*(a0 + a1*HALF_SHIFT2));
-        let (res2, carry) = split_128(
-	    a.d1*a0_2 + a1*(a1 + a2*HALF_SHIFT2) + carry,
-        );
+        let (res0, carry) = split_128(a0 * (a0 + a1 * HALF_SHIFT2));
+        let (res2, carry) = split_128(a.d1 * a0_2 + a1 * (a1 + a2 * HALF_SHIFT2) + carry);
         let (res4, carry) = split_128(
-	    a.d2*a0_2 + (a3 + a34)*a1 + a2*(a2 + a3*HALF_SHIFT2) + carry,
+            a.d2 * a0_2 + (a3 + a34) * a1 + a2 * (a2 + a3 * HALF_SHIFT2) + carry
         );
-        let (res6, carry) = split_128(
-	    (a5*a1 + a.d2*a2)*2 + a3*a34 + carry,
-        );
-        let (res8, carry) = split_128(
-	    a5*(a3 + a34) + a4*a4 + carry
-        );
+        let (res6, carry) = split_128((a5 * a1 + a.d2 * a2) * 2 + a3 * a34 + carry);
+        let (res8, carry) = split_128(a5 * (a3 + a34) + a4 * a4 + carry);
         // let (res10, carry) = split_64(a5*a5 + carry)
 
         return (
             low=Uint384(d0=res0, d1=res2, d2=res4),
-            high=Uint384(d0=res6, d1=res8, d2=a5*a5 + carry),
+            high=Uint384(d0=res6, d1=res8, d2=a5 * a5 + carry),
         );
     }
 
@@ -446,7 +444,7 @@ namespace uint384_lib {
         [range_check_ptr] = root.d0;
 
         // We don't need to check that 0 <= d1 < 2**64, since this gets checked
-	// when we check that carry==0 later
+        // when we check that carry==0 later
         assert [range_check_ptr + 1] = root.d1;
         let range_check_ptr = range_check_ptr + 2;
 
@@ -474,11 +472,13 @@ func test_uint384_operations{range_check_ptr}() {
     // Test unsigned_div_rem
     let a = Uint384(83434123481193248, 82349321849739284, 839243219401320423);
     let div = Uint384(9283430921839492319493, 313248123482483248, 3790328402913840);
-    let (quotient: Uint384, remainder: Uint384) = uint384_lib.unsigned_div_rem{range_check_ptr=range_check_ptr}(a, div);
+    let (quotient: Uint384, remainder: Uint384) = uint384_lib.unsigned_div_rem{
+        range_check_ptr=range_check_ptr
+    }(a, div);
     assert quotient.d0 = 221;
     assert quotient.d1 = 0;
     assert quotient.d2 = 0;
-    
+
     assert remainder.d0 = 340282366920936411825224315027446796751;
     assert remainder.d1 = 340282366920938463394229121463989152931;
     assert remainder.d2 = 1580642357361782;
@@ -501,13 +501,17 @@ func test_uint384_operations{range_check_ptr}() {
     assert carry = 1;
 
     // Test unsigned_div_rem_expanded
-    let e = Uint384(83434123481193248,82349321849739284, 839243219401320423);
-    let div_expand = Uint384_expand(9283430921839492319493, 313248123482483248, 3790328402913840, 13, 78990, 109, 7);
-    let (quotient: Uint384, remainder: Uint384) = uint384_lib.unsigned_div_rem_expanded{range_check_ptr=range_check_ptr}(a, div_expand);
+    let e = Uint384(83434123481193248, 82349321849739284, 839243219401320423);
+    let div_expand = Uint384_expand(
+        9283430921839492319493, 313248123482483248, 3790328402913840, 13, 78990, 109, 7
+    );
+    let (quotient: Uint384, remainder: Uint384) = uint384_lib.unsigned_div_rem_expanded{
+        range_check_ptr=range_check_ptr
+    }(a, div_expand);
     assert quotient.d0 = 7699479077076334;
     assert quotient.d1 = 0;
     assert quotient.d2 = 0;
-    
+
     assert remainder.d0 = 340279955073565776659831804641277151872;
     assert remainder.d1 = 340282366920938463463356863525615958397;
     assert remainder.d2 = 16;
@@ -519,10 +523,10 @@ func test_uint384_operations{range_check_ptr}() {
     assert root.d1 = 916102188;
     assert root.d2 = 0;
 
-    return();
+    return ();
 }
 
-func main{range_check_ptr: felt}(){
+func main{range_check_ptr: felt}() {
     test_uint384_operations();
-    return();
+    return ();
 }

--- a/cairo_programs/uint384.cairo
+++ b/cairo_programs/uint384.cairo
@@ -235,10 +235,11 @@ namespace uint384_lib {
     }
 }
 
-func main{range_check_ptr: felt}(){
+func test_uint384_operations{range_check_ptr}() {
+    // Test unsigned_div_rem
     let a = Uint384(83434123481193248,82349321849739284, 839243219401320423);
     let div = Uint384(9283430921839492319493, 313248123482483248, 3790328402913840);
-    let (quotient: Uint384, remainder: Uint384) = uint384_lib.unsigned_div_rem(a, div);
+    let (quotient: Uint384, remainder: Uint384) = uint384_lib.unsigned_div_rem{range_check_ptr=range_check_ptr}(a, div);
     assert quotient.d0 = 221;
     assert quotient.d1 = 0;
     assert quotient.d2 = 0;
@@ -246,5 +247,16 @@ func main{range_check_ptr: felt}(){
     assert remainder.d0 = 340282366920936411825224315027446796751;
     assert remainder.d1 = 340282366920938463394229121463989152931;
     assert remainder.d2 = 1580642357361782;
-    return ();
+
+    // Test split_128
+    let b = 6805647338418769269267492148635364229100;
+    let (low, high) = uint384_lib.split_128{range_check_ptr=range_check_ptr}(b);
+    assert high = 19;
+    assert low = 340282366920938463463374607431768211436;
+    return();
+}
+
+func main{range_check_ptr: felt}(){
+    test_uint384_operations();
+    return();
 }

--- a/cairo_programs/uint384.cairo
+++ b/cairo_programs/uint384.cairo
@@ -1,0 +1,250 @@
+%builtins range_check
+// Code taken from https://github.com/NethermindEth/research-basic-Cairo-operations-big-integers/blob/main/lib/uint384.cairo
+from starkware.cairo.common.bitwise import bitwise_and, bitwise_or, bitwise_xor
+from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
+from starkware.cairo.common.math import assert_in_range, assert_le, assert_nn_le, assert_not_zero
+from starkware.cairo.common.math import unsigned_div_rem as frem
+from starkware.cairo.common.math_cmp import is_le
+from starkware.cairo.common.uint256 import Uint256, uint256_add, word_reverse_endian
+from starkware.cairo.common.pow import pow
+from starkware.cairo.common.registers import get_ap, get_fp_and_pc
+
+// This library is adapted from Cairo's common library Uint256 and it follows it as closely as possible.
+// The library implements basic operations between 384-bit integers.
+// Most operations use unsigned integers. Only a few operations are implemented for signed integers
+
+// Represents an integer in the range [0, 2^384).
+struct Uint384 {
+    // The low 128 bits of the value.
+    d0: felt,
+    // The middle 128 bits of the value.
+    d1: felt,
+    // The # 128 bits of the value.
+    d2: felt,
+}
+
+const SHIFT = 2 ** 128;
+const ALL_ONES = 2 ** 128 - 1;
+const HALF_SHIFT = 2 ** 64;
+
+namespace uint384_lib {
+    // Verifies that the given integer is valid.
+    func check{range_check_ptr}(a: Uint384) {
+        [range_check_ptr] = a.d0;
+        [range_check_ptr + 1] = a.d1;
+        [range_check_ptr + 2] = a.d2;
+        let range_check_ptr = range_check_ptr + 3;
+        return ();
+    }
+
+    // Adds two integers. Returns the result as a 384-bit integer and the (1-bit) carry.
+    // Doesn't verify that the result is a proper Uint384, that's now the responsibility of the calling function
+    func _add_no_uint384_check{range_check_ptr}(a: Uint384, b: Uint384) -> (res: Uint384, carry: felt) {
+        alloc_locals;
+        local res: Uint384;
+        local carry_d0: felt;
+        local carry_d1: felt;
+        local carry_d2: felt;
+        %{
+            sum_d0 = ids.a.d0 + ids.b.d0
+            ids.carry_d0 = 1 if sum_d0 >= ids.SHIFT else 0
+            sum_d1 = ids.a.d1 + ids.b.d1 + ids.carry_d0
+            ids.carry_d1 = 1 if sum_d1 >= ids.SHIFT else 0
+            sum_d2 = ids.a.d2 + ids.b.d2 + ids.carry_d1
+            ids.carry_d2 = 1 if sum_d2 >= ids.SHIFT else 0
+        %}
+
+        // Either 0 or 1
+        assert carry_d0 * carry_d0 = carry_d0;
+        assert carry_d1 * carry_d1 = carry_d1;
+        assert carry_d2 * carry_d2 = carry_d2;
+
+        assert res.d0 = a.d0 + b.d0 - carry_d0 * SHIFT;
+        assert res.d1 = a.d1 + b.d1 + carry_d0 - carry_d1 * SHIFT;
+        assert res.d2 = a.d2 + b.d2 + carry_d1 - carry_d2 * SHIFT;
+
+        return (res, carry_d2);
+    }
+
+    // Splits a field element in the range [0, 2^192) to its low 64-bit and high 128-bit parts.
+    func split_64{range_check_ptr}(a: felt) -> (low: felt, high: felt) {
+        alloc_locals;
+        local low: felt;
+        local high: felt;
+
+        %{
+            ids.low = ids.a & ((1<<64) - 1)
+            ids.high = ids.a >> 64
+        %}
+        assert a = low + high * HALF_SHIFT;
+        assert [range_check_ptr + 0] = low;
+        assert [range_check_ptr + 1] = HALF_SHIFT - 1 - low;
+        assert [range_check_ptr + 2] = high;
+        let range_check_ptr = range_check_ptr + 3;
+        return (low, high);
+    }
+
+    // Splits a field element in the range [0, 2^224) to its low 128-bit and high 96-bit parts.
+    func split_128{range_check_ptr}(a: felt) -> (low: felt, high: felt) {
+        alloc_locals;
+        const UPPER_BOUND = 2 ** 224;
+        const HIGH_BOUND = UPPER_BOUND / SHIFT;
+        local low: felt;
+        local high: felt;
+
+        %{
+            ids.low = ids.a & ((1<<128) - 1)
+            ids.high = ids.a >> 128
+        %}
+        assert a = low + high * SHIFT;
+        assert [range_check_ptr + 0] = high;
+        assert [range_check_ptr + 1] = HIGH_BOUND - 1 - high;
+        assert [range_check_ptr + 2] = low;
+        let range_check_ptr = range_check_ptr + 3;
+        return (low, high);
+    }
+
+    // Multiplies two integers. Returns the result as two 384-bit integers: the result has 2*384 bits,
+    // the returned integers represent the lower 384-bits and the higher 384-bits, respectively.
+    func mul{range_check_ptr}(a: Uint384, b: Uint384) -> (low: Uint384, high: Uint384) {
+        let (a0, a1) = split_64(a.d0);
+        let (a2, a3) = split_64(a.d1);
+        let (a4, a5) = split_64(a.d2);
+        let (b0, b1) = split_64(b.d0);
+        let (b2, b3) = split_64(b.d1);
+        let (b4, b5) = split_64(b.d2);
+
+        let (res0, carry) = split_64(a0 * b0);
+        let (res1, carry) = split_64(a1 * b0 + a0 * b1 + carry);
+        let (res2, carry) = split_64(a2 * b0 + a1 * b1 + a0 * b2 + carry);
+        let (res3, carry) = split_64(a3 * b0 + a2 * b1 + a1 * b2 + a0 * b3 + carry);
+        let (res4, carry) = split_64(a4 * b0 + a3 * b1 + a2 * b2 + a1 * b3 + a0 * b4 + carry);
+        let (res5, carry) = split_64(
+            a5 * b0 + a4 * b1 + a3 * b2 + a2 * b3 + a1 * b4 + a0 * b5 + carry
+        );
+        let (res6, carry) = split_64(a5 * b1 + a4 * b2 + a3 * b3 + a2 * b4 + a1 * b5 + carry);
+        let (res7, carry) = split_64(a5 * b2 + a4 * b3 + a3 * b4 + a2 * b5 + carry);
+        let (res8, carry) = split_64(a5 * b3 + a4 * b4 + a3 * b5 + carry);
+        let (res9, carry) = split_64(a5 * b4 + a4 * b5 + carry);
+        let (res10, carry) = split_64(a5 * b5 + carry);
+
+        return (
+            low=Uint384(d0=res0 + HALF_SHIFT * res1, d1=res2 + HALF_SHIFT * res3, d2=res4 + HALF_SHIFT * res5),
+            high=Uint384(d0=res6 + HALF_SHIFT * res7, d1=res8 + HALF_SHIFT * res9, d2=res10 + HALF_SHIFT * carry),
+        );
+    }
+
+        func mul_d{range_check_ptr}(a: Uint384, b: Uint384) -> (low: Uint384, high: Uint384) {
+        alloc_locals;
+        let (a0, a1) = split_64(a.d0);
+        let (a2, a3) = split_64(a.d1);
+        let (a4, a5) = split_64(a.d2);
+        let (b0, b1) = split_64(b.d0);
+        let (b2, b3) = split_64(b.d1);
+        let (b4, b5) = split_64(b.d2);
+
+	local B0 = b0*HALF_SHIFT;
+	local b12 = b1 + b2*HALF_SHIFT;
+	local b34 = b3 + b4*HALF_SHIFT;
+
+        let (res0, carry) = split_128(a1 * B0 + a0 * b.d0);
+        let (res2, carry) = split_128(
+	    a3 * B0 + a2 * b.d0 + a1 * b12 + a0 * b.d1 + carry,
+        );
+        let (res4, carry) = split_128(
+            a5 * B0 + a4 * b.d0 + a3 * b12 + a2 * b.d1 + a1 * b34 + a0 * b.d2 + carry,
+        );
+        let (res6, carry) = split_128(
+            a5 * b12 + a4 * b.d1 + a3 * b34 + a2 * b.d2 + a1 * b5 + carry,
+        );
+        let (res8, carry) = split_128(
+            a5 * b34 + a4 * b.d2 + a3 * b5 + carry
+        );
+        // let (res10, carry) = split_64(a5 * b5 + carry)
+
+        return (
+            low=Uint384(d0=res0, d1=res2, d2=res4),
+            high=Uint384(d0=res6, d1=res8, d2=a5 * b5 + carry),
+        );
+    }
+
+    func lt{range_check_ptr}(a: Uint384, b: Uint384) -> (res: felt) {
+        if (a.d2 == b.d2) {
+            if (a.d1 == b.d1) {
+                return (is_le(a.d0 + 1, b.d0),);
+            }
+            return (is_le(a.d1 + 1, b.d1),);
+        }
+        return (is_le(a.d2 + 1, b.d2),);
+    }
+
+    // Unsigned integer division between two integers. Returns the quotient and the remainder.
+    // Conforms to EVM specifications: division by 0 yields 0.
+    func unsigned_div_rem{range_check_ptr}(a: Uint384, div: Uint384) -> (
+        quotient: Uint384, remainder: Uint384
+    ) {
+        alloc_locals;
+        local quotient: Uint384;
+        local remainder: Uint384;
+
+        // If div == 0, return (0, 0, 0).
+        if (div.d0 + div.d1 + div.d2 == 0) {
+            return (quotient=Uint384(0, 0, 0), remainder=Uint384(0, 0, 0));
+        }
+
+        %{
+            def split(num: int, num_bits_shift: int, length: int):
+                a = []
+                for _ in range(length):
+                    a.append( num & ((1 << num_bits_shift) - 1) )
+                    num = num >> num_bits_shift
+                return tuple(a)
+
+            def pack(z, num_bits_shift: int) -> int:
+                limbs = (z.d0, z.d1, z.d2)
+                return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))
+
+            a = pack(ids.a, num_bits_shift = 128)
+            div = pack(ids.div, num_bits_shift = 128)
+            quotient, remainder = divmod(a, div)
+
+            quotient_split = split(quotient, num_bits_shift=128, length=3)
+            assert len(quotient_split) == 3
+
+            ids.quotient.d0 = quotient_split[0]
+            ids.quotient.d1 = quotient_split[1]
+            ids.quotient.d2 = quotient_split[2]
+
+            remainder_split = split(remainder, num_bits_shift=128, length=3)
+            ids.remainder.d0 = remainder_split[0]
+            ids.remainder.d1 = remainder_split[1]
+            ids.remainder.d2 = remainder_split[2]
+        %}
+	check(quotient);
+	check(remainder);
+        let (res_mul: Uint384, carry: Uint384) = mul_d(quotient, div);
+        assert carry = Uint384(0, 0, 0);
+
+        let (check_val: Uint384, add_carry: felt) = _add_no_uint384_check(res_mul, remainder);
+        assert check_val = a;
+        assert add_carry = 0;
+
+        let (is_valid) = lt(remainder, div);
+        assert is_valid = 1;
+        return (quotient=quotient, remainder=remainder);
+    }
+}
+
+func main{range_check_ptr: felt}(){
+    let a = Uint384(83434123481193248,82349321849739284, 839243219401320423);
+    let b = Uint384(9283430921839492319493, 313248123482483248, 3790328402913840);
+    let (quotient: Uint384, remainder: Uint384) = uint384_lib.unsigned_div_rem(a, b);
+    assert quotient.d0 = 221;
+    assert quotient.d1 = 0;
+    assert quotient.d2 = 0;
+    
+    assert remainder.d0 = 340282366920936411825224315027446796751;
+    assert remainder.d1 = 340282366920938463394229121463989152931;
+    assert remainder.d2 = 1580642357361782;
+    return ();
+}

--- a/cairo_programs/uint384.cairo
+++ b/cairo_programs/uint384.cairo
@@ -253,6 +253,18 @@ func test_uint384_operations{range_check_ptr}() {
     let (low, high) = uint384_lib.split_128{range_check_ptr=range_check_ptr}(b);
     assert high = 19;
     assert low = 340282366920938463463374607431768211436;
+
+    // Test _add_no_uint384_test
+
+    let c = Uint384(3789423292314891293, 21894, 340282366920938463463374607431768211455);
+    let d = Uint384(32838232, 17, 8);
+    let (sum_res, carry) = uint384_lib._add_no_uint384_check(c, d);
+
+    assert sum_res.d0 = 3789423292347729525;
+    assert sum_res.d1 = 21911;
+    assert sum_res.d2 = 7;
+    assert carry = 1;
+
     return();
 }
 

--- a/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -71,7 +71,10 @@ use felt::Felt252;
 use crate::hint_processor::builtin_hint_processor::skip_next_instruction::skip_next_instruction;
 
 use super::ec_utils::{chained_ec_op_random_ec_point_hint, random_ec_point_hint, recover_y_hint};
-use super::uint384::{add_no_uint384_check, uint384_split_128, uint384_unsigned_div_rem};
+use super::uint384::{
+    add_no_uint384_check, uint384_split_128, uint384_unsigned_div_rem,
+    uint384_unsigned_div_rem_expanded,
+};
 
 pub struct HintProcessorData {
     pub code: String,
@@ -458,6 +461,9 @@ impl HintProcessor for BuiltinHintProcessor {
             }
             hint_code::ADD_NO_UINT384_CHECK => {
                 add_no_uint384_check(vm, &hint_data.ids_data, &hint_data.ap_tracking, constants)
+            }
+            hint_code::UINT384_UNSIGNED_DIV_REM_EXPANDED => {
+                uint384_unsigned_div_rem_expanded(vm, &hint_data.ids_data, &hint_data.ap_tracking)
             }
             #[cfg(feature = "skip_next_instruction_hint")]
             hint_code::SKIP_NEXT_INSTRUCTION => skip_next_instruction(vm),

--- a/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -71,7 +71,7 @@ use felt::Felt252;
 use crate::hint_processor::builtin_hint_processor::skip_next_instruction::skip_next_instruction;
 
 use super::ec_utils::{chained_ec_op_random_ec_point_hint, random_ec_point_hint, recover_y_hint};
-use super::uint384::{uint384_split_128, uint384_unsigned_div_rem};
+use super::uint384::{add_no_uint384_check, uint384_split_128, uint384_unsigned_div_rem};
 
 pub struct HintProcessorData {
     pub code: String,
@@ -455,6 +455,9 @@ impl HintProcessor for BuiltinHintProcessor {
             }
             hint_code::UINT384_SPLIT_128 => {
                 uint384_split_128(vm, &hint_data.ids_data, &hint_data.ap_tracking)
+            }
+            hint_code::ADD_NO_UINT384_CHECK => {
+                add_no_uint384_check(vm, &hint_data.ids_data, &hint_data.ap_tracking, constants)
             }
             #[cfg(feature = "skip_next_instruction_hint")]
             hint_code::SKIP_NEXT_INSTRUCTION => skip_next_instruction(vm),

--- a/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -465,6 +465,9 @@ impl HintProcessor for BuiltinHintProcessor {
             hint_code::UINT384_UNSIGNED_DIV_REM_EXPANDED => {
                 uint384_unsigned_div_rem_expanded(vm, &hint_data.ids_data, &hint_data.ap_tracking)
             }
+            hint_code::UINT384_SQRT => {
+                uint256_sqrt(vm, &hint_data.ids_data, &hint_data.ap_tracking)
+            }
             #[cfg(feature = "skip_next_instruction_hint")]
             hint_code::SKIP_NEXT_INSTRUCTION => skip_next_instruction(vm),
             code => Err(HintError::UnknownHint(code.to_string())),

--- a/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -456,7 +456,7 @@ impl HintProcessor for BuiltinHintProcessor {
             hint_code::CHAINED_EC_OP_RANDOM_EC_POINT => {
                 chained_ec_op_random_ec_point_hint(vm, &hint_data.ids_data, &hint_data.ap_tracking)
             }
-            hint_code::RECOVER_Y => recover_y_hint(vm, &hint_data.ids_data, &hint_data.ap_tracking)
+            hint_code::RECOVER_Y => recover_y_hint(vm, &hint_data.ids_data, &hint_data.ap_tracking),
             hint_code::UINT384_UNSIGNED_DIV_REM => {
                 uint384_unsigned_div_rem(vm, &hint_data.ids_data, &hint_data.ap_tracking)
             }

--- a/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -71,6 +71,7 @@ use felt::Felt252;
 use crate::hint_processor::builtin_hint_processor::skip_next_instruction::skip_next_instruction;
 
 use super::ec_utils::{chained_ec_op_random_ec_point_hint, random_ec_point_hint, recover_y_hint};
+use super::uint384::uint384_unsigned_div_rem;
 
 pub struct HintProcessorData {
     pub code: String,
@@ -449,6 +450,9 @@ impl HintProcessor for BuiltinHintProcessor {
                 chained_ec_op_random_ec_point_hint(vm, &hint_data.ids_data, &hint_data.ap_tracking)
             }
             hint_code::RECOVER_Y => recover_y_hint(vm, &hint_data.ids_data, &hint_data.ap_tracking),
+            hint_code::UINT384_UNSIGNED_DIV_REM => {
+                uint384_unsigned_div_rem(vm, &hint_data.ids_data, &hint_data.ap_tracking)
+            }
             #[cfg(feature = "skip_next_instruction_hint")]
             hint_code::SKIP_NEXT_INSTRUCTION => skip_next_instruction(vm),
             code => Err(HintError::UnknownHint(code.to_string())),

--- a/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -71,7 +71,7 @@ use felt::Felt252;
 use crate::hint_processor::builtin_hint_processor::skip_next_instruction::skip_next_instruction;
 
 use super::ec_utils::{chained_ec_op_random_ec_point_hint, random_ec_point_hint, recover_y_hint};
-use super::uint384::uint384_unsigned_div_rem;
+use super::uint384::{uint384_split_128, uint384_unsigned_div_rem};
 
 pub struct HintProcessorData {
     pub code: String,
@@ -452,6 +452,9 @@ impl HintProcessor for BuiltinHintProcessor {
             hint_code::RECOVER_Y => recover_y_hint(vm, &hint_data.ids_data, &hint_data.ap_tracking),
             hint_code::UINT384_UNSIGNED_DIV_REM => {
                 uint384_unsigned_div_rem(vm, &hint_data.ids_data, &hint_data.ap_tracking)
+            }
+            hint_code::UINT384_SPLIT_128 => {
+                uint384_split_128(vm, &hint_data.ids_data, &hint_data.ap_tracking)
             }
             #[cfg(feature = "skip_next_instruction_hint")]
             hint_code::SKIP_NEXT_INSTRUCTION => skip_next_instruction(vm),

--- a/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -72,7 +72,7 @@ use crate::hint_processor::builtin_hint_processor::skip_next_instruction::skip_n
 
 use super::ec_utils::{chained_ec_op_random_ec_point_hint, random_ec_point_hint, recover_y_hint};
 use super::uint384::{
-    add_no_uint384_check, uint384_split_128, uint384_unsigned_div_rem,
+    add_no_uint384_check, uint384_split_128, uint384_sqrt, uint384_unsigned_div_rem,
     uint384_unsigned_div_rem_expanded,
 };
 
@@ -466,7 +466,7 @@ impl HintProcessor for BuiltinHintProcessor {
                 uint384_unsigned_div_rem_expanded(vm, &hint_data.ids_data, &hint_data.ap_tracking)
             }
             hint_code::UINT384_SQRT => {
-                uint256_sqrt(vm, &hint_data.ids_data, &hint_data.ap_tracking)
+                uint384_sqrt(vm, &hint_data.ids_data, &hint_data.ap_tracking)
             }
             #[cfg(feature = "skip_next_instruction_hint")]
             hint_code::SKIP_NEXT_INSTRUCTION => skip_next_instruction(vm),

--- a/src/hint_processor/builtin_hint_processor/hint_code.rs
+++ b/src/hint_processor/builtin_hint_processor/hint_code.rs
@@ -610,6 +610,8 @@ ids.p.x = ids.x
 ids.p.y = recover_y(ids.x, ALPHA, BETA, FIELD_PRIME)";
 // The following hints support the lib https://github.com/NethermindEth/research-basic-Cairo-operations-big-integers/blob/main/lib/uint384.cairo
 pub(crate) const UINT384_UNSIGNED_DIV_REM: &str ="def split(num: int, num_bits_shift: int, length: int):\n    a = []\n    for _ in range(length):\n        a.append( num & ((1 << num_bits_shift) - 1) )\n        num = num >> num_bits_shift\n    return tuple(a)\n\ndef pack(z, num_bits_shift: int) -> int:\n    limbs = (z.d0, z.d1, z.d2)\n    return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))\n\na = pack(ids.a, num_bits_shift = 128)\ndiv = pack(ids.div, num_bits_shift = 128)\nquotient, remainder = divmod(a, div)\n\nquotient_split = split(quotient, num_bits_shift=128, length=3)\nassert len(quotient_split) == 3\n\nids.quotient.d0 = quotient_split[0]\nids.quotient.d1 = quotient_split[1]\nids.quotient.d2 = quotient_split[2]\n\nremainder_split = split(remainder, num_bits_shift=128, length=3)\nids.remainder.d0 = remainder_split[0]\nids.remainder.d1 = remainder_split[1]\nids.remainder.d2 = remainder_split[2]";
+pub(crate) const UINT384_SPLIT_128: &str = "ids.low = ids.a & ((1<<128) - 1)
+ids.high = ids.a >> 128";
 
 #[cfg(feature = "skip_next_instruction_hint")]
 pub(crate) const SKIP_NEXT_INSTRUCTION: &str = "skip_next_instruction()";

--- a/src/hint_processor/builtin_hint_processor/hint_code.rs
+++ b/src/hint_processor/builtin_hint_processor/hint_code.rs
@@ -619,5 +619,37 @@ ids.carry_d1 = 1 if sum_d1 >= ids.SHIFT else 0
 sum_d2 = ids.a.d2 + ids.b.d2 + ids.carry_d1
 ids.carry_d2 = 1 if sum_d2 >= ids.SHIFT else 0";
 
+pub(crate) const UINT384_UNSIGNED_DIV_REM_EXPANDED: &str =
+    "def split(num: int, num_bits_shift: int, length: int):
+a = []
+for _ in range(length):
+    a.append( num & ((1 << num_bits_shift) - 1) )
+    num = num >> num_bits_shift
+return tuple(a)
+
+def pack(z, num_bits_shift: int) -> int:
+limbs = (z.d0, z.d1, z.d2)
+return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))
+
+def pack2(z, num_bits_shift: int) -> int:
+limbs = (z.b01, z.b23, z.b45)
+return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))
+
+a = pack(ids.a, num_bits_shift = 128)
+div = pack2(ids.div, num_bits_shift = 128)
+quotient, remainder = divmod(a, div)
+
+quotient_split = split(quotient, num_bits_shift=128, length=3)
+assert len(quotient_split) == 3
+
+ids.quotient.d0 = quotient_split[0]
+ids.quotient.d1 = quotient_split[1]
+ids.quotient.d2 = quotient_split[2]
+
+remainder_split = split(remainder, num_bits_shift=128, length=3)
+ids.remainder.d0 = remainder_split[0]
+ids.remainder.d1 = remainder_split[1]
+ids.remainder.d2 = remainder_split[2]";
+
 #[cfg(feature = "skip_next_instruction_hint")]
 pub(crate) const SKIP_NEXT_INSTRUCTION: &str = "skip_next_instruction()";

--- a/src/hint_processor/builtin_hint_processor/hint_code.rs
+++ b/src/hint_processor/builtin_hint_processor/hint_code.rs
@@ -608,5 +608,34 @@ from starkware.python.math_utils import recover_y
 ids.p.x = ids.x
 # This raises an exception if `x` is not on the curve.
 ids.p.y = recover_y(ids.x, ALPHA, BETA, FIELD_PRIME)";
+// The following hints support the lib https://github.com/NethermindEth/research-basic-Cairo-operations-big-integers/blob/main/lib/uint384.cairo
+pub(crate) const UINT348_UNSIGNED_DIV_REM: &str =
+    "def split(num: int, num_bits_shift: int, length: int):
+a = []
+for _ in range(length):
+    a.append( num & ((1 << num_bits_shift) - 1) )
+    num = num >> num_bits_shift
+return tuple(a)
+
+def pack(z, num_bits_shift: int) -> int:
+limbs = (z.d0, z.d1, z.d2)
+return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))
+
+a = pack(ids.a, num_bits_shift = 128)
+div = pack(ids.div, num_bits_shift = 128)
+quotient, remainder = divmod(a, div)
+
+quotient_split = split(quotient, num_bits_shift=128, length=3)
+assert len(quotient_split) == 3
+
+ids.quotient.d0 = quotient_split[0]
+ids.quotient.d1 = quotient_split[1]
+ids.quotient.d2 = quotient_split[2]
+
+remainder_split = split(remainder, num_bits_shift=128, length=3)
+ids.remainder.d0 = remainder_split[0]
+ids.remainder.d1 = remainder_split[1]
+ids.remainder.d2 = remainder_split[2]";
+
 #[cfg(feature = "skip_next_instruction_hint")]
 pub(crate) const SKIP_NEXT_INSTRUCTION: &str = "skip_next_instruction()";

--- a/src/hint_processor/builtin_hint_processor/hint_code.rs
+++ b/src/hint_processor/builtin_hint_processor/hint_code.rs
@@ -619,7 +619,33 @@ ids.p.x = ids.x
 ids.p.y = recover_y(ids.x, ALPHA, BETA, FIELD_PRIME)";
 
 // The following hints support the lib https://github.com/NethermindEth/research-basic-Cairo-operations-big-integers/blob/main/lib/uint384.cairo
-pub(crate) const UINT384_UNSIGNED_DIV_REM: &str ="def split(num: int, num_bits_shift: int, length: int):\n    a = []\n    for _ in range(length):\n        a.append( num & ((1 << num_bits_shift) - 1) )\n        num = num >> num_bits_shift\n    return tuple(a)\n\ndef pack(z, num_bits_shift: int) -> int:\n    limbs = (z.d0, z.d1, z.d2)\n    return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))\n\na = pack(ids.a, num_bits_shift = 128)\ndiv = pack(ids.div, num_bits_shift = 128)\nquotient, remainder = divmod(a, div)\n\nquotient_split = split(quotient, num_bits_shift=128, length=3)\nassert len(quotient_split) == 3\n\nids.quotient.d0 = quotient_split[0]\nids.quotient.d1 = quotient_split[1]\nids.quotient.d2 = quotient_split[2]\n\nremainder_split = split(remainder, num_bits_shift=128, length=3)\nids.remainder.d0 = remainder_split[0]\nids.remainder.d1 = remainder_split[1]\nids.remainder.d2 = remainder_split[2]";
+pub(crate) const UINT384_UNSIGNED_DIV_REM: &str =
+    "def split(num: int, num_bits_shift: int, length: int):
+    a = []
+    for _ in range(length):
+        a.append( num & ((1 << num_bits_shift) - 1) )
+        num = num >> num_bits_shift
+    return tuple(a)
+
+def pack(z, num_bits_shift: int) -> int:
+    limbs = (z.d0, z.d1, z.d2)
+    return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))
+
+a = pack(ids.a, num_bits_shift = 128)
+div = pack(ids.div, num_bits_shift = 128)
+quotient, remainder = divmod(a, div)
+
+quotient_split = split(quotient, num_bits_shift=128, length=3)
+assert len(quotient_split) == 3
+
+ids.quotient.d0 = quotient_split[0]
+ids.quotient.d1 = quotient_split[1]
+ids.quotient.d2 = quotient_split[2]
+
+remainder_split = split(remainder, num_bits_shift=128, length=3)
+ids.remainder.d0 = remainder_split[0]
+ids.remainder.d1 = remainder_split[1]
+ids.remainder.d2 = remainder_split[2]";
 pub(crate) const UINT384_SPLIT_128: &str = "ids.low = ids.a & ((1<<128) - 1)
 ids.high = ids.a >> 128";
 pub(crate) const ADD_NO_UINT384_CHECK: &str = "sum_d0 = ids.a.d0 + ids.b.d0
@@ -628,7 +654,37 @@ sum_d1 = ids.a.d1 + ids.b.d1 + ids.carry_d0
 ids.carry_d1 = 1 if sum_d1 >= ids.SHIFT else 0
 sum_d2 = ids.a.d2 + ids.b.d2 + ids.carry_d1
 ids.carry_d2 = 1 if sum_d2 >= ids.SHIFT else 0";
-pub(crate) const UINT384_UNSIGNED_DIV_REM_EXPANDED: &str = "def split(num: int, num_bits_shift: int, length: int):\n    a = []\n    for _ in range(length):\n        a.append( num & ((1 << num_bits_shift) - 1) )\n        num = num >> num_bits_shift\n    return tuple(a)\n\ndef pack(z, num_bits_shift: int) -> int:\n    limbs = (z.d0, z.d1, z.d2)\n    return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))\n\ndef pack2(z, num_bits_shift: int) -> int:\n    limbs = (z.b01, z.b23, z.b45)\n    return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))\n\na = pack(ids.a, num_bits_shift = 128)\ndiv = pack2(ids.div, num_bits_shift = 128)\nquotient, remainder = divmod(a, div)\n\nquotient_split = split(quotient, num_bits_shift=128, length=3)\nassert len(quotient_split) == 3\n\nids.quotient.d0 = quotient_split[0]\nids.quotient.d1 = quotient_split[1]\nids.quotient.d2 = quotient_split[2]\n\nremainder_split = split(remainder, num_bits_shift=128, length=3)\nids.remainder.d0 = remainder_split[0]\nids.remainder.d1 = remainder_split[1]\nids.remainder.d2 = remainder_split[2]";
+pub(crate) const UINT384_UNSIGNED_DIV_REM_EXPANDED: &str =
+    "def split(num: int, num_bits_shift: int, length: int):
+    a = []
+    for _ in range(length):
+        a.append( num & ((1 << num_bits_shift) - 1) )
+        num = num >> num_bits_shift
+    return tuple(a)
+
+def pack(z, num_bits_shift: int) -> int:
+    limbs = (z.d0, z.d1, z.d2)
+    return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))
+
+def pack2(z, num_bits_shift: int) -> int:
+    limbs = (z.b01, z.b23, z.b45)
+    return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))
+
+a = pack(ids.a, num_bits_shift = 128)
+div = pack2(ids.div, num_bits_shift = 128)
+quotient, remainder = divmod(a, div)
+
+quotient_split = split(quotient, num_bits_shift=128, length=3)
+assert len(quotient_split) == 3
+
+ids.quotient.d0 = quotient_split[0]
+ids.quotient.d1 = quotient_split[1]
+ids.quotient.d2 = quotient_split[2]
+
+remainder_split = split(remainder, num_bits_shift=128, length=3)
+ids.remainder.d0 = remainder_split[0]
+ids.remainder.d1 = remainder_split[1]
+ids.remainder.d2 = remainder_split[2]";
 pub(crate) const UINT384_SQRT: &str = "from starkware.python.math_utils import isqrt
 
 def split(num: int, num_bits_shift: int, length: int):

--- a/src/hint_processor/builtin_hint_processor/hint_code.rs
+++ b/src/hint_processor/builtin_hint_processor/hint_code.rs
@@ -609,33 +609,7 @@ ids.p.x = ids.x
 # This raises an exception if `x` is not on the curve.
 ids.p.y = recover_y(ids.x, ALPHA, BETA, FIELD_PRIME)";
 // The following hints support the lib https://github.com/NethermindEth/research-basic-Cairo-operations-big-integers/blob/main/lib/uint384.cairo
-pub(crate) const UINT348_UNSIGNED_DIV_REM: &str =
-    "def split(num: int, num_bits_shift: int, length: int):
-a = []
-for _ in range(length):
-    a.append( num & ((1 << num_bits_shift) - 1) )
-    num = num >> num_bits_shift
-return tuple(a)
-
-def pack(z, num_bits_shift: int) -> int:
-limbs = (z.d0, z.d1, z.d2)
-return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))
-
-a = pack(ids.a, num_bits_shift = 128)
-div = pack(ids.div, num_bits_shift = 128)
-quotient, remainder = divmod(a, div)
-
-quotient_split = split(quotient, num_bits_shift=128, length=3)
-assert len(quotient_split) == 3
-
-ids.quotient.d0 = quotient_split[0]
-ids.quotient.d1 = quotient_split[1]
-ids.quotient.d2 = quotient_split[2]
-
-remainder_split = split(remainder, num_bits_shift=128, length=3)
-ids.remainder.d0 = remainder_split[0]
-ids.remainder.d1 = remainder_split[1]
-ids.remainder.d2 = remainder_split[2]";
+pub(crate) const UINT384_UNSIGNED_DIV_REM: &str ="def split(num: int, num_bits_shift: int, length: int):\n    a = []\n    for _ in range(length):\n        a.append( num & ((1 << num_bits_shift) - 1) )\n        num = num >> num_bits_shift\n    return tuple(a)\n\ndef pack(z, num_bits_shift: int) -> int:\n    limbs = (z.d0, z.d1, z.d2)\n    return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))\n\na = pack(ids.a, num_bits_shift = 128)\ndiv = pack(ids.div, num_bits_shift = 128)\nquotient, remainder = divmod(a, div)\n\nquotient_split = split(quotient, num_bits_shift=128, length=3)\nassert len(quotient_split) == 3\n\nids.quotient.d0 = quotient_split[0]\nids.quotient.d1 = quotient_split[1]\nids.quotient.d2 = quotient_split[2]\n\nremainder_split = split(remainder, num_bits_shift=128, length=3)\nids.remainder.d0 = remainder_split[0]\nids.remainder.d1 = remainder_split[1]\nids.remainder.d2 = remainder_split[2]";
 
 #[cfg(feature = "skip_next_instruction_hint")]
 pub(crate) const SKIP_NEXT_INSTRUCTION: &str = "skip_next_instruction()";

--- a/src/hint_processor/builtin_hint_processor/hint_code.rs
+++ b/src/hint_processor/builtin_hint_processor/hint_code.rs
@@ -620,6 +620,26 @@ ids.carry_d1 = 1 if sum_d1 >= ids.SHIFT else 0
 sum_d2 = ids.a.d2 + ids.b.d2 + ids.carry_d1
 ids.carry_d2 = 1 if sum_d2 >= ids.SHIFT else 0";
 pub(crate) const UINT384_UNSIGNED_DIV_REM_EXPANDED: &str = "def split(num: int, num_bits_shift: int, length: int):\n    a = []\n    for _ in range(length):\n        a.append( num & ((1 << num_bits_shift) - 1) )\n        num = num >> num_bits_shift\n    return tuple(a)\n\ndef pack(z, num_bits_shift: int) -> int:\n    limbs = (z.d0, z.d1, z.d2)\n    return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))\n\ndef pack2(z, num_bits_shift: int) -> int:\n    limbs = (z.b01, z.b23, z.b45)\n    return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))\n\na = pack(ids.a, num_bits_shift = 128)\ndiv = pack2(ids.div, num_bits_shift = 128)\nquotient, remainder = divmod(a, div)\n\nquotient_split = split(quotient, num_bits_shift=128, length=3)\nassert len(quotient_split) == 3\n\nids.quotient.d0 = quotient_split[0]\nids.quotient.d1 = quotient_split[1]\nids.quotient.d2 = quotient_split[2]\n\nremainder_split = split(remainder, num_bits_shift=128, length=3)\nids.remainder.d0 = remainder_split[0]\nids.remainder.d1 = remainder_split[1]\nids.remainder.d2 = remainder_split[2]";
+pub(crate) const UINT384_SQRT: &str = "from starkware.python.math_utils import isqrt
+
+def split(num: int, num_bits_shift: int, length: int):
+    a = []
+    for _ in range(length):
+        a.append( num & ((1 << num_bits_shift) - 1) )
+        num = num >> num_bits_shift
+    return tuple(a)
+
+def pack(z, num_bits_shift: int) -> int:
+    limbs = (z.d0, z.d1, z.d2)
+    return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))
+
+a = pack(ids.a, num_bits_shift=128)
+root = isqrt(a)
+assert 0 <= root < 2 ** 192
+root_split = split(root, num_bits_shift=128, length=3)
+ids.root.d0 = root_split[0]
+ids.root.d1 = root_split[1]
+ids.root.d2 = root_split[2]";
 
 #[cfg(feature = "skip_next_instruction_hint")]
 pub(crate) const SKIP_NEXT_INSTRUCTION: &str = "skip_next_instruction()";

--- a/src/hint_processor/builtin_hint_processor/hint_code.rs
+++ b/src/hint_processor/builtin_hint_processor/hint_code.rs
@@ -608,6 +608,7 @@ from starkware.python.math_utils import recover_y
 ids.p.x = ids.x
 # This raises an exception if `x` is not on the curve.
 ids.p.y = recover_y(ids.x, ALPHA, BETA, FIELD_PRIME)";
+
 // The following hints support the lib https://github.com/NethermindEth/research-basic-Cairo-operations-big-integers/blob/main/lib/uint384.cairo
 pub(crate) const UINT384_UNSIGNED_DIV_REM: &str ="def split(num: int, num_bits_shift: int, length: int):\n    a = []\n    for _ in range(length):\n        a.append( num & ((1 << num_bits_shift) - 1) )\n        num = num >> num_bits_shift\n    return tuple(a)\n\ndef pack(z, num_bits_shift: int) -> int:\n    limbs = (z.d0, z.d1, z.d2)\n    return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))\n\na = pack(ids.a, num_bits_shift = 128)\ndiv = pack(ids.div, num_bits_shift = 128)\nquotient, remainder = divmod(a, div)\n\nquotient_split = split(quotient, num_bits_shift=128, length=3)\nassert len(quotient_split) == 3\n\nids.quotient.d0 = quotient_split[0]\nids.quotient.d1 = quotient_split[1]\nids.quotient.d2 = quotient_split[2]\n\nremainder_split = split(remainder, num_bits_shift=128, length=3)\nids.remainder.d0 = remainder_split[0]\nids.remainder.d1 = remainder_split[1]\nids.remainder.d2 = remainder_split[2]";
 pub(crate) const UINT384_SPLIT_128: &str = "ids.low = ids.a & ((1<<128) - 1)
@@ -618,38 +619,7 @@ sum_d1 = ids.a.d1 + ids.b.d1 + ids.carry_d0
 ids.carry_d1 = 1 if sum_d1 >= ids.SHIFT else 0
 sum_d2 = ids.a.d2 + ids.b.d2 + ids.carry_d1
 ids.carry_d2 = 1 if sum_d2 >= ids.SHIFT else 0";
-
-pub(crate) const UINT384_UNSIGNED_DIV_REM_EXPANDED: &str =
-    "def split(num: int, num_bits_shift: int, length: int):
-a = []
-for _ in range(length):
-    a.append( num & ((1 << num_bits_shift) - 1) )
-    num = num >> num_bits_shift
-return tuple(a)
-
-def pack(z, num_bits_shift: int) -> int:
-limbs = (z.d0, z.d1, z.d2)
-return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))
-
-def pack2(z, num_bits_shift: int) -> int:
-limbs = (z.b01, z.b23, z.b45)
-return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))
-
-a = pack(ids.a, num_bits_shift = 128)
-div = pack2(ids.div, num_bits_shift = 128)
-quotient, remainder = divmod(a, div)
-
-quotient_split = split(quotient, num_bits_shift=128, length=3)
-assert len(quotient_split) == 3
-
-ids.quotient.d0 = quotient_split[0]
-ids.quotient.d1 = quotient_split[1]
-ids.quotient.d2 = quotient_split[2]
-
-remainder_split = split(remainder, num_bits_shift=128, length=3)
-ids.remainder.d0 = remainder_split[0]
-ids.remainder.d1 = remainder_split[1]
-ids.remainder.d2 = remainder_split[2]";
+pub(crate) const UINT384_UNSIGNED_DIV_REM_EXPANDED: &str = "def split(num: int, num_bits_shift: int, length: int):\n    a = []\n    for _ in range(length):\n        a.append( num & ((1 << num_bits_shift) - 1) )\n        num = num >> num_bits_shift\n    return tuple(a)\n\ndef pack(z, num_bits_shift: int) -> int:\n    limbs = (z.d0, z.d1, z.d2)\n    return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))\n\ndef pack2(z, num_bits_shift: int) -> int:\n    limbs = (z.b01, z.b23, z.b45)\n    return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))\n\na = pack(ids.a, num_bits_shift = 128)\ndiv = pack2(ids.div, num_bits_shift = 128)\nquotient, remainder = divmod(a, div)\n\nquotient_split = split(quotient, num_bits_shift=128, length=3)\nassert len(quotient_split) == 3\n\nids.quotient.d0 = quotient_split[0]\nids.quotient.d1 = quotient_split[1]\nids.quotient.d2 = quotient_split[2]\n\nremainder_split = split(remainder, num_bits_shift=128, length=3)\nids.remainder.d0 = remainder_split[0]\nids.remainder.d1 = remainder_split[1]\nids.remainder.d2 = remainder_split[2]";
 
 #[cfg(feature = "skip_next_instruction_hint")]
 pub(crate) const SKIP_NEXT_INSTRUCTION: &str = "skip_next_instruction()";

--- a/src/hint_processor/builtin_hint_processor/hint_code.rs
+++ b/src/hint_processor/builtin_hint_processor/hint_code.rs
@@ -612,6 +612,12 @@ ids.p.y = recover_y(ids.x, ALPHA, BETA, FIELD_PRIME)";
 pub(crate) const UINT384_UNSIGNED_DIV_REM: &str ="def split(num: int, num_bits_shift: int, length: int):\n    a = []\n    for _ in range(length):\n        a.append( num & ((1 << num_bits_shift) - 1) )\n        num = num >> num_bits_shift\n    return tuple(a)\n\ndef pack(z, num_bits_shift: int) -> int:\n    limbs = (z.d0, z.d1, z.d2)\n    return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))\n\na = pack(ids.a, num_bits_shift = 128)\ndiv = pack(ids.div, num_bits_shift = 128)\nquotient, remainder = divmod(a, div)\n\nquotient_split = split(quotient, num_bits_shift=128, length=3)\nassert len(quotient_split) == 3\n\nids.quotient.d0 = quotient_split[0]\nids.quotient.d1 = quotient_split[1]\nids.quotient.d2 = quotient_split[2]\n\nremainder_split = split(remainder, num_bits_shift=128, length=3)\nids.remainder.d0 = remainder_split[0]\nids.remainder.d1 = remainder_split[1]\nids.remainder.d2 = remainder_split[2]";
 pub(crate) const UINT384_SPLIT_128: &str = "ids.low = ids.a & ((1<<128) - 1)
 ids.high = ids.a >> 128";
+pub(crate) const ADD_NO_UINT384_CHECK: &str = "sum_d0 = ids.a.d0 + ids.b.d0
+ids.carry_d0 = 1 if sum_d0 >= ids.SHIFT else 0
+sum_d1 = ids.a.d1 + ids.b.d1 + ids.carry_d0
+ids.carry_d1 = 1 if sum_d1 >= ids.SHIFT else 0
+sum_d2 = ids.a.d2 + ids.b.d2 + ids.carry_d1
+ids.carry_d2 = 1 if sum_d2 >= ids.SHIFT else 0";
 
 #[cfg(feature = "skip_next_instruction_hint")]
 pub(crate) const SKIP_NEXT_INSTRUCTION: &str = "skip_next_instruction()";

--- a/src/hint_processor/builtin_hint_processor/mod.rs
+++ b/src/hint_processor/builtin_hint_processor/mod.rs
@@ -24,4 +24,5 @@ pub mod signature;
 pub mod skip_next_instruction;
 pub mod squash_dict_utils;
 pub mod uint256_utils;
+pub mod uint348;
 pub mod usort;

--- a/src/hint_processor/builtin_hint_processor/mod.rs
+++ b/src/hint_processor/builtin_hint_processor/mod.rs
@@ -24,5 +24,5 @@ pub mod signature;
 pub mod skip_next_instruction;
 pub mod squash_dict_utils;
 pub mod uint256_utils;
-pub mod uint348;
+pub mod uint384;
 pub mod usort;

--- a/src/hint_processor/builtin_hint_processor/uint348.rs
+++ b/src/hint_processor/builtin_hint_processor/uint348.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 
 use super::secp::bigint_utils::BigInt3;
+// Notes: Hints in this lib use the type Uint348, which is equal to common lib's BigInt3
 
 fn split<const T: usize>(num: &Felt252, num_bits_shift: u32) -> [Felt252; T] {
     let mut num = num.clone();
@@ -31,8 +32,6 @@ fn pack(num: BigInt3, num_bits_shift: usize) -> BigUint {
         .map(|(idx, value)| value.to_biguint().shl(idx * num_bits_shift))
         .sum()
 }
-
-// Notes: Hints in this lib use the type Uint348, which is equal to common lib's BigInt3
 /* Implements Hint:
        %{
            def split(num: int, num_bits_shift: int, length: int):

--- a/src/hint_processor/builtin_hint_processor/uint348.rs
+++ b/src/hint_processor/builtin_hint_processor/uint348.rs
@@ -1,0 +1,45 @@
+use crate::stdlib::{collections::HashMap, prelude::*};
+use crate::{
+    hint_processor::hint_processor_definition::HintReference,
+    serde::deserialize_program::ApTracking,
+    vm::{errors::hint_errors::HintError, vm_core::VirtualMachine},
+};
+
+// Notes: Hints in this lib use the type Uint348, which is equal to common lib's BigInt3
+/* Implements Hint:
+       %{
+           def split(num: int, num_bits_shift: int, length: int):
+               a = []
+               for _ in range(length):
+                   a.append( num & ((1 << num_bits_shift) - 1) )
+                   num = num >> num_bits_shift
+               return tuple(a)
+
+           def pack(z, num_bits_shift: int) -> int:
+               limbs = (z.d0, z.d1, z.d2)
+               return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))
+
+           a = pack(ids.a, num_bits_shift = 128)
+           div = pack(ids.div, num_bits_shift = 128)
+           quotient, remainder = divmod(a, div)
+
+           quotient_split = split(quotient, num_bits_shift=128, length=3)
+           assert len(quotient_split) == 3
+
+           ids.quotient.d0 = quotient_split[0]
+           ids.quotient.d1 = quotient_split[1]
+           ids.quotient.d2 = quotient_split[2]
+
+           remainder_split = split(remainder, num_bits_shift=128, length=3)
+           ids.remainder.d0 = remainder_split[0]
+           ids.remainder.d1 = remainder_split[1]
+           ids.remainder.d2 = remainder_split[2]
+       %}
+*/
+pub fn uint348_unsigned_div_rem(
+    vm: &mut VirtualMachine,
+    ids_data: &HashMap<String, HintReference>,
+    ap_tracking: &ApTracking,
+) -> Result<(), HintError> {
+    Ok(())
+}

--- a/src/hint_processor/builtin_hint_processor/uint348.rs
+++ b/src/hint_processor/builtin_hint_processor/uint348.rs
@@ -1,9 +1,36 @@
+use core::ops::Shl;
+
+use felt::Felt252;
+use num_bigint::BigUint;
+use num_traits::One;
+
 use crate::stdlib::{collections::HashMap, prelude::*};
 use crate::{
     hint_processor::hint_processor_definition::HintReference,
     serde::deserialize_program::ApTracking,
     vm::{errors::hint_errors::HintError, vm_core::VirtualMachine},
 };
+
+use super::secp::bigint_utils::BigInt3;
+
+fn split<const T: usize>(num: &Felt252, num_bits_shift: u32) -> [Felt252; T] {
+    let mut num = num.clone();
+    [0; T].map(|_| {
+        let a = &num & &((Felt252::one() << num_bits_shift) - 1_u32);
+        num = &num >> num_bits_shift;
+        a
+    })
+}
+
+fn pack(num: BigInt3, num_bits_shift: usize) -> BigUint {
+    let limbs = vec![num.d0, num.d1, num.d2];
+    #[allow(deprecated)]
+    limbs
+        .into_iter()
+        .enumerate()
+        .map(|(idx, value)| value.to_biguint().shl(idx * num_bits_shift))
+        .sum()
+}
 
 // Notes: Hints in this lib use the type Uint348, which is equal to common lib's BigInt3
 /* Implements Hint:

--- a/src/hint_processor/builtin_hint_processor/uint384.rs
+++ b/src/hint_processor/builtin_hint_processor/uint384.rs
@@ -18,8 +18,8 @@ use super::hint_utils::{
 use super::secp::bigint_utils::BigInt3;
 // Notes: Hints in this lib use the type Uint384, which is equal to common lib's BigInt3
 #[derive(Debug, PartialEq)]
+#[allow(non_snake_case)]
 pub(crate) struct Uint384Expand<'a> {
-    #[allow(non_snake_case)]
     pub B0: Cow<'a, Felt252>,
     pub b01: Cow<'a, Felt252>,
     pub b12: Cow<'a, Felt252>,
@@ -244,7 +244,7 @@ pub fn add_no_uint384_check(
            ids.remainder.d2 = remainder_split[2]
        %}
 */
-pub fn uint256_unsigned_div_rem_expanded(
+pub fn uint384_unsigned_div_rem_expanded(
     vm: &mut VirtualMachine,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,

--- a/src/hint_processor/builtin_hint_processor/uint384.rs
+++ b/src/hint_processor/builtin_hint_processor/uint384.rs
@@ -45,16 +45,16 @@ impl Uint384Expand<'_> {
             b12: vm.get_integer((addr + 2)?).map_err(|_| {
                 HintError::IdentifierHasNoMember(name.to_string(), "b12".to_string())
             })?,
-            b23: vm.get_integer((addr + 2)?).map_err(|_| {
+            b23: vm.get_integer((addr + 3)?).map_err(|_| {
                 HintError::IdentifierHasNoMember(name.to_string(), "b23".to_string())
             })?,
-            b34: vm.get_integer((addr + 2)?).map_err(|_| {
+            b34: vm.get_integer((addr + 4)?).map_err(|_| {
                 HintError::IdentifierHasNoMember(name.to_string(), "b34".to_string())
             })?,
-            b45: vm.get_integer((addr + 2)?).map_err(|_| {
+            b45: vm.get_integer((addr + 5)?).map_err(|_| {
                 HintError::IdentifierHasNoMember(name.to_string(), "b45".to_string())
             })?,
-            b5: vm.get_integer((addr + 2)?).map_err(|_| {
+            b5: vm.get_integer((addr + 6)?).map_err(|_| {
                 HintError::IdentifierHasNoMember(name.to_string(), "b5".to_string())
             })?,
         })

--- a/src/hint_processor/builtin_hint_processor/uint384.rs
+++ b/src/hint_processor/builtin_hint_processor/uint384.rs
@@ -70,7 +70,7 @@ fn split<const T: usize>(num: &BigUint, num_bits_shift: u32) -> [BigUint; T] {
 }
 
 fn pack(num: BigInt3, num_bits_shift: usize) -> BigUint {
-    let limbs = vec![num.d0, num.d1, num.d2];
+    let limbs = [num.d0, num.d1, num.d2];
     #[allow(deprecated)]
     limbs
         .into_iter()

--- a/src/hint_processor/builtin_hint_processor/uint384.rs
+++ b/src/hint_processor/builtin_hint_processor/uint384.rs
@@ -291,7 +291,7 @@ pub fn uint384_sqrt(
     let a = pack(BigInt3::from_var_name("a", vm, ids_data, ap_tracking)?, 128);
     let root_addr = get_relocatable_from_var_name("root", vm, ids_data, ap_tracking)?;
     let root = isqrt(&a)?;
-    if root.is_zero() || root >= BigUint::one().shl(192_u32) {
+    if root.is_zero() || root.bits() > 192 {
         return Err(HintError::AssertionFailed(String::from(
             "assert 0 <= root < 2 ** 192",
         )));

--- a/src/hint_processor/builtin_hint_processor/uint384.rs
+++ b/src/hint_processor/builtin_hint_processor/uint384.rs
@@ -86,3 +86,127 @@ pub fn uint384_unsigned_div_rem(
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hint_processor::builtin_hint_processor::hint_code;
+    use crate::vm::vm_memory::memory_segments::MemorySegmentManager;
+    use crate::{
+        any_box,
+        hint_processor::{
+            builtin_hint_processor::builtin_hint_processor_definition::{
+                BuiltinHintProcessor, HintProcessorData,
+            },
+            hint_processor_definition::HintProcessor,
+        },
+        types::{
+            exec_scope::ExecutionScopes,
+            relocatable::{MaybeRelocatable, Relocatable},
+        },
+        utils::test_utils::*,
+        vm::{
+            errors::memory_errors::MemoryError, runners::builtin_runner::RangeCheckBuiltinRunner,
+            vm_core::VirtualMachine, vm_memory::memory::Memory,
+        },
+    };
+    use assert_matches::assert_matches;
+    use felt::felt_str;
+
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn run_unsigned_div_rem_ok() {
+        let mut vm = vm_with_range_check!();
+        //Initialize fp
+        vm.run_context.fp = 10;
+        //Create hint_data
+        let ids_data =
+            non_continuous_ids_data![("a", -9), ("div", -6), ("quotient", -3), ("remainder", 0)];
+        //Insert ids into memory
+        vm.segments = segments![
+            //a
+            ((1, 1), 83434123481193248),
+            ((1, 2), 82349321849739284),
+            ((1, 3), 839243219401320423),
+            //div
+            ((1, 4), 9283430921839492319493),
+            ((1, 5), 313248123482483248),
+            ((1, 6), 3790328402913840),
+            //quotient
+            ((1, 7), 2)
+        ];
+        //Execute the hint
+        assert_matches!(
+            run_hint!(vm, ids_data, hint_code::UINT384_UNSIGNED_DIV_REM),
+            Ok(())
+        );
+        //Check hint memory inserts
+        check_memory![
+            vm.segments.memory,
+            // quotient
+            ((1, 7), 221),
+            ((1, 8), 0),
+            ((1, 9), 0),
+            // remainder
+            //((1, 10), 340282366920936411825224315027446796751),
+            //((1, 11), 340282366920938463394229121463989152931),
+            ((1, 12), 1580642357361782)
+        ];
+        assert_eq!(
+            vm.segments
+                .memory
+                .get_integer((1, 10).into())
+                .unwrap()
+                .as_ref(),
+            &felt_str!("340282366920936411825224315027446796751")
+        );
+        assert_eq!(
+            vm.segments
+                .memory
+                .get_integer((1, 11).into())
+                .unwrap()
+                .as_ref(),
+            &felt_str!("340282366920938463394229121463989152931")
+        );
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn run_unsigned_div_rem_invalid_memory_insert() {
+        let mut vm = vm_with_range_check!();
+        //Initialize fp
+        vm.run_context.fp = 10;
+        //Create hint_data
+        let ids_data =
+            non_continuous_ids_data![("a", -9), ("div", -6), ("quotient", -3), ("remainder", 0)];
+        //Insert ids into memory
+        vm.segments = segments![
+            //a
+            ((1, 1), 83434123481193248),
+            ((1, 2), 82349321849739284),
+            ((1, 3), 839243219401320423),
+            //div
+            ((1, 4), 9283430921839492319493),
+            ((1, 5), 313248123482483248),
+            ((1, 6), 3790328402913840),
+            //quotient
+            ((1, 7), 2)
+        ];
+        //Execute the hint
+        assert_matches!(
+            run_hint!(vm, ids_data, hint_code::UINT384_UNSIGNED_DIV_REM),
+            Err(HintError::Memory(
+                MemoryError::InconsistentMemory(
+                    x,
+                    y,
+                    z,
+                )
+            )) if x == Relocatable::from((1, 7)) &&
+                    y == MaybeRelocatable::from(Felt252::new(2)) &&
+                    z == MaybeRelocatable::from(Felt252::new(221))
+        );
+    }
+}

--- a/src/hint_processor/builtin_hint_processor/uint384.rs
+++ b/src/hint_processor/builtin_hint_processor/uint384.rs
@@ -13,7 +13,7 @@ use crate::{
 
 use super::hint_utils::get_relocatable_from_var_name;
 use super::secp::bigint_utils::BigInt3;
-// Notes: Hints in this lib use the type Uint348, which is equal to common lib's BigInt3
+// Notes: Hints in this lib use the type Uint384, which is equal to common lib's BigInt3
 
 fn split<const T: usize>(num: &BigUint, num_bits_shift: u32) -> [BigUint; T] {
     let mut num = num.clone();
@@ -63,7 +63,7 @@ fn pack(num: BigInt3, num_bits_shift: usize) -> BigUint {
            ids.remainder.d2 = remainder_split[2]
        %}
 */
-pub fn uint348_unsigned_div_rem(
+pub fn uint384_unsigned_div_rem(
     vm: &mut VirtualMachine,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
@@ -74,7 +74,7 @@ pub fn uint348_unsigned_div_rem(
         128,
     );
     let quotient_addr = get_relocatable_from_var_name("quotient", vm, ids_data, ap_tracking)?;
-    let remainder_addr = get_relocatable_from_var_name("quotient", vm, ids_data, ap_tracking)?;
+    let remainder_addr = get_relocatable_from_var_name("remainder", vm, ids_data, ap_tracking)?;
     let (quotient, remainder) = a.div_mod_floor(&div);
     let quotient_split = split::<3>(&quotient, 128);
     for (i, quotient_split) in quotient_split.iter().enumerate() {

--- a/src/hint_processor/builtin_hint_processor/uint384.rs
+++ b/src/hint_processor/builtin_hint_processor/uint384.rs
@@ -88,34 +88,34 @@ fn pack2(num: Uint384ExpandReduced, num_bits_shift: usize) -> BigUint {
         .sum()
 }
 /* Implements Hint:
-       %{
-           def split(num: int, num_bits_shift: int, length: int):
-               a = []
-               for _ in range(length):
-                   a.append( num & ((1 << num_bits_shift) - 1) )
-                   num = num >> num_bits_shift
-               return tuple(a)
+%{
+    def split(num: int, num_bits_shift: int, length: int):
+        a = []
+        for _ in range(length):
+            a.append( num & ((1 << num_bits_shift) - 1) )
+            num = num >> num_bits_shift
+        return tuple(a)
 
-           def pack(z, num_bits_shift: int) -> int:
-               limbs = (z.d0, z.d1, z.d2)
-               return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))
+    def pack(z, num_bits_shift: int) -> int:
+        limbs = (z.d0, z.d1, z.d2)
+        return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))
 
-           a = pack(ids.a, num_bits_shift = 128)
-           div = pack(ids.div, num_bits_shift = 128)
-           quotient, remainder = divmod(a, div)
+    a = pack(ids.a, num_bits_shift = 128)
+    div = pack(ids.div, num_bits_shift = 128)
+    quotient, remainder = divmod(a, div)
 
-           quotient_split = split(quotient, num_bits_shift=128, length=3)
-           assert len(quotient_split) == 3
+    quotient_split = split(quotient, num_bits_shift=128, length=3)
+    assert len(quotient_split) == 3
 
-           ids.quotient.d0 = quotient_split[0]
-           ids.quotient.d1 = quotient_split[1]
-           ids.quotient.d2 = quotient_split[2]
+    ids.quotient.d0 = quotient_split[0]
+    ids.quotient.d1 = quotient_split[1]
+    ids.quotient.d2 = quotient_split[2]
 
-           remainder_split = split(remainder, num_bits_shift=128, length=3)
-           ids.remainder.d0 = remainder_split[0]
-           ids.remainder.d1 = remainder_split[1]
-           ids.remainder.d2 = remainder_split[2]
-       %}
+    remainder_split = split(remainder, num_bits_shift=128, length=3)
+    ids.remainder.d0 = remainder_split[0]
+    ids.remainder.d1 = remainder_split[1]
+    ids.remainder.d2 = remainder_split[2]
+%}
 */
 pub fn uint384_unsigned_div_rem(
     vm: &mut VirtualMachine,
@@ -201,38 +201,38 @@ pub fn add_no_uint384_check(
 }
 
 /* Implements Hint:
-       %{
-           def split(num: int, num_bits_shift: int, length: int):
-               a = []
-               for _ in range(length):
-                   a.append( num & ((1 << num_bits_shift) - 1) )
-                   num = num >> num_bits_shift
-               return tuple(a)
+%{
+    def split(num: int, num_bits_shift: int, length: int):
+        a = []
+        for _ in range(length):
+            a.append( num & ((1 << num_bits_shift) - 1) )
+            num = num >> num_bits_shift
+        return tuple(a)
 
-           def pack(z, num_bits_shift: int) -> int:
-               limbs = (z.d0, z.d1, z.d2)
-               return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))
+    def pack(z, num_bits_shift: int) -> int:
+        limbs = (z.d0, z.d1, z.d2)
+        return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))
 
-           def pack2(z, num_bits_shift: int) -> int:
-               limbs = (z.b01, z.b23, z.b45)
-               return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))
+    def pack2(z, num_bits_shift: int) -> int:
+        limbs = (z.b01, z.b23, z.b45)
+        return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))
 
-           a = pack(ids.a, num_bits_shift = 128)
-           div = pack2(ids.div, num_bits_shift = 128)
-           quotient, remainder = divmod(a, div)
+    a = pack(ids.a, num_bits_shift = 128)
+    div = pack2(ids.div, num_bits_shift = 128)
+    quotient, remainder = divmod(a, div)
 
-           quotient_split = split(quotient, num_bits_shift=128, length=3)
-           assert len(quotient_split) == 3
+    quotient_split = split(quotient, num_bits_shift=128, length=3)
+    assert len(quotient_split) == 3
 
-           ids.quotient.d0 = quotient_split[0]
-           ids.quotient.d1 = quotient_split[1]
-           ids.quotient.d2 = quotient_split[2]
+    ids.quotient.d0 = quotient_split[0]
+    ids.quotient.d1 = quotient_split[1]
+    ids.quotient.d2 = quotient_split[2]
 
-           remainder_split = split(remainder, num_bits_shift=128, length=3)
-           ids.remainder.d0 = remainder_split[0]
-           ids.remainder.d1 = remainder_split[1]
-           ids.remainder.d2 = remainder_split[2]
-       %}
+    remainder_split = split(remainder, num_bits_shift=128, length=3)
+    ids.remainder.d0 = remainder_split[0]
+    ids.remainder.d1 = remainder_split[1]
+    ids.remainder.d2 = remainder_split[2]
+%}
 */
 pub fn uint384_unsigned_div_rem_expanded(
     vm: &mut VirtualMachine,
@@ -257,6 +257,31 @@ pub fn uint384_unsigned_div_rem_expanded(
     }
     Ok(())
 }
+
+/* Implements Hint
+%{
+    from starkware.python.math_utils import isqrt
+
+    def split(num: int, num_bits_shift: int, length: int):
+        a = []
+        for _ in range(length):
+            a.append( num & ((1 << num_bits_shift) - 1) )
+            num = num >> num_bits_shift
+        return tuple(a)
+
+    def pack(z, num_bits_shift: int) -> int:
+        limbs = (z.d0, z.d1, z.d2)
+        return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))
+
+    a = pack(ids.a, num_bits_shift=128)
+    root = isqrt(a)
+    assert 0 <= root < 2 ** 192
+    root_split = split(root, num_bits_shift=128, length=3)
+    ids.root.d0 = root_split[0]
+    ids.root.d1 = root_split[1]
+    ids.root.d2 = root_split[2]
+%}
+ */
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/hint_processor/builtin_hint_processor/uint384.rs
+++ b/src/hint_processor/builtin_hint_processor/uint384.rs
@@ -80,7 +80,7 @@ fn pack(num: BigInt3, num_bits_shift: usize) -> BigUint {
 }
 
 fn pack2(num: Uint384ExpandReduced, num_bits_shift: usize) -> BigUint {
-    let limbs = vec![num.b01, num.b23, num.b45];
+    let limbs = [num.b01, num.b23, num.b45];
     #[allow(deprecated)]
     limbs
         .into_iter()

--- a/src/tests/cairo_run_test.rs
+++ b/src/tests/cairo_run_test.rs
@@ -1267,6 +1267,8 @@ fn cairo_run_recover_y() {
     run_program_simple(program_data.as_slice());
 }
 
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn cairo_run_math_integration() {
     let program_data = include_bytes!("../../cairo_programs/math_integration_tests.json");
     run_program_simple(program_data.as_slice());

--- a/src/tests/cairo_run_test.rs
+++ b/src/tests/cairo_run_test.rs
@@ -1269,7 +1269,7 @@ fn cairo_run_recover_y() {
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_uibt384() {
+fn cairo_run_uint384() {
     let program_data = include_bytes!("../../cairo_programs/uint384.json");
     run_program_simple(program_data.as_slice());
 }

--- a/src/tests/cairo_run_test.rs
+++ b/src/tests/cairo_run_test.rs
@@ -1266,3 +1266,10 @@ fn cairo_run_recover_y() {
     let program_data = include_bytes!("../../cairo_programs/recover_y.json");
     run_program_simple(program_data.as_slice());
 }
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn cairo_run_uibt384() {
+    let program_data = include_bytes!("../../cairo_programs/uint384.json");
+    run_program_simple(program_data.as_slice());
+}


### PR DESCRIPTION
lib where these hints come from can be found here (https://github.com/NethermindEth/research-basic-Cairo-operations-big-integers/blob/main/lib/uint384.cairo)
Contains 5 hints:
UINT384_UNSIGNED_DIV_REM
UINT384_SPLIT_128
ADD_NO_UINT384_CHECK
UINT384_UNSIGNED_DIV_REM_EXPANDED
UINT384_SQRT
