### PR TITLE
Add pipeline to enforce updating CHANGELOG.md

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,15 @@
+name: "Pull Request Workflow"
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  # Enforces the update of a changelog file on every pull request 
+  # We only want this for user-visible changes, so we add a few labels
+  # for which the check is skipped
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: dangoslen/changelog-enforcer@v3
+      with:
+        skipLabels: pipelines,coverage


### PR DESCRIPTION
As we've been failing to keep this critical documentation up-to-date, this acts as a strong reminder that it should be updated by failing the checks on every PR lacking this update.
It includes the exception for the labels "pipelines" and "coverage", as PRs that only work on those don't introduce user-visible changes.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
