### PR TITLE
ci: pipelines overhaul and optimization

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
         run: touch target/doc/.nojekyll
       - name: Set short sha output
         id: short_sha
-        run: echo "::set-output name=sha::$(git rev-parse --short HEAD)"
+        run: echo ":name=sha::$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Checkout gh-pages
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/hyperfine.yml
+++ b/.github/workflows/hyperfine.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/cache@v3
         id: cache
         with:
-          path: ${{ matrix.branch }}_programs/*.json
+          path: ${{ matrix.branch }}_programs/*.json
           key: benchmarks-${{ matrix.branch }}-${{ hashFiles( 'cairo_programs/benchmarks/*.cairo' ) }}
           restore-keys: benchmarks-${{ matrix.branch }}-
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: rust
+name: QA
 
 on:
   merge_group:
@@ -11,80 +11,360 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-    runs-on: ubuntu-20.04
+  build-programs:
+    strategy:
+      matrix:
+        # NOTE: we build cairo_proof_programs so clippy can check the benchmarks too
+        program-target: [ cairo_bench_programs, cairo_proof_programs, cairo_test_programs ]
+    name: Build Cairo programs
+    runs-on: ubuntu-22.04
     steps:
-    - name: Install Rust 1.66.1
-      uses: actions-rs/toolchain@v1
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Fetch from cache
+      uses: actions/cache@v3
+      id: cache-programs
       with:
-          toolchain: 1.66.1
-          override: true
-          components: rustfmt, clippy
+        path: cairo_programs/**/*.json
+        key: ${{ matrix.program-target }}-cache-${{ hashFiles( 'cairo_programs/**/*.cairo' ) }}
+        restore-keys: ${{ matrix.program-target }}-cache-
+
     - name: Python3 Build
+      if: ${{ steps.cache-programs.outputs.cache-hit != 'true' }}
       uses: actions/setup-python@v4
       with:
         python-version: '3.9'
+        cache: 'pip'
+    - name: Install cairo-lang and deps
+      if: ${{ steps.cache-programs.outputs.cache-hit != 'true' }}
+      run: pip install -r requirements.txt
 
-    - name: Install Nextest
-      uses: taiki-e/install-action@nextest
-    - name: Install cargo-llvm-cov
-      uses: taiki-e/install-action@cargo-llvm-cov
-    - name: Install wasm-bindgen-cli
-      uses: jetli/wasm-pack-action@v0.4.0
+    - name: Build programs
+      if: ${{ steps.cache-programs.outputs.cache-hit != 'true' }}
+      run: make -j ${{ matrix.program-target }}
+
+
+  lint:
+    needs: build-programs
+    name: Run Lints
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Install Rust 1.69.0
+      uses: dtolnay/rust-toolchain@1.69.0
       with:
-        version: "v0.10.3"
-
+          components: rustfmt, clippy
     - name: Set up cargo cache
       uses: Swatinem/rust-cache@v2
     - name: Checkout
       uses: actions/checkout@v3
-      with:
-        fetch-depth: 0 
-    - name: Install test dependencies
-      run: pip install -r requirements.txt
+
     - name: Format
       run: cargo fmt --all -- --check
-    - name: Build
-      run: make build
-    - name: Populate cache
-      uses: actions/cache@v3
-      id: cache-cairo-programs
+
+    - name: Fetch test programs
+      uses: actions/cache/restore@v3
       with:
-        path: |
-          cairo_programs/*.json
-          cairo_programs/*.memory
-          cairo_programs/*.trace
-          !cairo_programs/*.rs.*
-          cairo_programs/*/*.json
-          cairo_programs/*/*.memory
-          cairo_programs/*/*.trace
-          !cairo_programs/*/*.rs.*
-        key: cairo-cache-${{ hashFiles( 'cairo_programs/*.cairo', 'cairo_programs/*/*.cairo' ) }}
-        restore-keys: cairo-cache-
-    - name: Restore timestamps
-      uses: chetan/git-restore-mtime-action@v1
-    - name: Install dependencies
-      run: pip install -r requirements.txt
-    - name: Run tests
-      run: make -j test
-    - name: Run tests no_std
-      run: make -j test-no_std
-    - name: Run wasm tests
-      run: make -j test-wasm
-    - name: Compare trace and memory
-      run: make -j compare_trace_memory
-    - name: Compare trace and memory with proof mode
-      run: make -j compare_trace_memory_proof
+        path: cairo_programs/**/*.json
+        key: cairo_test_programs-cache-${{ hashFiles( 'cairo_programs/**/*.cairo' ) }}
+    - name: Fetch proof programs
+      uses: actions/cache/restore@v3
+      with:
+        path: cairo_programs/**/*.json
+        key: cairo_proof_programs-cache-${{ hashFiles( 'cairo_programs/**/*.cairo' ) }}
+    - name: Fetch bench programs
+      uses: actions/cache/restore@v3
+      with:
+        path: cairo_programs/**/*.json
+        key: cairo_bench_programs-cache-${{ hashFiles( 'cairo_programs/**/*.cairo' ) }}
     - name: Run clippy
       run: make clippy
-    - name: Coverage
-      run: make coverage
+
+
+  # NOTE: the term "smoke test" comes from electronics design: the minimal
+  # expectations anyone has in their device is to not catch fire on boot.
+  smoke:
+    needs: build-programs
+    name: Make sure all builds work
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Install Rust 1.69.0
+      uses: dtolnay/rust-toolchain@1.69.0
+    - name: Set up cargo cache
+      uses: Swatinem/rust-cache@v2
+    - name: Install cargo-all-features
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-all-features
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Fetch test programs
+      uses: actions/cache/restore@v3
+      with:
+        path: cairo_programs/**/*.json
+        key: cairo_test_programs-cache-${{ hashFiles( 'cairo_programs/**/*.cairo' ) }}
+    - name: Fetch proof programs
+      uses: actions/cache/restore@v3
+      with:
+        path: cairo_programs/**/*.json
+        key: cairo_proof_programs-cache-${{ hashFiles( 'cairo_programs/**/*.cairo' ) }}
+    - name: Fetch bench programs
+      uses: actions/cache/restore@v3
+      with:
+        path: cairo_programs/**/*.json
+        key: cairo_bench_programs-cache-${{ hashFiles( 'cairo_programs/**/*.cairo' ) }}
+
+    - name: Check
+      run: cargo check-all-features --workspace --all-targets
+
+
+  tests:
+    needs: build-programs
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [ test, test-no_std, test-wasm ]
+        # TODO: features
+    name: Run tests
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Install Rust 1.69.0
+      uses: dtolnay/rust-toolchain@1.69.0
+      with:
+          components: llvm-tools-preview
+    - name: Set up cargo cache
+      uses: Swatinem/rust-cache@v2
+    - name: Checkout
+      uses: actions/checkout@v3
+    # This is not pretty, but we need `make` to see the compiled programs are
+    # actually newer than the sources, otherwise it will try to rebuild them
+    # FIXME: it doesn't even seem to cut it anymore
+    #- name: Restore timestamps
+    #uses: chetan/git-restore-mtime-action@v1
+
+    - name: Fetch test programs
+      uses: actions/cache/restore@v3
+      with:
+        path: cairo_programs/**/*.json
+        key: cairo_test_programs-cache-${{ hashFiles( 'cairo_programs/**/*.cairo' ) }}
+    - name: Fetch proof programs
+      uses: actions/cache/restore@v3
+      with:
+        path: cairo_programs/**/*.json
+        key: cairo_proof_programs-cache-${{ hashFiles( 'cairo_programs/**/*.cairo' ) }}
+
+    - name: Install testing tools
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-nextest,cargo-llvm-cov,wasm-pack
+    - name: Run
+      # FIXME: side-stepping make, it tries to build the programs even though
+      # they are already up to date
+      run:
+        case ${{ matrix.target }} in
+        'test')
+          cargo llvm-cov nextest --lcov --output-path lcov-${{ matrix.target }}.info --workspace --features test_utils
+          ;;
+        'test-no_std')
+          cargo llvm-cov nextest --lcov --output-path lcov-${{ matrix.target }}.info --workspace --features test_utils --no-default-features
+          ;;
+        'test-wasm')
+          wasm-pack test --node --no-default-features
+          ;;
+        esac
+
+    - name: Save coverage
+      if: matrix.target != 'test-wasm'
+      uses: actions/cache/save@v3
+      with:
+        path: lcov-${{ matrix.target }}.info
+        key: codecov-cache-${{ matrix.target }}-${{ github.sha }}
+
+
+  build-release:
+    name: Build release binary for comparisons
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Install Rust 1.69.0
+      uses: dtolnay/rust-toolchain@1.69.0
+    - name: Set up cargo cache
+      uses: Swatinem/rust-cache@v2
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Build
+      run: cargo b --release -p cairo-vm-cli
+    # We don't read from cache because it should always miss
+    - name: Store in cache
+      uses: actions/cache/save@v3
+      with:
+        key: cli-bin-rel-${{ github.sha }}
+        path: target/release/cairo-vm-cli
+
+
+  run-cairo-reference:
+    strategy:
+      matrix:
+        include:
+        - program-target: cairo_proof_programs
+          programs-dir: cairo_programs/proof_programs
+          nprocs: 1
+          extra-args: '--proof_mode'
+        - program-target: cairo_test_programs
+          programs-dir: cairo_programs
+          nprocs: 2
+          extra-args: ''
+    name: Compute memory and execution traces with cairo-lang
+    needs: build-programs
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Check cache
+      uses: actions/cache@v3
+      id: trace-cache
+      with:
+        path: |
+          cairo_programs/**/*.memory
+          cairo_programs/**/*.trace
+        key: ${{ matrix.program-target }}-reference-trace-cache-${{ hashFiles( 'cairo_programs/**/*.cairo' ) }}
+
+    - name: Python3 Build
+      if: steps.trace-cache.outputs.cache-hit != 'true'
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
+        cache: 'pip'
+    - name: Install cairo-lang and deps
+      if: steps.trace-cache.outputs.cache-hit != 'true'
+      run: pip install -r requirements.txt
+
+    - name: Fetch programs
+      if: ${{ steps.trace-cache.outputs.cache-hit != 'true' }}
+      uses: actions/cache/restore@v3
+      with:
+        path: cairo_programs/**/*.json
+        key: ${{ matrix.program-target }}-cache-${{ hashFiles( 'cairo_programs/**/*.cairo' ) }}
+        fail-on-cache-miss: true
+
+    - name: Generate traces
+      if: ${{ steps.trace-cache.outputs.cache-hit != 'true' }}
+      run: |
+        ls ${{ matrix.programs-dir }}/*.json | cut -f1 -d'.' | \
+        xargs -P ${{ matrix.nprocs }} -I '{program}' \
+        cairo-run --program '{program}'.json --layout starknet_with_keccak \
+        --memory_file '{program}'.memory --trace_file '{program}'.trace \
+        ${{ matrix.extra-args }}
+
+
+  run-cairo-release:
+    strategy:
+      matrix:
+        include:
+        - program-target: cairo_proof_programs
+          programs-dir: cairo_programs/proof_programs
+          extra-args: '--proof_mode'
+        - program-target: cairo_test_programs
+          programs-dir: cairo_programs
+          extra-args: ''
+    name: Compute memory and execution traces with cairo-rs
+    needs: [ build-programs, build-release ]
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Fetch release binary
+      uses: actions/cache/restore@v3
+      with:
+        key: cli-bin-rel-${{ github.sha }}
+        path: target/release/cairo-vm-cli
+        fail-on-cache-miss: true
+
+    - name: Fetch programs
+      uses: actions/cache/restore@v3
+      with:
+        path: cairo_programs/**/*.json
+        key: ${{ matrix.program-target }}-cache-${{ hashFiles( 'cairo_programs/**/*.cairo' ) }}
+        fail-on-cache-miss: true
+
+    - name: Generate traces
+      run: |
+        ls ${{ matrix.programs-dir }}/*.json | cut -f1 -d'.' | \
+        xargs -P 2 -I '{program}' \
+        ./target/release/cairo-vm-cli '{program}'.json --layout starknet_with_keccak \
+        --memory_file '{program}'.rs.memory --trace_file '{program}'.rs.trace \
+        ${{ matrix.extra-args }}
+    - name: Update cache
+      uses: actions/cache/save@v3
+      with:
+        path: |
+          cairo_programs/**/*.memory
+          cairo_programs/**/*.trace
+        key: ${{ matrix.program-target }}-release-trace-cache-${{ github.sha }}
+
+
+  upload-coverage:
+    name: Upload coverage results to codecov.io
+    needs: tests
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Fetch results for tests with stdlib
+      uses: actions/cache/restore@v3
+      with:
+        path: lcov-test.info
+        key: codecov-cache-test-${{ github.sha }}
+        fail-on-cache-miss: true
+    - name: Fetch results for tests without stdlib
+      uses: actions/cache/restore@v3
+      with:
+        path: lcov-test-no_std.info
+        key: codecov-cache-test-no_std-${{ github.sha }}
+        fail-on-cache-miss: true
+
     - name: Upload coverage to codecov.io
       uses: codecov/codecov-action@v3
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        files: lcov.info
-        fail_ci_if_error:     true
-    # NB: the following step is needed so caching doesn't cause misleading coverage in later runs
-    - name: Clean coverage artifacts
-      run: make coverage-clean
+        files: '*.info'
+        fail_ci_if_error: true
+
+
+  compare-memory-and-trace:
+    strategy:
+      matrix:
+        program-target: [ cairo_proof_programs, cairo_test_programs ]
+    name: Compare memory and execution traces from cairo-lang and cairo-rs
+    needs: [ run-cairo-reference, run-cairo-release ]
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Fetch traces for cairo-lang
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          cairo_programs/**/*.memory
+          cairo_programs/**/*.trace
+        key: ${{ matrix.program-target }}-reference-trace-cache-${{ hashFiles( 'cairo_programs/**/*.cairo' ) }}
+        fail-on-cache-miss: true
+
+    - name: Fetch traces for cairo-rs
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          cairo_programs/**/*.memory
+          cairo_programs/**/*.trace
+        key: ${{ matrix.program-target }}-release-trace-cache-${{ github.sha }}
+        fail-on-cache-miss: true
+
+    - name: Run comparison script
+      run: |
+        if [ ${{ matrix.program-target }} = cairo_proof_programs ]; then
+          PROOF=proof
+        fi
+        ./src/tests/compare_vm_state.sh trace memory $PROOF

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -137,11 +137,12 @@ jobs:
       uses: Swatinem/rust-cache@v2
     - name: Checkout
       uses: actions/checkout@v3
+      with:
+        depth: 0
     # This is not pretty, but we need `make` to see the compiled programs are
     # actually newer than the sources, otherwise it will try to rebuild them
-    # FIXME: it doesn't even seem to cut it anymore
-    #- name: Restore timestamps
-    #uses: chetan/git-restore-mtime-action@v1
+    - name: Restore timestamps
+      uses: chetan/git-restore-mtime-action@v1
 
     - name: Fetch test programs
       uses: actions/cache/restore@v3
@@ -159,9 +160,8 @@ jobs:
       with:
         tool: cargo-nextest,cargo-llvm-cov,wasm-pack
     - name: Run
-      # FIXME: side-stepping make, it tries to build the programs even though
-      # they are already up to date
       run:
+        # FIXME: we need to update the Makefile to do this correctly
         case ${{ matrix.target }} in
         'test')
           cargo llvm-cov nextest --lcov --output-path lcov-${{ matrix.target }}.info --workspace --features test_utils

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ run:
 check:
 	cargo check
 
-cairo_test_programs: $(COMPILED_TESTS) $(COMPILED_BAD_TESTS)
+cairo_test_programs: $(COMPILED_TESTS) $(COMPILED_BAD_TESTS) $(COMPILED_NORETROCOMPAT_TESTS)
 cairo_proof_programs: $(COMPILED_PROOF_TESTS)
 cairo_bench_programs: $(COMPILED_BENCHES)
 
@@ -145,7 +145,7 @@ test-wasm: $(COMPILED_PROOF_TESTS) $(COMPILED_TESTS) $(COMPILED_BAD_TESTS) $(COM
 	wasm-pack test --node --no-default-features
 
 clippy:
-	cargo clippy --tests --examples --all-features -- -D warnings
+	cargo clippy --all --all-features --benches --examples --tests -- -D warnings
 
 coverage:
 	cargo llvm-cov report --lcov --output-path lcov.info

--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -1087,7 +1087,7 @@ mod tests {
             let p = &CAIRO_PRIME_BIGUINT;
             let result = x + y;
             let as_uint = &result.to_biguint();
-            prop_assert!(as_uint < &p, "{}", as_uint);
+            prop_assert!(as_uint < p, "{}", as_uint);
 
         }
         #[test]
@@ -1098,7 +1098,7 @@ mod tests {
             let p = &CAIRO_PRIME_BIGUINT;
             x += y;
             let as_uint = &x.to_biguint();
-            prop_assert!(as_uint < &p, "{}", as_uint);
+            prop_assert!(as_uint < p, "{}", as_uint);
         }
 
         #[test]
@@ -1211,10 +1211,10 @@ mod tests {
             let y = FeltBigInt::<FIELD_HIGH, FIELD_LOW>::parse_bytes(y.as_bytes(), 10).unwrap();
             let z = FeltBigInt::<FIELD_HIGH, FIELD_LOW>::parse_bytes(z.as_bytes(), 10).unwrap();
             let p:BigUint = BigUint::parse_bytes(CAIRO_PRIME_BIGUINT.to_string().as_bytes(), 16).unwrap();
-            let v = vec![x.clone(), y, z];
+            let v = vec![x, y, z];
             let result: FeltBigInt<FIELD_HIGH, FIELD_LOW> = v.into_iter().sum();
             let as_uint = result.to_biguint();
-            prop_assert!(&as_uint < &p, "{}", as_uint);
+            prop_assert!(as_uint < p, "{}", as_uint);
         }
     }
 }

--- a/felt/src/lib.rs
+++ b/felt/src/lib.rs
@@ -51,7 +51,6 @@ pub(crate) trait FeltOps {
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn to_str_radix(&self, radix: u32) -> String;
 
-    #[deprecated]
     /// Converts [`Felt252`] into a [`BigInt`] number in the range: `(- FIELD / 2, FIELD / 2)`.
     ///
     /// # Examples
@@ -68,7 +67,6 @@ pub(crate) trait FeltOps {
     /// ```
     fn to_bigint(&self) -> BigInt;
 
-    #[deprecated]
     /// Converts [`Felt252`] into a [`BigUint`] number.
     ///
     /// # Examples

--- a/hint_accountant/src/main.rs
+++ b/hint_accountant/src/main.rs
@@ -11,10 +11,9 @@ use cairo_vm::{
     with_std::collections::{HashMap, HashSet},
 };
 use serde::Deserialize;
-use serde_json;
 use serde_json::Value;
 
-const WHITELISTS: [&'static str; 15] = [
+const WHITELISTS: [&str; 15] = [
     include_str!("../whitelists/0.10.3.json"),
     include_str!("../whitelists/0.6.0.json"),
     include_str!("../whitelists/0.8.2.json"),
@@ -65,7 +64,7 @@ fn run() {
         .map(|ahe| ahe.hint_lines.join("\n"))
         .filter(|h| {
             let hint_data = hint_executor
-                .compile_hint(&h, &ap_tracking_data, &reference_ids, &references)
+                .compile_hint(h, &ap_tracking_data, &reference_ids, &references)
                 .expect("this implementation is infallible");
             matches!(
                 hint_executor.execute_hint(&mut vm, &mut exec_scopes, &hint_data, &constants),
@@ -76,7 +75,7 @@ fn run() {
 
     println!("{} missing hints:", missing_hints.len());
     for hint in missing_hints.iter() {
-        println!("");
+        println!();
         println!("```");
         println!("%{{");
         println!("{hint}");

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,0 @@
-[toolchain]
-channel = "1.66.1"
-components = ["rustfmt", "clippy"]
-profile = "minimal"

--- a/src/vm/errors/vm_exception.rs
+++ b/src/vm/errors/vm_exception.rs
@@ -271,7 +271,7 @@ impl Location {
         if !(0 < self.start_line && ((self.start_line - 1) as usize) < split_lines.len()) {
             return String::new();
         }
-        let start_line = split_lines[((self.start_line - 1) as usize)];
+        let start_line = split_lines[(self.start_line - 1) as usize];
         let start_col = self.start_col as usize;
         let mut result = format!("{start_line}\n");
         let end_col = if self.start_line == self.end_line {


### PR DESCRIPTION
This is a major overhaul of how the QA pipelines run. The code became complex, but it enables much more parallelism in our bottleneck. It creates many independent and interdependent jobs that share data via caches.
There are separate jobs to:
- compile test, proof and benchmark Cairo programs
- run those programs against the reference cairo-lang VM for later comparison of traces
- compile the release binary
- run each of proof and normal executions with the cairo-rs binary
- compare the traces
- run unit tests for each of std, no_std and wasm
- upload the coverage report
- run linters (clippy and cairo fmt)
- test that test every configuration can at least build

The toolchain was updated to 1.69.0 to allow usage of sparse indexes for crates.io. In turn, this meant fixing new clippy alerts. An actionlint alert was fixed as well.