### PR TITLE
perf: bump starknet-crypto version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 #### Upcoming Changes
 
+* Update `starknet-crypto` to version `0.4.3` [#1011](https://github.com/lambdaclass/cairo-rs/pull/1011)
+  * The new version carries an 85% reduction in execution time for ECDSA signature verification
+
 * BREAKING CHANGE: refactor `Program` to optimize `Program::clone` [#999](https://github.com/lambdaclass/cairo-rs/pull/999)
     * Breaking change: many fields that were (unnecessarily) public become hidden by the refactor.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1430,9 +1430,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "starknet-crypto"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d49eb65d58fa98a164ad2cd4d04775885386b83bdad6060f168a38ede77c9aed"
+checksum = "8802a516a2556b2ddb9630898d2c8387d928a3e603799b8b2a7dc4018b852c8f"
 dependencies = [
  "crypto-bigint",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ hex = { version = "0.4.3", default-features = false }
 bincode = { version = "2.0.0-rc.2", tag = "v2.0.0-rc.2", git = "https://github.com/bincode-org/bincode.git", default-features = false, features = [
     "serde",
 ] }
-starknet-crypto = { version = "0.4.2", default-features = false, features = [
+starknet-crypto = { version = "0.4.3", default-features = false, features = [
     "signature-display",
     "alloc",
 ] }


### PR DESCRIPTION
The new release includes an optimization for the ECDSA signature verification that makes it take 85% less time.
We're missing automated benchmarks for this case, but manually modifying `cairo_programs/common_signature.cairo` to run 1000 times I measured the new version to be 8.5x faster than `main` with Hyperfine.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [x] CHANGELOG has been updated.

