### PR TITLE
feat: getters for prime, builtin names and data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 #### Upcoming Changes
 
+* Add getters to read properties of a `Program` [#1017](https://github.com/lambdaclass/cairo-rs/pull/1017):
+  * `prime(&self) -> &str`: get the prime associated to data in hex representation
+  * `iter_data(&self) -> Iterator<Item = &MaybeRelocatable>`: get an iterator over all elements in the program data
+  * `iter_builtins(&self) -> Iterator<Item = &BuiltinName>`: get an iterator over the names of required builtins
+
 * Add missing hint on cairo_secp lib [#1008](https://github.com/lambdaclass/cairo-rs/pull/1008):
 
     `BuiltinHintProcessor` now supports the following hint:


### PR DESCRIPTION
Required by starknet_in_rust, `Program` now has three new methods:
- `prime() -> &str` returns the prime for that `Program` as a string
- `iter_data() -> Iterator<Item = &MaybeRelocatable>`, an iterator over the program data
- `iter_builtins() -> Iterator<Item = &BuiltinName>`, an iterator over the names of enabled builtins

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [x] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [x] CHANGELOG has been updated.

