### PR TITLE
Fix workflows not running on merge queue

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,5 +1,6 @@
 name: "Pull Request Workflow"
 on:
+  merge_group:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,7 @@
 name: rust
 
 on:
+  merge_group:
   push:
     branches: [ main ]
   pull_request:


### PR DESCRIPTION
Currently, the rust & changelog workflowa are required by the merge queue but they are not set to run in it, causing PRs to become stuck, this PR aims to fix it by adding merge_group to the workflow run target

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.
