### PR TITLE
ci: bash is not happy without space between ! and command

### DIFF
--- a/.github/workflows/hyperfine.yml
+++ b/.github/workflows/hyperfine.yml
@@ -141,7 +141,7 @@ jobs:
           BINS=head
           for f in head_programs/*.json; do
             # Only run new or modified benchmarks
-            if !cmp -s ${f/head/base} $f; then
+            if ! cmp -s ${f/head/base} $f; then
               cp $f target_programs/
             fi
           done


### PR DESCRIPTION
The hyperfine workflow was silently failing a comparison between files because bash interprets `!cmp` as a single expression rather than the negation of `cmp`. Added the missing space.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

