### PR TITLE
feat: re-export felt crate from cairo_vm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 #### Upcoming Changes
 
+* Re-export the `cairo-felt` crate as `cairo_vm::felt` #981
+  Removes the need of explicitly importing `cairo-felt` in downstream projects
+  and helps ensure there is no version mismatch caused by that
 * Move `Memory` into `MemorySegmentManager` [#830](https://github.com/lambdaclass/cairo-rs/pull/830)
     * Structural changes:
         * Remove `memory: Memory` field from `VirtualMachine`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 #### Upcoming Changes
 
-* Re-export the `cairo-felt` crate as `cairo_vm::felt` #981
-  Removes the need of explicitly importing `cairo-felt` in downstream projects
+* Re-export the `cairo-felt` crate as `cairo_vm::felt` [#981](https://github.com/lambdaclass/cairo-rs/pull/981)
+  * Removes the need of explicitly importing `cairo-felt` in downstream projects
   and helps ensure there is no version mismatch caused by that
 * Move `Memory` into `MemorySegmentManager` [#830](https://github.com/lambdaclass/cairo-rs/pull/830)
     * Structural changes:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ mod stdlib {
     pub use crate::without_std::*;
 }
 
+pub extern crate felt;
 pub mod cairo_run;
 pub mod hint_processor;
 pub mod math_utils;


### PR DESCRIPTION
Re-exports as `pub extern crate` the imported `cairo-felt`. It's a public dependency (types defined by it are part of the public APIs) and requiring explicit imports causes issues where the version imported by downstream does not match the one imported by `cairo-vm`, which ends up in compilation failures.
After this change the users have the option of importing `cairo-vm` only and use `cairo_vm::felt::Felt252` to get the exact version of the type used by the VM crate, eliminating such errors.
This is not a breaking change.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [x] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [x] CHANGELOG has been updated.
