### PR TITLE
ci: fix head programs not being stored in cache

### DIFF
--- a/.github/workflows/hyperfine.yml
+++ b/.github/workflows/hyperfine.yml
@@ -31,9 +31,9 @@ jobs:
         uses: actions/cache@v3
         id: cache
         with:
-          path: base_programs/*.json
-          key: benchmarks-${{ hashFiles( 'cairo_programs/benchmarks/*.cairo' ) }}
-          restore-keys: benchmarks-
+          path: ${{ matrix.branch }}_programs/*.json
+          key: benchmarks-${{ matrix.branch }}-${{ hashFiles( 'cairo_programs/benchmarks/*.cairo' ) }}
+          restore-keys: benchmarks-${{ matrix.branch }}-
 
       - name: Install Python
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
@@ -125,13 +125,13 @@ jobs:
       uses: actions/cache/restore@v3
       with:
         path: base_programs/*.json
-        key: benchmarks-${{ needs.build-programs.outputs.benchmark-hashes-base }}
+        key: benchmarks-base-${{ needs.build-programs.outputs.benchmark-hashes-base }}
 
     - name: Fetch head programs
       uses: actions/cache/restore@v3
       with:
         path: head_programs/*.json
-        key: benchmarks-${{ needs.build-programs.outputs.benchmark-hashes-head }}
+        key: benchmarks-head-${{ needs.build-programs.outputs.benchmark-hashes-head }}
 
     - name: Benchmark ${{ matrix.program_state }} programs
       id: run-benchmarks


### PR DESCRIPTION
A leftover `base_programs` caused the cache for head programs to fail.
Also change the cache key to distinguish base from head.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

