### PR TITLE
feat(hints): add NewHint#51

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,6 +240,46 @@
         ids.res.high = res_split[1]
     ```
 
+* Implement hint on vrf.json lib [#1049](https://github.com/lambdaclass/cairo-rs/pull/1049)
+
+    `BuiltinHintProcessor` now supports the following hint:
+    
+    ```python
+        def split(num: int, num_bits_shift: int, length: int):
+            a = []
+            for _ in range(length):
+                a.append( num & ((1 << num_bits_shift) - 1) )
+                num = num >> num_bits_shift
+            return tuple(a)
+
+        def pack(z, num_bits_shift: int) -> int:
+            limbs = (z.d0, z.d1, z.d2)
+            return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))
+
+        def pack_extended(z, num_bits_shift: int) -> int:
+            limbs = (z.d0, z.d1, z.d2, z.d3, z.d4, z.d5)
+            return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))
+
+        a = pack_extended(ids.a, num_bits_shift = 128)
+        div = pack(ids.div, num_bits_shift = 128)
+
+        quotient, remainder = divmod(a, div)
+
+        quotient_split = split(quotient, num_bits_shift=128, length=6)
+
+        ids.quotient.d0 = quotient_split[0]
+        ids.quotient.d1 = quotient_split[1]
+        ids.quotient.d2 = quotient_split[2]
+        ids.quotient.d3 = quotient_split[3]
+        ids.quotient.d4 = quotient_split[4]
+        ids.quotient.d5 = quotient_split[5]
+
+        remainder_split = split(remainder, num_bits_shift=128, length=3)
+        ids.remainder.d0 = remainder_split[0]
+        ids.remainder.d1 = remainder_split[1]
+        ids.remainder.d2 = remainder_split[2]
+    ```
+
 * Add missing hint on vrf.json lib [#1030](https://github.com/lambdaclass/cairo-rs/pull/1030):
 
     `BuiltinHintProcessor` now supports the following hint:
@@ -350,13 +390,13 @@
             a = []
             for _ in range(length):
                 a.append( num & ((1 << num_bits_shift) - 1) )
-                num = num >> num_bits_shift
+                num = num >> num_bits_shift 
             return tuple(a)
 
         def pack(z, num_bits_shift: int) -> int:
             limbs = (z.d0, z.d1, z.d2)
             return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))
-
+            
         def pack_extended(z, num_bits_shift: int) -> int:
             limbs = (z.d0, z.d1, z.d2, z.d3, z.d4, z.d5)
             return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -342,6 +342,8 @@
         ids.remainder.d2 = remainder_split[2]
     ```
 
+    _Note: this hint is similar to the one in #983, but with some trailing whitespace removed_
+
 * Add missing hint on vrf.json lib [#1030](https://github.com/lambdaclass/cairo-rs/pull/1030):
 
     `BuiltinHintProcessor` now supports the following hint:

--- a/cairo_programs/uint384_extension_test.cairo
+++ b/cairo_programs/uint384_extension_test.cairo
@@ -20,7 +20,26 @@ func test_uint384_extension_operations{range_check_ptr}() {
     return ();
 }
 
+func test_uint384_unsigned_div_rem_alt{range_check_ptr}() {
+    // Test unsigned_div_rem_uint768_by_uint384
+    let a = Uint768(1, 2, 3, 4, 5, 6);
+    let div = Uint384(6, 7, 8);
+    let (q, r) = u384_ext.unsigned_div_rem_uint768_by_uint384_alt(a, div);
+    assert q.d0 = 328319314958874220607240343889245110272;
+    assert q.d1 = 329648542954659136480144150949525454847;
+    assert q.d2 = 255211775190703847597530955573826158591;
+    assert q.d3 = 0;
+    assert q.d4 = 0;
+    assert q.d5 = 0;
+
+    assert r.d0 = 71778311772385457136805581255138607105;
+    assert r.d1 = 147544307532125661892322583691118247938;
+    assert r.d2 = 3;
+    return ();
+}
+
 func main{range_check_ptr: felt}() {
     test_uint384_extension_operations();
+    test_uint384_unsigned_div_rem_alt();
     return ();
 }

--- a/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -570,7 +570,8 @@ impl HintProcessor for BuiltinHintProcessor {
             hint_code::UINT384_SQRT => {
                 uint384_sqrt(vm, &hint_data.ids_data, &hint_data.ap_tracking)
             }
-            hint_code::UNSIGNED_DIV_REM_UINT768_BY_UINT384 => {
+            hint_code::UNSIGNED_DIV_REM_UINT768_BY_UINT384
+            | hint_code::UNSIGNED_DIV_REM_UINT768_BY_UINT384_STRIPPED => {
                 unsigned_div_rem_uint768_by_uint384(vm, &hint_data.ids_data, &hint_data.ap_tracking)
             }
             hint_code::GET_SQUARE_ROOT => {

--- a/src/hint_processor/builtin_hint_processor/hint_code.rs
+++ b/src/hint_processor/builtin_hint_processor/hint_code.rs
@@ -858,6 +858,7 @@ root_split = split(root, num_bits_shift=128, length=3)
 ids.root.d0 = root_split[0]
 ids.root.d1 = root_split[1]
 ids.root.d2 = root_split[2]";
+
 pub const UNSIGNED_DIV_REM_UINT768_BY_UINT384: &str =
     "def split(num: int, num_bits_shift: int, length: int):
     a = []
@@ -892,6 +893,43 @@ remainder_split = split(remainder, num_bits_shift=128, length=3)
 ids.remainder.d0 = remainder_split[0]
 ids.remainder.d1 = remainder_split[1]
 ids.remainder.d2 = remainder_split[2]";
+
+// equal to UNSIGNED_DIV_REM_UINT768_BY_UINT384 but with some whitespace removed
+// in the `num = num >> num_bits_shift` and between `pack` and `pack_extended`
+pub const UNSIGNED_DIV_REM_UINT768_BY_UINT384_STRIPPED: &str = r#"def split(num: int, num_bits_shift: int, length: int):
+    a = []
+    for _ in range(length):
+        a.append( num & ((1 << num_bits_shift) - 1) )
+        num = num >> num_bits_shift
+    return tuple(a)
+
+def pack(z, num_bits_shift: int) -> int:
+    limbs = (z.d0, z.d1, z.d2)
+    return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))
+
+def pack_extended(z, num_bits_shift: int) -> int:
+    limbs = (z.d0, z.d1, z.d2, z.d3, z.d4, z.d5)
+    return sum(limb << (num_bits_shift * i) for i, limb in enumerate(limbs))
+
+a = pack_extended(ids.a, num_bits_shift = 128)
+div = pack(ids.div, num_bits_shift = 128)
+
+quotient, remainder = divmod(a, div)
+
+quotient_split = split(quotient, num_bits_shift=128, length=6)
+
+ids.quotient.d0 = quotient_split[0]
+ids.quotient.d1 = quotient_split[1]
+ids.quotient.d2 = quotient_split[2]
+ids.quotient.d3 = quotient_split[3]
+ids.quotient.d4 = quotient_split[4]
+ids.quotient.d5 = quotient_split[5]
+
+remainder_split = split(remainder, num_bits_shift=128, length=3)
+ids.remainder.d0 = remainder_split[0]
+ids.remainder.d1 = remainder_split[1]
+ids.remainder.d2 = remainder_split[2]"#;
+
 pub const UINT384_SIGNED_NN: &str = "memory[ap] = 1 if 0 <= (ids.a.d2 % PRIME) < 2 ** 127 else 0";
 
 pub(crate) const GET_SQUARE_ROOT: &str =

--- a/src/hint_processor/builtin_hint_processor/uint384_extension.rs
+++ b/src/hint_processor/builtin_hint_processor/uint384_extension.rs
@@ -177,6 +177,7 @@ mod tests {
 
     use felt::felt_str;
     use num_traits::One;
+    use rstest::rstest;
     #[cfg(target_arch = "wasm32")]
     use wasm_bindgen_test::*;
 
@@ -298,9 +299,11 @@ mod tests {
         assert_matches!(r, Err(HintError::UnknownIdentifier(x)) if x == "x")
     }
 
-    #[test]
+    #[rstest]
+    #[case(hint_code::UNSIGNED_DIV_REM_UINT768_BY_UINT384)]
+    #[case(hint_code::UNSIGNED_DIV_REM_UINT768_BY_UINT384_STRIPPED)]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    fn run_unsigned_div_rem_ok() {
+    fn run_unsigned_div_rem_ok(#[case] hint_code: &str) {
         let mut vm = vm_with_range_check!();
         //Initialize fp
         vm.run_context.fp = 17;
@@ -326,10 +329,7 @@ mod tests {
             ((1, 8), 8)
         ];
         //Execute the hint
-        assert_matches!(
-            run_hint!(vm, ids_data, hint_code::UNSIGNED_DIV_REM_UINT768_BY_UINT384),
-            Ok(())
-        );
+        assert_matches!(run_hint!(vm, ids_data, hint_code), Ok(()));
         //Check hint memory inserts
         check_memory![
             vm.segments.memory,
@@ -371,9 +371,11 @@ mod tests {
         );
     }
 
-    #[test]
+    #[rstest]
+    #[case(hint_code::UNSIGNED_DIV_REM_UINT768_BY_UINT384)]
+    #[case(hint_code::UNSIGNED_DIV_REM_UINT768_BY_UINT384_STRIPPED)]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-    fn run_unsigned_div_rem_divide_by_zero() {
+    fn run_unsigned_div_rem_divide_by_zero(#[case] hint_code: &str) {
         let mut vm = vm_with_range_check!();
         //Initialize fp
         vm.run_context.fp = 17;
@@ -400,7 +402,7 @@ mod tests {
         ];
         //Execute the hint
         assert_matches!(
-            run_hint!(vm, ids_data, hint_code::UNSIGNED_DIV_REM_UINT768_BY_UINT384),
+            run_hint!(vm, ids_data, hint_code),
             Err(HintError::Math(MathError::DividedByZero))
         );
     }

--- a/src/tests/cairo_run_test.rs
+++ b/src/tests/cairo_run_test.rs
@@ -713,7 +713,7 @@ fn uint384() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn uint384_extension() {
     let program_data = include_bytes!("../../cairo_programs/uint384_extension_test.json");
-    run_program_simple_with_memory_holes(program_data.as_slice(), 20);
+    run_program_simple_with_memory_holes(program_data.as_slice(), 40);
 }
 
 #[test]


### PR DESCRIPTION
## Description

This PR adds the missing hint _NewHint#51_, now known as `UNSIGNED_DIV_REM_UINT768_BY_UINT384_STRIPPED`.
NOTE: this hint is a copy of _NewHint#6_ but with less spaces.