### PR TITLE
fix : Fix `CairoRunner::get_memory_holes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Upcoming Changes
 
-* Fix `CairoRunner::get_memory_holes`
+* Fix `CairoRunner::get_memory_holes` [#1027](https://github.com/lambdaclass/cairo-rs/pull/1027):
 
     * Skip builtin segements when counting memory holes
     * Check amount of memory holes for all tests in cairo_run_test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 #### Upcoming Changes
 
+* Fix `CairoRunner::get_memory_holes`
+
+    * Skip builtin segements when counting memory holes
+    * Check amount of memory holes for all tests in cairo_run_test
+    * Remove duplicated tests in cairo_run_test
+
 * Add methor `Program::data_len(&self) -> usize` to get the number of data cells in a given program [#1022](https://github.com/lambdaclass/cairo-rs/pull/1022)
 
 * Add missing hint on uint256_improvements lib [#1013](https://github.com/lambdaclass/cairo-rs/pull/1013):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 #### Upcoming Changes
 
-* Fix `CairoRunner::get_memory_holes` [#1027](https://github.com/lambdaclass/cairo-rs/pull/1027):
+* BREAKING CHANGE: Fix `CairoRunner::get_memory_holes` [#1027](https://github.com/lambdaclass/cairo-rs/pull/1027):
 
   * Skip builtin segements when counting memory holes
   * Check amount of memory holes for all tests in cairo_run_test
   * Remove duplicated tests in cairo_run_test
+  * BREAKING CHANGE: `MemorySegmentManager.get_memory_holes` now also receives the amount of builtins in the vm. Signature is now `pub fn get_memory_holes(&self, builtin_count: usize) -> Result<usize, MemoryError>`
 
 * Implement hints on field_arithmetic lib[#985](https://github.com/lambdaclass/cairo-rs/pull/983)
 

--- a/cairo_programs/memory_holes.cairo
+++ b/cairo_programs/memory_holes.cairo
@@ -1,0 +1,5 @@
+func main() {
+    // Deliberately create memory holes
+    assert [ap + 5] = 1;
+    return ();
+}

--- a/src/tests/cairo_run_test.rs
+++ b/src/tests/cairo_run_test.rs
@@ -4,7 +4,7 @@ use crate::tests::*;
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn fibonacci() {
     let program_data = include_bytes!("../../cairo_programs/fibonacci.json");
-    run_program_simple(program_data.as_slice());
+    run_program_small(program_data.as_slice());
 }
 
 #[test]
@@ -82,7 +82,7 @@ fn jmp() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn jmp_if_condition() {
     let program_data = include_bytes!("../../cairo_programs/jmp_if_condition.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 1);
 }
 
 #[test]
@@ -187,14 +187,14 @@ fn compare_arrays() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn compare_greater_array() {
     let program_data = include_bytes!("../../cairo_programs/compare_greater_array.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 177);
+    run_program_simple_with_memory_holes(program_data.as_slice(), 170);
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn compare_lesser_array() {
     let program_data = include_bytes!("../../cairo_programs/compare_lesser_array.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 200);
 }
 
 #[test]
@@ -313,7 +313,7 @@ fn memset() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn pow() {
     let program_data = include_bytes!("../../cairo_programs/pow.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 6);
 }
 
 #[test]
@@ -327,14 +327,14 @@ fn dict() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn dict_update() {
     let program_data = include_bytes!("../../cairo_programs/dict_update.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 1);
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn uint256() {
     let program_data = include_bytes!("../../cairo_programs/uint256.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 3514);
 }
 
 #[test]
@@ -348,14 +348,14 @@ fn find_element() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn search_sorted_lower() {
     let program_data = include_bytes!("../../cairo_programs/search_sorted_lower.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 4);
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn usort() {
     let program_data = include_bytes!("../../cairo_programs/usort.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 3);
 }
 
 #[test]
@@ -376,7 +376,7 @@ fn dict_squash() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn set_add() {
     let program_data = include_bytes!("../../cairo_programs/set_add.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 2);
 }
 
 #[test]
@@ -388,15 +388,15 @@ fn secp() {
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn signature() {
-    let program_data = include_bytes!("../../cairo_programs/signature.json");
-    run_program_simple(program_data.as_slice());
+fn secp_ec() {
+    let program_data = include_bytes!("../../cairo_programs/secp_ec.json");
+    run_program_simple_with_memory_holes(program_data.as_slice(), 1752);
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn secp_ec() {
-    let program_data = include_bytes!("../../cairo_programs/secp_ec.json");
+fn signature() {
+    let program_data = include_bytes!("../../cairo_programs/signature.json");
     run_program_simple(program_data.as_slice());
 }
 
@@ -411,7 +411,7 @@ fn blake2s_hello_world_hash() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn finalize_blake2s() {
     let program_data = include_bytes!("../../cairo_programs/finalize_blake2s.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 20);
 }
 
 #[test]
@@ -460,21 +460,21 @@ fn keccak_copy_inputs() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn cairo_finalize_keccak() {
     let program_data = include_bytes!("../../cairo_programs/cairo_finalize_keccak.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 50);
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn operations_with_data_structures() {
     let program_data = include_bytes!("../../cairo_programs/operations_with_data_structures.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 72);
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn sha256() {
     let program_data = include_bytes!("../../cairo_programs/sha256.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 2);
 }
 
 #[test]
@@ -482,42 +482,42 @@ fn sha256() {
 fn math_cmp_and_pow_integration_tests() {
     let program_data =
         include_bytes!("../../cairo_programs/math_cmp_and_pow_integration_tests.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 1213);
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn uint256_integration_tests() {
     let program_data = include_bytes!("../../cairo_programs/uint256_integration_tests.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 1027);
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn set_integration_tests() {
     let program_data = include_bytes!("../../cairo_programs/set_integration_tests.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 20);
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn memory_integration_tests() {
     let program_data = include_bytes!("../../cairo_programs/memory_integration_tests.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 5);
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn dict_integration_tests() {
     let program_data = include_bytes!("../../cairo_programs/dict_integration_tests.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 32);
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn secp_integration_tests() {
     let program_data = include_bytes!("../../cairo_programs/secp_integration_tests.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 1752);
 }
 
 #[test]
@@ -531,7 +531,7 @@ fn keccak_integration_tests() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn blake2s_integration_tests() {
     let program_data = include_bytes!("../../cairo_programs/blake2s_integration_tests.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 409);
 }
 
 #[test]
@@ -543,9 +543,16 @@ fn relocate_segments() {
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn relocate_segments_with_offset() {
+    let program_data = include_bytes!("../../cairo_programs/relocate_segments_with_offset.json");
+    run_program_simple_with_memory_holes(program_data.as_slice(), 5);
+}
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn dict_store_cast_ptr() {
     let program_data = include_bytes!("../../cairo_programs/dict_store_cast_ptr.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 1);
 }
 
 #[test]
@@ -567,7 +574,7 @@ fn bad_usort() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn bad_dict_new() {
     let program_data = include_bytes!("../../cairo_programs/bad_programs/bad_dict_new.json");
-    let error_msg = "Dict Error: Tried to create a dict whithout an initial dict";
+    let error_msg = "Dict Error: Tried to create a dict without an initial dict";
     run_program_with_error(program_data.as_slice(), error_msg);
 }
 
@@ -612,257 +619,21 @@ fn error_msg_attr_struct() {
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_usort_bad() {
-    let program_data = include_bytes!("../../cairo_programs/bad_programs/bad_usort.json");
-    let error_msg = "unexpected verify multiplicity fail: positions length != 0";
-    run_program_with_error(program_data.as_slice(), error_msg);
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_dict_write_bad() {
-    let program_data = include_bytes!("../../cairo_programs/bad_programs/bad_dict_new.json");
-    let error_msg = "Dict Error: Tried to create a dict whithout an initial dict";
-    run_program_with_error(program_data.as_slice(), error_msg);
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_dict_update_bad() {
-    let program_data = include_bytes!("../../cairo_programs/bad_programs/bad_dict_update.json");
-    let error_msg =
-        "Dict Error: Got the wrong value for dict_update, expected value: 3, got: 5 for key: 2";
-    run_program_with_error(program_data.as_slice(), error_msg);
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_squash_dict() {
-    let program_data = include_bytes!("../../cairo_programs/squash_dict.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_dict_squash() {
-    let program_data = include_bytes!("../../cairo_programs/dict_squash.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_set_add() {
-    let program_data = include_bytes!("../../cairo_programs/set_add.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_secp() {
-    let program_data = include_bytes!("../../cairo_programs/secp.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_signature() {
-    let program_data = include_bytes!("../../cairo_programs/signature.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_secp_ec() {
-    let program_data = include_bytes!("../../cairo_programs/secp_ec.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_finalize_blake2s() {
-    let program_data = include_bytes!("../../cairo_programs/finalize_blake2s.json");
-    run_program_simple(program_data.as_slice());
-}
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_unsafe_keccak() {
-    let program_data = include_bytes!("../../cairo_programs/unsafe_keccak.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_unsafe_keccak_finalize() {
-    let program_data = include_bytes!("../../cairo_programs/unsafe_keccak_finalize.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_keccak_add_uint256() {
-    let program_data = include_bytes!("../../cairo_programs/keccak_add_uint256.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_private_keccak() {
-    let program_data = include_bytes!("../../cairo_programs/_keccak.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_keccak_copy_inputs() {
-    let program_data = include_bytes!("../../cairo_programs/keccak_copy_inputs.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_finalize_keccak() {
-    let program_data = include_bytes!("../../cairo_programs/cairo_finalize_keccak.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_operations_with_data() {
-    let program_data = include_bytes!("../../cairo_programs/operations_with_data_structures.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_sha256() {
-    let program_data = include_bytes!("../../cairo_programs/sha256.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_math_cmp_and_pow_integration() {
-    let program_data =
-        include_bytes!("../../cairo_programs/math_cmp_and_pow_integration_tests.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_uint256_integration() {
-    let program_data = include_bytes!("../../cairo_programs/uint256_integration_tests.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_set_integration() {
-    let program_data = include_bytes!("../../cairo_programs/set_integration_tests.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_memory_module_integration() {
-    let program_data = include_bytes!("../../cairo_programs/memory_integration_tests.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_dict_integration() {
-    let program_data = include_bytes!("../../cairo_programs/dict_integration_tests.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_secp_integration() {
-    let program_data = include_bytes!("../../cairo_programs/secp_integration_tests.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_keccak_integration() {
-    let program_data = include_bytes!("../../cairo_programs/keccak_integration_tests.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_blake2s_integration() {
-    let program_data = include_bytes!("../../cairo_programs/blake2s_integration_tests.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_relocate_segments() {
-    let program_data = include_bytes!("../../cairo_programs/relocate_segments.json");
-    run_program_small(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_error_msg_attr() {
-    let program_data = include_bytes!("../../cairo_programs/bad_programs/error_msg_attr.json");
-    let error_msg = "SafeUint256: addition overflow";
-    run_program_with_error(program_data.as_slice(), error_msg);
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_error_msg_attr_ap_based_reference() {
-    let program_data =
-        include_bytes!("../../cairo_programs/bad_programs/error_msg_attr_tempvar.json");
-    #[cfg(feature = "std")]
-    let error_msg = "Error message: SafeUint256: addition overflow: {x} (Cannot evaluate ap-based or complex references: ['x'])\ncairo_programs/bad_programs/error_msg_attr_tempvar.cairo:4:9: Error at pc=0:2:\nAn ASSERT_EQ instruction failed: 3 != 2.\n        assert x = 2;\n        ^***********^\n";
-    #[cfg(not(feature = "std"))]
-    let error_msg = "Error message: SafeUint256: addition overflow: {x} (Cannot evaluate ap-based or complex references: ['x'])\ncairo_programs/bad_programs/error_msg_attr_tempvar.cairo:4:9: Error at pc=0:2:\nAn ASSERT_EQ instruction failed: 3 != 2.\n";
-    run_program_with_error(program_data.as_slice(), error_msg);
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_error_msg_attr_complex_reference() {
-    let program_data =
-        include_bytes!("../../cairo_programs/bad_programs/error_msg_attr_struct.json");
-    let error_msg = "Error message: Cats cannot have more than nine lives: {cat} (Cannot evaluate ap-based or complex references: ['cat'])";
-    run_program_with_error(program_data.as_slice(), error_msg);
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_dict_store_cast_pointer() {
-    let program_data = include_bytes!("../../cairo_programs/dict_store_cast_ptr.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_verify_signature_hint() {
-    let program_data = include_bytes!("../../cairo_programs/common_signature.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_poseidon_builtin() {
+fn poseidon_builtin() {
     let program_data = include_bytes!("../../cairo_programs/poseidon_builtin.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_ec_op() {
+fn ec_op() {
     let program_data = include_bytes!("../../cairo_programs/ec_op.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_poseidon_hash() {
+fn poseidon_hash() {
     let program_data = include_bytes!("../../cairo_programs/poseidon_hash.json");
     run_program_simple(program_data.as_slice());
 }
@@ -876,140 +647,140 @@ fn cairo_chained_run_ec_op() {
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_keccak_builtin() {
+fn keccak_builtin() {
     let program_data = include_bytes!("../../cairo_programs/keccak_builtin.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_keccak_uint256() {
+fn keccak_uint256() {
     let program_data = include_bytes!("../../cairo_programs/keccak_uint256.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_recover_y() {
+fn recover_y() {
     let program_data = include_bytes!("../../cairo_programs/recover_y.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_math_integration() {
+fn math_integration() {
     let program_data = include_bytes!("../../cairo_programs/math_integration_tests.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 109);
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_is_quad_residue_test() {
+fn is_quad_residue_test() {
     let program_data = include_bytes!("../../cairo_programs/is_quad_residue_test.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 6);
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_mul_s_inv() {
+fn mul_s_inv() {
     let program_data = include_bytes!("../../cairo_programs/mul_s_inv.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_keccak_alternative_hint() {
+fn keccak_alternative_hint() {
     let program_data = include_bytes!("../../cairo_programs/_keccak_alternative_hint.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 23);
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_uint384() {
+fn uint384() {
     let program_data = include_bytes!("../../cairo_programs/uint384.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 74);
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_uint384_extension() {
+fn uint384_extension() {
     let program_data = include_bytes!("../../cairo_programs/uint384_extension.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 20);
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_ed25519_field() {
+fn ed25519_field() {
     let program_data = include_bytes!("../../cairo_programs/ed25519_field.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_ed25519_ec() {
+fn ed25519_ec() {
     let program_data = include_bytes!("../../cairo_programs/ed25519_ec.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_efficient_secp256r1_ec() {
+fn efficient_secp256r1_ec() {
     let program_data = include_bytes!("../../cairo_programs/efficient_secp256r1_ec.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_garaga() {
+fn garaga() {
     let program_data = include_bytes!("../../cairo_programs/garaga.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_div_mod_n() {
+fn div_mod_n() {
     let program_data = include_bytes!("../../cairo_programs/div_mod_n.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_is_zero() {
+fn is_zero() {
     let program_data = include_bytes!("../../cairo_programs/is_zero.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_is_zero_pack() {
+fn is_zero_pack() {
     let program_data = include_bytes!("../../cairo_programs/is_zero_pack.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_n_bit() {
+fn n_bit() {
     let program_data = include_bytes!("../../cairo_programs/n_bit.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_highest_bitlen() {
+fn highest_bitlen() {
     let program_data = include_bytes!("../../cairo_programs/highest_bitlen.json");
     run_program_simple(program_data.as_slice());
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_uint256_improvements() {
+fn uint256_improvements() {
     let program_data = include_bytes!("../../cairo_programs/uint256_improvements.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 40);
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_memory_holes() {
+fn memory_holes() {
     let program_data = include_bytes!("../../cairo_programs/memory_holes.json");
-    run_program(program_data, Some("all_cairo"), None, None, Some(5))
+    run_program_simple_with_memory_holes(program_data.as_slice(), 5)
 }

--- a/src/tests/cairo_run_test.rs
+++ b/src/tests/cairo_run_test.rs
@@ -446,7 +446,7 @@ fn keccak_add_uint256() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn keccak() {
     let program_data = include_bytes!("../../cairo_programs/_keccak.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 21);
 }
 
 #[test]
@@ -517,14 +517,14 @@ fn dict_integration_tests() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn secp_integration_tests() {
     let program_data = include_bytes!("../../cairo_programs/secp_integration_tests.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 1752);
+    run_program_simple_with_memory_holes(program_data.as_slice(), 4626);
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn keccak_integration_tests() {
     let program_data = include_bytes!("../../cairo_programs/keccak_integration_tests.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 507);
 }
 
 #[test]

--- a/src/tests/cairo_run_test.rs
+++ b/src/tests/cairo_run_test.rs
@@ -782,7 +782,7 @@ fn highest_bitlen() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn uint256_improvements() {
     let program_data = include_bytes!("../../cairo_programs/uint256_improvements.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 40);
+    run_program_simple_with_memory_holes(program_data.as_slice(), 108);
 }
 
 #[test]

--- a/src/tests/cairo_run_test.rs
+++ b/src/tests/cairo_run_test.rs
@@ -1378,3 +1378,10 @@ fn cairo_run_uint256_improvements() {
     let program_data = include_bytes!("../../cairo_programs/uint256_improvements.json");
     run_program_simple(program_data.as_slice());
 }
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn cairo_run_memory_holes() {
+    let program_data = include_bytes!("../../cairo_programs/memory_holes.json");
+    run_program(program_data, Some("all_cairo"), None, None, Some(4))
+}

--- a/src/tests/cairo_run_test.rs
+++ b/src/tests/cairo_run_test.rs
@@ -1383,5 +1383,5 @@ fn cairo_run_uint256_improvements() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn cairo_run_memory_holes() {
     let program_data = include_bytes!("../../cairo_programs/memory_holes.json");
-    run_program(program_data, Some("all_cairo"), None, None, Some(4))
+    run_program(program_data, Some("all_cairo"), None, None, Some(5))
 }

--- a/src/tests/cairo_run_test.rs
+++ b/src/tests/cairo_run_test.rs
@@ -187,7 +187,7 @@ fn compare_arrays() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn compare_greater_array() {
     let program_data = include_bytes!("../../cairo_programs/compare_greater_array.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 177);
 }
 
 #[test]
@@ -201,7 +201,7 @@ fn compare_lesser_array() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn assert_le_felt_hint() {
     let program_data = include_bytes!("../../cairo_programs/assert_le_felt_hint.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 2);
 }
 
 #[test]
@@ -271,7 +271,7 @@ fn split_felt() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn math_cmp() {
     let program_data = include_bytes!("../../cairo_programs/math_cmp.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 372);
 }
 
 #[test]
@@ -292,7 +292,7 @@ fn signed_div_rem() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn assert_lt_felt() {
     let program_data = include_bytes!("../../cairo_programs/assert_lt_felt.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 8);
 }
 
 #[test]
@@ -320,7 +320,7 @@ fn pow() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn dict() {
     let program_data = include_bytes!("../../cairo_programs/dict.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 4);
 }
 
 #[test]
@@ -404,7 +404,7 @@ fn secp_ec() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn blake2s_hello_world_hash() {
     let program_data = include_bytes!("../../cairo_programs/blake2s_hello_world_hash.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 20);
 }
 
 #[test]
@@ -425,7 +425,7 @@ fn unsafe_keccak() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn blake2s_felts() {
     let program_data = include_bytes!("../../cairo_programs/blake2s_felts.json");
-    run_program_simple(program_data.as_slice());
+    run_program_simple_with_memory_holes(program_data.as_slice(), 139);
 }
 
 #[test]
@@ -612,364 +612,6 @@ fn error_msg_attr_struct() {
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_test() {
-    let program_data = include_bytes!("../../cairo_programs/fibonacci.json");
-    run_program_small(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_array_sum() {
-    let program_data = include_bytes!("../../cairo_programs/array_sum.json");
-    run_program_small(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_big_struct() {
-    let program_data = include_bytes!("../../cairo_programs/big_struct.json");
-    run_program_small(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_call_function_assign_param_by_name() {
-    let program_data =
-        include_bytes!("../../cairo_programs/call_function_assign_param_by_name.json");
-    run_program_small(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_function_return() {
-    let program_data = include_bytes!("../../cairo_programs/function_return.json");
-    run_program_small(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_function_return_if_print() {
-    let program_data = include_bytes!("../../cairo_programs/function_return_if_print.json");
-    run_program_small(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_function_return_to_variable() {
-    let program_data = include_bytes!("../../cairo_programs/function_return_to_variable.json");
-    run_program_small(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_if_and_prime() {
-    let program_data = include_bytes!("../../cairo_programs/if_and_prime.json");
-    run_program_small(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_if_in_function() {
-    let program_data = include_bytes!("../../cairo_programs/if_in_function.json");
-    run_program_small(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_if_list() {
-    let program_data = include_bytes!("../../cairo_programs/if_list.json");
-    run_program_small(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_jmp() {
-    let program_data = include_bytes!("../../cairo_programs/jmp.json");
-    run_program_small(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_jmp_if_condition() {
-    let program_data = include_bytes!("../../cairo_programs/jmp_if_condition.json");
-    run_program_small(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_pointers() {
-    let program_data = include_bytes!("../../cairo_programs/pointers.json");
-    run_program_small(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_print() {
-    let program_data = include_bytes!("../../cairo_programs/print.json");
-    run_program_small(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_return() {
-    let program_data = include_bytes!("../../cairo_programs/return.json");
-    run_program_small(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_reversed_register_instructions() {
-    let program_data = include_bytes!("../../cairo_programs/reversed_register_instructions.json");
-    run_program_small(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_simple_print() {
-    let program_data = include_bytes!("../../cairo_programs/simple_print.json");
-    run_program_small(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_test_addition_if() {
-    let program_data = include_bytes!("../../cairo_programs/test_addition_if.json");
-    run_program_small(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_test_reverse_if() {
-    let program_data = include_bytes!("../../cairo_programs/test_reverse_if.json");
-    run_program_small(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_test_subtraction_if() {
-    let program_data = include_bytes!("../../cairo_programs/test_subtraction_if.json");
-    run_program_small(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_use_imported_module() {
-    let program_data = include_bytes!("../../cairo_programs/use_imported_module.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_bitwise_output() {
-    let program_data = include_bytes!("../../cairo_programs/bitwise_output.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_bitwise_recursion() {
-    let program_data = include_bytes!("../../cairo_programs/bitwise_recursion.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_integration() {
-    let program_data = include_bytes!("../../cairo_programs/integration.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_integration_with_alloc_locals() {
-    let program_data = include_bytes!("../../cairo_programs/integration_with_alloc_locals.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_compare_arrays() {
-    let program_data = include_bytes!("../../cairo_programs/compare_arrays.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_compare_greater_array() {
-    let program_data = include_bytes!("../../cairo_programs/compare_greater_array.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_compare_lesser_array() {
-    let program_data = include_bytes!("../../cairo_programs/compare_lesser_array.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_assert_le_felt_hint() {
-    let program_data = include_bytes!("../../cairo_programs/assert_le_felt_hint.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_assert_250_bit_element_array() {
-    let program_data = include_bytes!("../../cairo_programs/assert_250_bit_element_array.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_abs_value() {
-    let program_data = include_bytes!("../../cairo_programs/abs_value_array.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_compare_different_arrays() {
-    let program_data = include_bytes!("../../cairo_programs/compare_different_arrays.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_assert_nn() {
-    let program_data = include_bytes!("../../cairo_programs/assert_nn.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_sqrt() {
-    let program_data = include_bytes!("../../cairo_programs/sqrt.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_assert_not_zero() {
-    let program_data = include_bytes!("../../cairo_programs/assert_not_zero.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_split_int() {
-    let program_data = include_bytes!("../../cairo_programs/split_int.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_split_int_big() {
-    let program_data = include_bytes!("../../cairo_programs/split_int_big.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_split_felt() {
-    let program_data = include_bytes!("../../cairo_programs/split_felt.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_math_cmp() {
-    let program_data = include_bytes!("../../cairo_programs/math_cmp.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_unsigned_div_rem() {
-    let program_data = include_bytes!("../../cairo_programs/unsigned_div_rem.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_signed_div_rem() {
-    let program_data = include_bytes!("../../cairo_programs/signed_div_rem.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_assert_lt_felt() {
-    let program_data = include_bytes!("../../cairo_programs/assert_lt_felt.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_memcpy() {
-    let program_data = include_bytes!("../../cairo_programs/memcpy_test.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_memset() {
-    let program_data = include_bytes!("../../cairo_programs/memset.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_pow() {
-    let program_data = include_bytes!("../../cairo_programs/pow.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_dict() {
-    let program_data = include_bytes!("../../cairo_programs/dict.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_dict_update() {
-    let program_data = include_bytes!("../../cairo_programs/dict_update.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_uint256() {
-    let program_data = include_bytes!("../../cairo_programs/uint256.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_find_element() {
-    let program_data = include_bytes!("../../cairo_programs/find_element.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_search_sorted_lower() {
-    let program_data = include_bytes!("../../cairo_programs/search_sorted_lower.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_usort() {
-    let program_data = include_bytes!("../../cairo_programs/usort.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn cairo_run_usort_bad() {
     let program_data = include_bytes!("../../cairo_programs/bad_programs/bad_usort.json");
     let error_msg = "unexpected verify multiplicity fail: positions length != 0";
@@ -1037,13 +679,6 @@ fn cairo_run_secp_ec() {
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_blake2s_hello_world_hash() {
-    let program_data = include_bytes!("../../cairo_programs/blake2s_hello_world_hash.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn cairo_run_finalize_blake2s() {
     let program_data = include_bytes!("../../cairo_programs/finalize_blake2s.json");
     run_program_simple(program_data.as_slice());
@@ -1052,13 +687,6 @@ fn cairo_run_finalize_blake2s() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn cairo_run_unsafe_keccak() {
     let program_data = include_bytes!("../../cairo_programs/unsafe_keccak.json");
-    run_program_simple(program_data.as_slice());
-}
-
-#[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn cairo_run_blake2s_felts() {
-    let program_data = include_bytes!("../../cairo_programs/blake2s_felts.json");
     run_program_simple(program_data.as_slice());
 }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -6,7 +6,6 @@ use crate::{
     vm::trace::trace_entry::TraceEntry,
 };
 
-use num_traits::Zero;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_test::*;
 
@@ -20,20 +19,20 @@ mod skip_instruction_test;
 
 //For simple programs that should just succeed and have no special needs.
 pub(self) fn run_program_simple(data: &[u8]) {
-    run_program(data, Some("all_cairo"), None, None)
+    run_program(data, Some("all_cairo"), None, None, Some(0))
 }
 
 //For simple programs that should just succeed but using small layout.
 pub(self) fn run_program_small(data: &[u8]) {
-    run_program(data, Some("small"), None, None)
+    run_program(data, Some("small"), None, None, Some(0))
 }
 
 pub(self) fn run_program_with_trace(data: &[u8], trace: &[(usize, usize, usize)]) {
-    run_program(data, Some("all_cairo"), Some(trace), None)
+    run_program(data, Some("all_cairo"), Some(trace), None, Some(0))
 }
 
 pub(self) fn run_program_with_error(data: &[u8], error: &str) {
-    run_program(data, Some("all_cairo"), None, Some(error))
+    run_program(data, Some("all_cairo"), None, Some(error), Some(0))
 }
 
 pub(self) fn run_program(
@@ -41,6 +40,7 @@ pub(self) fn run_program(
     layout: Option<&str>,
     trace: Option<&[(usize, usize, usize)]>,
     error: Option<&str>,
+    memory_holes: Option<usize>,
 ) {
     let mut hint_executor = BuiltinHintProcessor::new_empty();
     let cairo_run_config = CairoRunConfig {
@@ -68,6 +68,7 @@ pub(self) fn run_program(
             assert_eq!(entry, expected);
         }
     }
-    // Check there are no memory holes
-    assert!(runner.get_memory_holes(&vm).unwrap().is_zero());
+    if let Some(holes) = memory_holes {
+        assert_eq!(runner.get_memory_holes(&vm).unwrap(), holes);
+    }
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -18,21 +18,28 @@ mod struct_test;
 mod skip_instruction_test;
 
 //For simple programs that should just succeed and have no special needs.
+//Checks memory holes == 0
 pub(self) fn run_program_simple(data: &[u8]) {
     run_program(data, Some("all_cairo"), None, None, Some(0))
 }
 
+//For simple programs that should just succeed and have no special needs.
+//Checks memory holes
+pub(self) fn run_program_simple_with_memory_holes(data: &[u8], holes: usize) {
+    run_program(data, Some("all_cairo"), None, None, Some(holes))
+}
+
 //For simple programs that should just succeed but using small layout.
 pub(self) fn run_program_small(data: &[u8]) {
-    run_program(data, Some("small"), None, None, Some(0))
+    run_program(data, Some("small"), None, None, None)
 }
 
 pub(self) fn run_program_with_trace(data: &[u8], trace: &[(usize, usize, usize)]) {
-    run_program(data, Some("all_cairo"), Some(trace), None, Some(0))
+    run_program(data, Some("all_cairo"), Some(trace), None, None)
 }
 
 pub(self) fn run_program_with_error(data: &[u8], error: &str) {
-    run_program(data, Some("all_cairo"), None, Some(error), Some(0))
+    run_program(data, Some("all_cairo"), None, Some(error), None)
 }
 
 pub(self) fn run_program(

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -6,6 +6,7 @@ use crate::{
     vm::trace::trace_entry::TraceEntry,
 };
 
+use num_traits::Zero;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_test::*;
 
@@ -54,7 +55,7 @@ pub(self) fn run_program(
         assert!(res.err().unwrap().to_string().contains(error));
         return;
     }
-    let (_runner, vm) = res.expect("Execution failed");
+    let (runner, vm) = res.expect("Execution failed");
     if let Some(trace) = trace {
         let expected_trace: Vec<_> = trace
             .iter()
@@ -67,4 +68,6 @@ pub(self) fn run_program(
             assert_eq!(entry, expected);
         }
     }
+    // Check there are no memory holes
+    assert!(runner.get_memory_holes(&vm).unwrap().is_zero());
 }

--- a/src/vm/errors/hint_errors.rs
+++ b/src/vm/errors/hint_errors.rs
@@ -73,7 +73,7 @@ pub enum HintError {
     InvalidTrackingGroup(usize, usize),
     #[error("Expected relocatable for ap, got {0}")]
     InvalidApValue(MaybeRelocatable),
-    #[error("Dict Error: Tried to create a dict whithout an initial dict")]
+    #[error("Dict Error: Tried to create a dict without an initial dict")]
     NoInitialDict,
     #[error("squash_dict_inner fail: couldnt find key {0} in accesses_indices")]
     NoKeyInAccessIndices(Felt252),

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -4540,8 +4540,8 @@ mod tests {
             .initialize_function_runner(&mut vm, false)
             .unwrap();
 
-        assert_matches!(
-            cairo_runner.run_from_entrypoint(
+        assert!(cairo_runner
+            .run_from_entrypoint(
                 main_entrypoint,
                 &[
                     &MaybeRelocatable::from((2, 0)).into() //bitwise_ptr
@@ -4550,9 +4550,8 @@ mod tests {
                 None,
                 &mut vm,
                 &mut hint_processor,
-            ),
-            Ok(())
-        );
+            )
+            .is_ok());
 
         // Check that memory_holes == 0
         assert!(cairo_runner.get_memory_holes(&vm).unwrap().is_zero());

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -4529,7 +4529,8 @@ mod tests {
 
         //this entrypoint tells which function to run in the cairo program
         let main_entrypoint = program
-            .shared_program_data.identifiers
+            .shared_program_data
+            .identifiers
             .get("__main__.main")
             .unwrap()
             .pc

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -642,7 +642,7 @@ impl CairoRunner {
 
     /// Count the number of holes present in the segments.
     pub fn get_memory_holes(&self, vm: &VirtualMachine) -> Result<usize, MemoryError> {
-        vm.segments.get_memory_holes()
+        vm.segments.get_memory_holes(vm.builtin_runners.len())
     }
 
     /// Check if there are enough trace cells to fill the entire diluted checks.

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -4485,9 +4485,9 @@ mod tests {
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    fn run_from_entrypoint_duck_duck() {
+    fn run_from_entrypoint_bitwise_test_check_memory_holes() {
         let program = Program::from_bytes(
-            include_bytes!("../../../cairo_programs/xor_func.json"),
+            include_bytes!("../../../cairo_programs/bitwise_builtin_test.json"),
             None,
         )
         .unwrap();
@@ -4498,7 +4498,7 @@ mod tests {
         //this entrypoint tells which function to run in the cairo program
         let main_entrypoint = program
             .identifiers
-            .get("__main__.xor_counters")
+            .get("__main__.main")
             .unwrap()
             .pc
             .unwrap();
@@ -4507,18 +4507,12 @@ mod tests {
             .initialize_function_runner(&mut vm, false)
             .unwrap();
 
-        vm.mark_address_range_as_accessed(
-            cairo_runner.program_base.unwrap(),
-            cairo_runner.program.data_len(),
-        )
-        .unwrap();
         assert_matches!(
             cairo_runner.run_from_entrypoint(
                 main_entrypoint,
                 &[
-                    &mayberelocatable!(2).into(),
-                    &MaybeRelocatable::from((2, 0)).into()
-                ], //bitwise_ptr
+                    &MaybeRelocatable::from((2, 0)).into() //bitwise_ptr
+                ],
                 true,
                 None,
                 &mut vm,
@@ -4527,8 +4521,8 @@ mod tests {
             Ok(())
         );
 
-        let memory_holes = cairo_runner.get_memory_holes(&vm).unwrap();
-        dbg!(&memory_holes);
+        // Check that memory_holes == 0
+        assert!(cairo_runner.get_memory_holes(&vm).unwrap().is_zero());
     }
 
     #[test]

--- a/src/vm/vm_memory/memory_segments.rs
+++ b/src/vm/vm_memory/memory_segments.rs
@@ -191,7 +191,7 @@ impl MemorySegmentManager {
         for i in 0..data.len() {
             // Instead of marking all of the builtin segment's address as accessed, we just skip them when counting memory holes
             if i > builtin_segments_start || i < builtin_segments_end {
-                continue
+                continue;
             }
             let accessed_amount = match self.memory.get_amount_of_accessed_addresses_for_segment(i)
             {

--- a/src/vm/vm_memory/memory_segments.rs
+++ b/src/vm/vm_memory/memory_segments.rs
@@ -184,13 +184,13 @@ impl MemorySegmentManager {
     pub fn get_memory_holes(&self, builtin_count: usize) -> Result<usize, MemoryError> {
         let data = &self.memory.data;
         let mut memory_holes = 0;
-        let builtin_segments_start = 2; // program segment + execution segment
+        let builtin_segments_start = 1; // program segment + execution segment
         let builtin_segments_end = builtin_segments_start + builtin_count;
         // Count the memory holes for each segment by substracting the amount of accessed_addresses from the segment's size
         // Segments without accesses addresses are not accounted for when counting memory holes
         for i in 0..data.len() {
             // Instead of marking all of the builtin segment's address as accessed, we just skip them when counting memory holes
-            if i > builtin_segments_start && i < builtin_segments_end {
+            if i > builtin_segments_start && i <= builtin_segments_end {
                 continue;
             }
             let accessed_amount = match self.memory.get_amount_of_accessed_addresses_for_segment(i)

--- a/src/vm/vm_memory/memory_segments.rs
+++ b/src/vm/vm_memory/memory_segments.rs
@@ -190,7 +190,7 @@ impl MemorySegmentManager {
         // Segments without accesses addresses are not accounted for when counting memory holes
         for i in 0..data.len() {
             // Instead of marking all of the builtin segment's address as accessed, we just skip them when counting memory holes
-            if i > builtin_segments_start || i < builtin_segments_end {
+            if i > builtin_segments_start && i < builtin_segments_end {
                 continue;
             }
             let accessed_amount = match self.memory.get_amount_of_accessed_addresses_for_segment(i)

--- a/src/vm/vm_memory/memory_segments.rs
+++ b/src/vm/vm_memory/memory_segments.rs
@@ -181,12 +181,18 @@ impl MemorySegmentManager {
         }
     }
 
-    pub fn get_memory_holes(&self) -> Result<usize, MemoryError> {
+    pub fn get_memory_holes(&self, builtin_count: usize) -> Result<usize, MemoryError> {
         let data = &self.memory.data;
         let mut memory_holes = 0;
+        let builtin_segments_start = 2; // program segment + execution segment
+        let builtin_segments_end = builtin_segments_start + builtin_count;
         // Count the memory holes for each segment by substracting the amount of accessed_addresses from the segment's size
         // Segments without accesses addresses are not accounted for when counting memory holes
         for i in 0..data.len() {
+            // Instead of marking all of the builtin segment's address as accessed, we just skip them when counting memory holes
+            if i > builtin_segments_start || i < builtin_segments_end {
+                continue
+            }
             let accessed_amount = match self.memory.get_amount_of_accessed_addresses_for_segment(i)
             {
                 Some(accessed_amount) if accessed_amount > 0 => accessed_amount,
@@ -594,7 +600,7 @@ mod tests {
             .memory
             .mark_as_accessed((0, 0).into());
         assert_eq!(
-            memory_segment_manager.get_memory_holes(),
+            memory_segment_manager.get_memory_holes(0),
             Err(MemoryError::MissingSegmentUsedSizes),
         );
     }
@@ -611,7 +617,7 @@ mod tests {
                 .mark_as_accessed((0, i).into());
         }
         assert_eq!(
-            memory_segment_manager.get_memory_holes(),
+            memory_segment_manager.get_memory_holes(0),
             Err(MemoryError::SegmentHasMoreAccessedAddressesThanSize(
                 0, 3, 2
             )),
@@ -623,7 +629,7 @@ mod tests {
     fn get_memory_holes_empty() {
         let mut memory_segment_manager = MemorySegmentManager::new();
         memory_segment_manager.segment_used_sizes = Some(Vec::new());
-        assert_eq!(memory_segment_manager.get_memory_holes(), Ok(0),);
+        assert_eq!(memory_segment_manager.get_memory_holes(0), Ok(0),);
     }
 
     #[test]
@@ -631,7 +637,7 @@ mod tests {
     fn get_memory_holes_empty2() {
         let mut memory_segment_manager = MemorySegmentManager::new();
         memory_segment_manager.segment_used_sizes = Some(vec![4]);
-        assert_eq!(memory_segment_manager.get_memory_holes(), Ok(0),);
+        assert_eq!(memory_segment_manager.get_memory_holes(0), Ok(0),);
     }
 
     #[test]
@@ -654,7 +660,7 @@ mod tests {
                 .memory
                 .mark_as_accessed((0, i).into());
         }
-        assert_eq!(memory_segment_manager.get_memory_holes(), Ok(2),);
+        assert_eq!(memory_segment_manager.get_memory_holes(0), Ok(2),);
     }
 
     #[test]
@@ -679,7 +685,7 @@ mod tests {
                 .memory
                 .mark_as_accessed((0, i).into());
         }
-        assert_eq!(memory_segment_manager.get_memory_holes(), Ok(7),);
+        assert_eq!(memory_segment_manager.get_memory_holes(0), Ok(7),);
     }
 
     #[test]


### PR DESCRIPTION
This PR aims to fix the `get_memory_holes` method which was uncorreclty counting memory holes for builtin segments.
In the python VM, all addresses in the builtin's segment are marked as accessed before counting memory holes. In this PR, builtin segments are skipped when counting memory holes instead.

Changes:

-    Skip builtin segements when counting memory holes

- Check amount of memory holes for all tests in cairo_run_test

-  Remove duplicated tests in cairo_run_test


## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [x] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [x] CHANGELOG has been updated.

