### PR TITLE
feat(hints): add NewHint#43

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 #### Upcoming Changes
 
+* Add missing hint on uint256_improvements lib [#1016](https://github.com/lambdaclass/cairo-rs/pull/1016):
+
+    `BuiltinHintProcessor` now supports the following hint:
+
+    ```python
+        def split(num: int, num_bits_shift: int = 128, length: int = 2):
+            a = []
+            for _ in range(length):
+                a.append( num & ((1 << num_bits_shift) - 1) )
+                num = num >> num_bits_shift
+            return tuple(a)
+
+        def pack(z, num_bits_shift: int = 128) -> int:
+            limbs = (z.low, z.high)
+            return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))
+
+        a = pack(ids.a)
+        b = pack(ids.b)
+        res = (a - b)%2**256
+        res_split = split(res)
+        ids.res.low = res_split[0]
+        ids.res.high = res_split[1]
+    ```
+
 * Add missing hint on uint256_improvements lib [#1013](https://github.com/lambdaclass/cairo-rs/pull/1013):
 
     `BuiltinHintProcessor` now supports the following hint:

--- a/cairo_programs/uint256_improvements.cairo
+++ b/cairo_programs/uint256_improvements.cairo
@@ -317,8 +317,30 @@ func test_udiv_expanded{range_check_ptr}() {
     return ();
 }
 
+func test_uint256_sub{range_check_ptr}() {
+    let x = Uint256(421, 5135);
+    let y = Uint256(787, 968);
+
+    // Compute x - y
+    let (res, sign) = uint256_sub(x, y);
+
+    assert res = Uint256(340282366920938463463374607431768211090, 4166);
+    // x - y >= 0
+    assert sign = 1;
+
+    // Compute y - x
+    let (res, sign) = uint256_sub(y, x);
+
+    assert res = Uint256(366, 340282366920938463463374607431768207289);
+    // y - x < 0
+    assert sign = 0;
+
+    return ();
+}
+
 func main{range_check_ptr}() {
     test_udiv_expanded();
+    test_uint256_sub();
 
     return ();
 }

--- a/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -57,8 +57,8 @@ use crate::{
             },
             uint256_utils::uint256_expanded_unsigned_div_rem,
             uint256_utils::{
-                split_64, uint256_add, uint256_mul_div_mod, uint256_signed_nn, uint256_sqrt,
-                uint256_unsigned_div_rem,
+                split_64, uint256_add, uint256_expanded_unsigned_div_rem, uint256_mul_div_mod,
+                uint256_signed_nn, uint256_sqrt, uint256_sub, uint256_unsigned_div_rem,
             },
             uint384::{
                 add_no_uint384_check, uint384_signed_nn, uint384_split_128, uint384_sqrt,
@@ -336,6 +336,7 @@ impl HintProcessor for BuiltinHintProcessor {
                 dict_squash_update_ptr(vm, exec_scopes, &hint_data.ids_data, &hint_data.ap_tracking)
             }
             hint_code::UINT256_ADD => uint256_add(vm, &hint_data.ids_data, &hint_data.ap_tracking),
+            hint_code::UINT256_SUB => uint256_sub(vm, &hint_data.ids_data, &hint_data.ap_tracking),
             hint_code::SPLIT_64 => split_64(vm, &hint_data.ids_data, &hint_data.ap_tracking),
             hint_code::UINT256_SQRT => {
                 uint256_sqrt(vm, &hint_data.ids_data, &hint_data.ap_tracking)

--- a/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -55,7 +55,6 @@ use crate::{
                 squash_dict_inner_next_key, squash_dict_inner_skip_loop,
                 squash_dict_inner_used_accesses_assert,
             },
-            uint256_utils::uint256_expanded_unsigned_div_rem,
             uint256_utils::{
                 split_64, uint256_add, uint256_expanded_unsigned_div_rem, uint256_mul_div_mod,
                 uint256_signed_nn, uint256_sqrt, uint256_sub, uint256_unsigned_div_rem,

--- a/src/hint_processor/builtin_hint_processor/hint_code.rs
+++ b/src/hint_processor/builtin_hint_processor/hint_code.rs
@@ -283,6 +283,24 @@ ids.carry_low = 1 if sum_low >= ids.SHIFT else 0
 sum_high = ids.a.high + ids.b.high + ids.carry_low
 ids.carry_high = 1 if sum_high >= ids.SHIFT else 0"#;
 
+pub const UINT256_SUB: &str = r#"def split(num: int, num_bits_shift: int = 128, length: int = 2):
+    a = []
+    for _ in range(length):
+        a.append( num & ((1 << num_bits_shift) - 1) )
+        num = num >> num_bits_shift
+    return tuple(a)
+
+def pack(z, num_bits_shift: int = 128) -> int:
+    limbs = (z.low, z.high)
+    return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))
+
+a = pack(ids.a)
+b = pack(ids.b)
+res = (a - b)%2**256
+res_split = split(res)
+ids.res.low = res_split[0]
+ids.res.high = res_split[1]"#;
+
 pub const UINT256_SQRT: &str = r#"from starkware.python.math_utils import isqrt
 n = (ids.n.high << 128) + ids.n.low
 root = isqrt(n)

--- a/src/hint_processor/builtin_hint_processor/uint256_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/uint256_utils.rs
@@ -21,7 +21,6 @@ use num_integer::{div_rem, Integer};
 use num_traits::{One, Signed, Zero};
 
 // TODO: use this type in all uint256 functions
-#[derive(Debug, PartialEq)]
 pub(crate) struct Uint256<'a> {
     pub low: Cow<'a, Felt252>,
     pub high: Cow<'a, Felt252>,

--- a/src/hint_processor/builtin_hint_processor/uint256_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/uint256_utils.rs
@@ -35,10 +35,10 @@ impl<'a> Uint256<'a> {
     ) -> Result<Self, HintError> {
         Ok(Self {
             low: vm.get_integer(addr).map_err(|_| {
-                HintError::IdentifierHasNoMember(name.to_string(), "d0".to_string())
+                HintError::IdentifierHasNoMember(name.to_string(), "low".to_string())
             })?,
             high: vm.get_integer((addr + 1)?).map_err(|_| {
-                HintError::IdentifierHasNoMember(name.to_string(), "d1".to_string())
+                HintError::IdentifierHasNoMember(name.to_string(), "high".to_string())
             })?,
         })
     }
@@ -556,6 +556,26 @@ mod tests {
             ((1, 4), ("340282366920938463463374607431768200278", 10)),
             ((1, 5), ("340282366920938463463374607431768205098", 10))
         ];
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn run_uint256_sub_missing_member() {
+        let hint_code = hint_code::UINT256_SUB;
+        let mut vm = vm_with_range_check!();
+        //Initialize fp
+        vm.run_context.fp = 0;
+        //Create hint_data
+        let ids_data = non_continuous_ids_data![("a", 0)];
+        //Execute the hint
+        assert_matches!(run_hint!(vm, ids_data.clone(), hint_code),
+            Err(HintError::IdentifierHasNoMember(s1, s2)) if s1 == "a" && s2 == "low"
+        );
+        vm.segments = segments![((1, 0), 1001)];
+        //Execute the hint
+        assert_matches!(run_hint!(vm, ids_data, hint_code),
+            Err(HintError::IdentifierHasNoMember(s1, s2)) if s1 == "a" && s2 == "high"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

This PR adds the missing hint _NewHint#43_, now known as `UINT256_SUB`. This also introduces a new wrapper type `Uint256` for a set of two `Cow`s loaded from VM memory. Old `uint256` utils should be refactored to use it in the future.