### PR TITLE
perf!: move `identifiers` to `SharedProgramData`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 #### Upcoming Changes
 
+* BREAKING CHANGE: move `Program::identifiers` to `SharedProgramData::identifiers` [#1023](https://github.com/lambdaclass/cairo-rs/pull/1023)
+    * Optimizes `CairoRunner::new`, needed for sequencers and other workflows reusing the same `Program` instance across `CairoRunner`s
+    * Breaking change: make all fields in `Program` and `SharedProgramData` `pub(crate)`, since we break by moving the field let's make it the last break for this struct
+    * Add `Program::get_identifier(&self, id: &str) -> &Identifier` to get a single identifier by name
+
 * Add missing hint on uint256_improvements lib [#1016](https://github.com/lambdaclass/cairo-rs/pull/1016):
 
     `BuiltinHintProcessor` now supports the following hint:
@@ -26,7 +31,7 @@
         ids.res.high = res_split[1]
     ```
 
-* Add methor `Program::data_len(&self) -> usize` to get the number of data cells in a given program [#1022](https://github.com/lambdaclass/cairo-rs/pull/1022)
+* Add method `Program::data_len(&self) -> usize` to get the number of data cells in a given program [#1022](https://github.com/lambdaclass/cairo-rs/pull/1022)
 
 * Add missing hint on uint256_improvements lib [#1013](https://github.com/lambdaclass/cairo-rs/pull/1013):
 

--- a/src/types/program.rs
+++ b/src/types/program.rs
@@ -35,23 +35,23 @@ use std::path::Path;
 // Fields in `Program` (other than `SharedProgramData` itself) are used by the main logic.
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
 pub(crate) struct SharedProgramData {
-    pub builtins: Vec<BuiltinName>,
-    pub data: Vec<MaybeRelocatable>,
-    pub hints: HashMap<usize, Vec<HintParams>>,
-    pub main: Option<usize>,
+    pub(crate) builtins: Vec<BuiltinName>,
+    pub(crate) data: Vec<MaybeRelocatable>,
+    pub(crate) hints: HashMap<usize, Vec<HintParams>>,
+    pub(crate) main: Option<usize>,
     //start and end labels will only be used in proof-mode
-    pub start: Option<usize>,
-    pub end: Option<usize>,
-    pub error_message_attributes: Vec<Attribute>,
-    pub instruction_locations: Option<HashMap<usize, InstructionLocation>>,
+    pub(crate) start: Option<usize>,
+    pub(crate) end: Option<usize>,
+    pub(crate) error_message_attributes: Vec<Attribute>,
+    pub(crate) instruction_locations: Option<HashMap<usize, InstructionLocation>>,
+    pub(crate) identifiers: HashMap<String, Identifier>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Program {
     pub(crate) shared_program_data: Arc<SharedProgramData>,
-    pub constants: HashMap<String, Felt252>,
-    pub reference_manager: ReferenceManager,
-    pub identifiers: HashMap<String, Identifier>,
+    pub(crate) constants: HashMap<String, Felt252>,
+    pub(crate) reference_manager: ReferenceManager,
 }
 
 impl Program {
@@ -66,6 +66,16 @@ impl Program {
         error_message_attributes: Vec<Attribute>,
         instruction_locations: Option<HashMap<usize, InstructionLocation>>,
     ) -> Result<Program, ProgramError> {
+        let mut constants = HashMap::new();
+        for (key, value) in identifiers.iter() {
+            if value.type_.as_deref() == Some("const") {
+                let value = value
+                    .value
+                    .clone()
+                    .ok_or_else(|| ProgramError::ConstWithoutValue(key.clone()))?;
+                constants.insert(key.clone(), value);
+            }
+        }
         let shared_program_data = SharedProgramData {
             builtins,
             data,
@@ -75,25 +85,12 @@ impl Program {
             end: None,
             error_message_attributes,
             instruction_locations,
+            identifiers,
         };
         Ok(Self {
             shared_program_data: Arc::new(shared_program_data),
-            constants: {
-                let mut constants = HashMap::new();
-                for (key, value) in identifiers.iter() {
-                    if value.type_.as_deref() == Some("const") {
-                        let value = value
-                            .value
-                            .clone()
-                            .ok_or_else(|| ProgramError::ConstWithoutValue(key.clone()))?;
-                        constants.insert(key.clone(), value);
-                    }
-                }
-
-                constants
-            },
+            constants,
             reference_manager,
-            identifiers,
         })
     }
 
@@ -123,6 +120,10 @@ impl Program {
     pub fn data_len(&self) -> usize {
         self.shared_program_data.data.len()
     }
+
+    pub fn get_identifier(&self, id: &str) -> Option<&Identifier> {
+        self.shared_program_data.identifiers.get(id)
+    }
 }
 
 impl Default for Program {
@@ -133,7 +134,6 @@ impl Default for Program {
             reference_manager: ReferenceManager {
                 references: Vec::new(),
             },
-            identifiers: HashMap::new(),
         }
     }
 }
@@ -181,7 +181,7 @@ mod tests {
         assert_eq!(program.shared_program_data.builtins, builtins);
         assert_eq!(program.shared_program_data.data, data);
         assert_eq!(program.shared_program_data.main, None);
-        assert_eq!(program.identifiers, HashMap::new());
+        assert_eq!(program.shared_program_data.identifiers, HashMap::new());
     }
 
     #[test]
@@ -243,7 +243,7 @@ mod tests {
         assert_eq!(program.shared_program_data.builtins, builtins);
         assert_eq!(program.shared_program_data.data, data);
         assert_eq!(program.shared_program_data.main, None);
-        assert_eq!(program.identifiers, identifiers);
+        assert_eq!(program.shared_program_data.identifiers, identifiers);
         assert_eq!(
             program.constants,
             [("__main__.main.SIZEOF_LOCALS", Felt252::zero())]
@@ -357,6 +357,76 @@ mod tests {
         .unwrap();
 
         assert_eq!(program.data_len(), data.len());
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn get_identifier() {
+        let reference_manager = ReferenceManager {
+            references: Vec::new(),
+        };
+
+        let builtins: Vec<BuiltinName> = Vec::new();
+
+        let data: Vec<MaybeRelocatable> = vec![
+            mayberelocatable!(5189976364521848832),
+            mayberelocatable!(1000),
+            mayberelocatable!(5189976364521848832),
+            mayberelocatable!(2000),
+            mayberelocatable!(5201798304953696256),
+            mayberelocatable!(2345108766317314046),
+        ];
+
+        let mut identifiers: HashMap<String, Identifier> = HashMap::new();
+
+        identifiers.insert(
+            String::from("__main__.main"),
+            Identifier {
+                pc: Some(0),
+                type_: Some(String::from("function")),
+                value: None,
+                full_name: None,
+                members: None,
+                cairo_type: None,
+            },
+        );
+
+        identifiers.insert(
+            String::from("__main__.main.SIZEOF_LOCALS"),
+            Identifier {
+                pc: None,
+                type_: Some(String::from("const")),
+                value: Some(Felt252::zero()),
+                full_name: None,
+                members: None,
+                cairo_type: None,
+            },
+        );
+
+        let program = Program::new(
+            builtins,
+            data,
+            None,
+            HashMap::new(),
+            reference_manager,
+            identifiers.clone(),
+            Vec::new(),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            program.get_identifier("__main__.main"),
+            identifiers.get("__main__.main"),
+        );
+        assert_eq!(
+            program.get_identifier("__main__.main.SIZEOF_LOCALS"),
+            identifiers.get("__main__.main.SIZEOF_LOCALS"),
+        );
+        assert_eq!(
+            program.get_identifier("missing"),
+            identifiers.get("missing"),
+        );
     }
 
     #[test]
@@ -497,7 +567,7 @@ mod tests {
         assert_eq!(program.shared_program_data.builtins, builtins);
         assert_eq!(program.shared_program_data.data, data);
         assert_eq!(program.shared_program_data.main, Some(0));
-        assert_eq!(program.identifiers, identifiers);
+        assert_eq!(program.shared_program_data.identifiers, identifiers);
     }
 
     /// Deserialize a program without an entrypoint.
@@ -596,7 +666,7 @@ mod tests {
         assert_eq!(program.shared_program_data.builtins, builtins);
         assert_eq!(program.shared_program_data.data, data);
         assert_eq!(program.shared_program_data.main, None);
-        assert_eq!(program.identifiers, identifiers);
+        assert_eq!(program.shared_program_data.identifiers, identifiers);
         assert_eq!(
             program.shared_program_data.error_message_attributes,
             error_message_attributes
@@ -654,6 +724,7 @@ mod tests {
             end: None,
             error_message_attributes: Vec::new(),
             instruction_locations: None,
+            identifiers: HashMap::new(),
         };
         let program = Program {
             shared_program_data: Arc::new(shared_program_data),
@@ -661,7 +732,6 @@ mod tests {
             reference_manager: ReferenceManager {
                 references: Vec::new(),
             },
-            identifiers: HashMap::new(),
         };
 
         assert_eq!(program, Program::default());

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -255,6 +255,7 @@ pub mod test_utils {
                 end: None,
                 error_message_attributes: crate::stdlib::vec::Vec::new(),
                 instruction_locations: None,
+                identifiers: crate::stdlib::collections::HashMap::new(),
             };
             Program {
                 shared_program_data: Arc::new(shared_program_data),
@@ -262,7 +263,6 @@ pub mod test_utils {
                 reference_manager: ReferenceManager {
                     references: crate::stdlib::vec::Vec::new(),
                 },
-                identifiers: crate::stdlib::collections::HashMap::new(),
             }
         }};
         // Custom program definition
@@ -278,14 +278,6 @@ pub mod test_utils {
             Program {
                 $(
                     reference_manager: $value,
-                )*
-                ..Default::default()
-            }
-        };
-        ($(identifiers = $value:expr),* $(,)?) => {
-            Program {
-                $(
-                    identifiers: $value,
                 )*
                 ..Default::default()
             }
@@ -883,6 +875,7 @@ mod test {
             end: None,
             error_message_attributes: Vec::new(),
             instruction_locations: None,
+            identifiers: HashMap::new(),
         };
         let program = Program {
             shared_program_data: Arc::new(shared_data),
@@ -890,7 +883,6 @@ mod test {
             reference_manager: ReferenceManager {
                 references: Vec::new(),
             },
-            identifiers: HashMap::new(),
         };
         assert_eq!(program, program!())
     }
@@ -907,6 +899,7 @@ mod test {
             end: None,
             error_message_attributes: Vec::new(),
             instruction_locations: None,
+            identifiers: HashMap::new(),
         };
         let program = Program {
             shared_program_data: Arc::new(shared_data),
@@ -914,7 +907,6 @@ mod test {
             reference_manager: ReferenceManager {
                 references: Vec::new(),
             },
-            identifiers: HashMap::new(),
         };
 
         assert_eq!(program, program![BuiltinName::range_check])
@@ -932,6 +924,7 @@ mod test {
             end: None,
             error_message_attributes: Vec::new(),
             instruction_locations: None,
+            identifiers: HashMap::new(),
         };
         let program = Program {
             shared_program_data: Arc::new(shared_data),
@@ -939,7 +932,6 @@ mod test {
             reference_manager: ReferenceManager {
                 references: Vec::new(),
             },
-            identifiers: HashMap::new(),
         };
 
         assert_eq!(

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -985,6 +985,7 @@ impl CairoRunner {
         let new_entrypoint = new_entrypoint.unwrap_or("main");
         self.entrypoint = Some(
             self.program
+                .shared_program_data
                 .identifiers
                 .get(&format!("__main__.{new_entrypoint}"))
                 .and_then(|x| x.pc)
@@ -4160,23 +4161,23 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn set_entrypoint_main_default() {
-        let program = program!();
+        let program = program!(
+            identifiers = [(
+                "__main__.main",
+                Identifier {
+                    pc: Some(0),
+                    type_: None,
+                    value: None,
+                    full_name: None,
+                    members: None,
+                    cairo_type: None,
+                },
+            )]
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v))
+            .collect(),
+        );
         let mut cairo_runner = cairo_runner!(program);
-
-        cairo_runner.program.identifiers = [(
-            "__main__.main",
-            Identifier {
-                pc: Some(0),
-                type_: None,
-                value: None,
-                full_name: None,
-                members: None,
-                cairo_type: None,
-            },
-        )]
-        .into_iter()
-        .map(|(k, v)| (k.to_string(), v))
-        .collect();
 
         cairo_runner
             .set_entrypoint(None)
@@ -4187,36 +4188,36 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn set_entrypoint_main() {
-        let program = program!();
+        let program = program!(
+            identifiers = [
+                (
+                    "__main__.main",
+                    Identifier {
+                        pc: Some(0),
+                        type_: None,
+                        value: None,
+                        full_name: None,
+                        members: None,
+                        cairo_type: None,
+                    },
+                ),
+                (
+                    "__main__.alternate_main",
+                    Identifier {
+                        pc: Some(1),
+                        type_: None,
+                        value: None,
+                        full_name: None,
+                        members: None,
+                        cairo_type: None,
+                    },
+                ),
+            ]
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v))
+            .collect(),
+        );
         let mut cairo_runner = cairo_runner!(program);
-
-        cairo_runner.program.identifiers = [
-            (
-                "__main__.main",
-                Identifier {
-                    pc: Some(0),
-                    type_: None,
-                    value: None,
-                    full_name: None,
-                    members: None,
-                    cairo_type: None,
-                },
-            ),
-            (
-                "__main__.alternate_main",
-                Identifier {
-                    pc: Some(1),
-                    type_: None,
-                    value: None,
-                    full_name: None,
-                    members: None,
-                    cairo_type: None,
-                },
-            ),
-        ]
-        .into_iter()
-        .map(|(k, v)| (k.to_string(), v))
-        .collect();
 
         cairo_runner
             .set_entrypoint(Some("alternate_main"))
@@ -4228,23 +4229,23 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn set_entrypoint_main_non_existent() {
-        let program = program!();
+        let program = program!(
+            identifiers = [(
+                "__main__.main",
+                Identifier {
+                    pc: Some(0),
+                    type_: None,
+                    value: None,
+                    full_name: None,
+                    members: None,
+                    cairo_type: None,
+                },
+            )]
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v))
+            .collect(),
+        );
         let mut cairo_runner = cairo_runner!(program);
-
-        cairo_runner.program.identifiers = [(
-            "__main__.main",
-            Identifier {
-                pc: Some(0),
-                type_: None,
-                value: None,
-                full_name: None,
-                members: None,
-                cairo_type: None,
-            },
-        )]
-        .into_iter()
-        .map(|(k, v)| (k.to_string(), v))
-        .collect();
 
         cairo_runner
             .set_entrypoint(Some("nonexistent_main"))
@@ -4459,6 +4460,7 @@ mod tests {
 
         //this entrypoint tells which function to run in the cairo program
         let main_entrypoint = program
+            .shared_program_data
             .identifiers
             .get("__main__.main")
             .unwrap()
@@ -4490,6 +4492,7 @@ mod tests {
         new_cairo_runner.initialize_segments(&mut new_vm, None);
 
         let fib_entrypoint = program
+            .shared_program_data
             .identifiers
             .get("__main__.evaluate_fib")
             .unwrap()
@@ -4605,6 +4608,7 @@ mod tests {
 
         //this entrypoint tells which function to run in the cairo program
         let main_entrypoint = program
+            .shared_program_data
             .identifiers
             .get("__main__.main")
             .unwrap()


### PR DESCRIPTION
Part of the same effort to reduce `CairoRunner` creation time. Breaks due to that field being public.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [x] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [x] CHANGELOG has been updated.

