### PR TITLE
Add missing `\n` character in traceback string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Cairo-VM Changelog
 
 #### Upcoming Changes
+
+* Add missing `\n` character in traceback string [#997](https://github.com/lambdaclass/cairo-rs/pull/997)
+    * BugFix: Add missing `\n` character after traceback lines when the filename is missing ("Unknown Location")
+
 * 0.11 Support
     * Layouts update [#874](https://github.com/lambdaclass/cairo-rs/pull/874)
     * Keccak builtin updated [#873](https://github.com/lambdaclass/cairo-rs/pull/873), [#883](https://github.com/lambdaclass/cairo-rs/pull/883)

--- a/src/vm/errors/vm_exception.rs
+++ b/src/vm/errors/vm_exception.rs
@@ -101,7 +101,10 @@ pub fn get_traceback(vm: &VirtualMachine, runner: &CairoRunner) -> Option<String
                 "{}\n",
                 location.to_string_with_content(&format!("(pc=0:{})", traceback_pc.offset))
             )),
-            None => traceback.push_str(&format!("Unknown location (pc=0:{})", traceback_pc.offset)),
+            None => traceback.push_str(&format!(
+                "Unknown location (pc=0:{})\n",
+                traceback_pc.offset
+            )),
         }
     }
     (!traceback.is_empty())


### PR DESCRIPTION
The `\n` character is missing after each traceback line when the filename is unknown

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [x] CHANGELOG has been updated.

