### PR TITLE
test: unit tests for cairo-vm-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "paste",
- "rustc_version",
+ "rustc_version 0.3.3",
  "zeroize",
 ]
 
@@ -233,11 +233,13 @@ dependencies = [
 name = "cairo-vm-cli"
 version = "0.3.0-rc1"
 dependencies = [
+ "assert_matches",
  "bincode",
  "cairo-vm",
  "clap 3.2.23",
  "mimalloc",
  "nom",
+ "rstest",
  "thiserror",
 ]
 
@@ -552,6 +554,101 @@ name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.13",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
+name = "futures-util"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -890,6 +987,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "plotters"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1101,12 +1210,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de1bb486a691878cd320c2f0d319ba91eeaa2e894066d8b5f8f117c000e9d962"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version 0.4.0",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290ca1a1c8ca7edb7c3283bd44dc35dd54fdec6253a3912e201ba1072018fca8"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.0",
+ "syn 1.0.109",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
 dependencies = [
- "semver",
+ "semver 0.11.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver 1.0.17",
 ]
 
 [[package]]
@@ -1182,6 +1326,12 @@ checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
  "semver-parser",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "semver-parser"
@@ -1261,6 +1411,15 @@ checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
 dependencies = [
  "digest 0.10.6",
  "keccak",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/cairo-vm-cli/Cargo.toml
+++ b/cairo-vm-cli/Cargo.toml
@@ -11,6 +11,10 @@ mimalloc = { version = "0.1.29", default-features = false, optional = true }
 nom = "7"
 thiserror = { version = "1.0.32" }
 
+[dev-dependencies]
+assert_matches = "1.5.0"
+rstest = "0.17.0"
+
 [features]
 default = ["with_mimalloc"]
 with_mimalloc = ["cairo-vm/with_mimalloc", "mimalloc"]

--- a/cairo-vm-cli/src/main.rs
+++ b/cairo-vm-cli/src/main.rs
@@ -56,6 +56,8 @@ fn validate_layout(value: &str) -> Result<(), String> {
 
 #[derive(Debug, Error)]
 enum Error {
+    #[error("Invalid arguments")]
+    CLI(#[from] clap::Error),
     #[error("Failed to interact with the file system")]
     IO(#[from] std::io::Error),
     #[error("The cairo program execution failed")]
@@ -101,8 +103,15 @@ impl FileWriter {
     }
 }
 
-fn main() -> Result<(), Error> {
-    let args = Args::parse();
+fn run(args: impl Iterator<Item = String>) -> Result<(), Error> {
+    let args = Args::try_parse_from(args);
+    let args = match args {
+        Ok(args) => args,
+        Err(error) => {
+            eprintln!("{error}");
+            return Err(Error::CLI(error.into()));
+        }
+    };
     let trace_enabled = args.trace_file.is_some();
     let mut hint_executor = BuiltinHintProcessor::new_empty();
     let cairo_run_config = cairo_run::CairoRunConfig {
@@ -120,7 +129,7 @@ fn main() -> Result<(), Error> {
         match cairo_run::cairo_run(&program_content, &cairo_run_config, &mut hint_executor) {
             Ok(runner) => runner,
             Err(error) => {
-                println!("{error}");
+                eprintln!("{error}");
                 return Err(Error::Runner(error));
             }
         };
@@ -154,9 +163,105 @@ fn main() -> Result<(), Error> {
     Ok(())
 }
 
+fn main() -> Result<(), Error> {
+    run(std::env::args())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use assert_matches::assert_matches;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case([].as_slice())]
+    #[case(["cairo-vm-cli"].as_slice())]
+    fn test_run_missing_mandatory_args(#[case] args: &[&str]) {
+        let args = args.into_iter().cloned().map(String::from);
+        assert_matches!(run(args), Err(Error::CLI(_)));
+    }
+
+    #[rstest]
+    #[case(["cairo-vm-cli", "--layout", "broken_layout", "../cairo_programs/fibonacci.json"].as_slice())]
+    fn test_run_invalid_args(#[case] args: &[&str]) {
+        let args = args.into_iter().cloned().map(String::from);
+        assert_matches!(run(args), Err(Error::CLI(_)));
+    }
+
+    #[rstest]
+    fn test_run_ok(
+        #[values(None,
+                 Some("plain"),
+                 Some("small"),
+                 Some("dex"),
+                 Some("starknet"),
+                 Some("starknet_with_keccak"),
+                 Some("recursive_large_output"),
+                 Some("all_cairo"),
+                 Some("all_solidity"),
+                 //FIXME: dynamic layout leads to _very_ slow execution
+                 //Some("dynamic"),
+        )]
+        layout: Option<&str>,
+        #[values(false, true)] memory_file: bool,
+        #[values(false, true)] mut trace_file: bool,
+        #[values(false, true)] proof_mode: bool,
+        #[values(false, true)] secure_run: bool,
+        #[values(false, true)] print_output: bool,
+        #[values(false, true)] entrypoint: bool,
+    ) {
+        let mut args = vec!["cairo-vm-cli".to_string()];
+        if let Some(layout) = layout {
+            args.extend_from_slice(&["--layout".to_string(), layout.to_string()]);
+        }
+        if proof_mode {
+            trace_file = true;
+            args.extend_from_slice(&["--proof_mode".to_string()]);
+        }
+        if entrypoint {
+            args.extend_from_slice(&["--entrypoint".to_string(), "main".to_string()]);
+        }
+        if memory_file {
+            args.extend_from_slice(&["--memory_file".to_string(), "/dev/null".to_string()]);
+        }
+        if trace_file {
+            args.extend_from_slice(&["--trace_file".to_string(), "/dev/null".to_string()]);
+        }
+        if secure_run {
+            args.extend_from_slice(&["--secure_run".to_string(), "true".to_string()]);
+        }
+        if print_output {
+            args.extend_from_slice(&["--print_output".to_string()]);
+        }
+        args.push("../cairo_programs/proof_programs/fibonacci.json".to_string());
+        assert_matches!(run(args.into_iter()), Ok(_));
+    }
+
+    #[test]
+    fn test_run_missing_program() {
+        let args = ["cairo-vm-cli", "../missing/program.json"]
+            .into_iter()
+            .map(String::from);
+        assert_matches!(run(args), Err(Error::IO(_)));
+    }
+
+    #[rstest]
+    #[case("../cairo_programs/manually_compiled/invalid_even_length_hex.json")]
+    #[case("../cairo_programs/manually_compiled/invalid_memory.json")]
+    #[case("../cairo_programs/manually_compiled/invalid_odd_length_hex.json")]
+    #[case("../cairo_programs/manually_compiled/no_data_program.json")]
+    #[case("../cairo_programs/manually_compiled/no_main_program.json")]
+    fn test_run_bad_file(#[case] program: &str) {
+        let args = ["cairo-vm-cli", program].into_iter().map(String::from);
+        assert_matches!(run(args), Err(Error::Runner(_)));
+    }
+
+    //Since the functionality here is trivial, I just call the function
+    //to fool Codecov.
+    #[test]
+    fn test_main() {
+        assert!(main().is_err());
+    }
 
     #[test]
     fn test_valid_layouts() {

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -652,7 +652,7 @@ impl CairoRunner {
         }
 
         let diluted_units = diluted_pool_instance.units_per_step as usize * vm.current_step;
-        let unused_diluted_units = diluted_units - used_units_by_builtins;
+        let unused_diluted_units = diluted_units.saturating_sub(used_units_by_builtins);
 
         let diluted_usage_upper_bound = 1usize << diluted_pool_instance.n_bits;
         if unused_diluted_units < diluted_usage_upper_bound {


### PR DESCRIPTION
This splits functionality into a `run` function that receives the iterator of arguments, and `main` that simply calls it with `std::env::args`.
Then, adds several test cases with `rstest`. It checks all combinations of successful runs and a few of invalid arguments and missing files. This should make the codecov path pipeline happier :)

NOTE: the dynamic layout is too slow, and it caused a panic (subsequently fixed) as well. It is commented out from the tests until optimized.

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.
