### PR TITLE
feat(hints): add NewHint#61

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,7 +120,24 @@
 * Optimizations for hash builtin [#1029](https://github.com/lambdaclass/cairo-rs/pull/1029):
   * Track the verified addresses by offset in a `Vec<bool>` rather than storing the address in a `Vec<Relocatable>`
 
-* Add missing hint on vrf.json lib [#1035](https://github.com/lambdaclass/cairo-rs/pull/1035):
+* Add missing hint on vrf.json whitelist [#1056](https://github.com/lambdaclass/cairo-rs/pull/1056):
+
+    `BuiltinHintProcessor` now supports the following hint:
+
+    ```python
+    %{
+        from starkware.python.math_utils import ec_double_slope
+        from starkware.cairo.common.cairo_secp.secp_utils import pack
+        SECP_P = 2**255-19
+
+        # Compute the slope.
+        x = pack(ids.point.x, PRIME)
+        y = pack(ids.point.y, PRIME)
+        value = slope = ec_double_slope(point=(x, y), alpha=42204101795669822316448953119945047945709099015225996174933988943478124189485, p=SECP_P)
+    %}
+    ```
+
+* Add missing hint on vrf.json whitelist [#1035](https://github.com/lambdaclass/cairo-rs/pull/1035):
 
     `BuiltinHintProcessor` now supports the following hint:
 
@@ -138,7 +155,7 @@
     %}
     ```
 
-* Add missing hint on vrf.json lib [#1035](https://github.com/lambdaclass/cairo-rs/pull/1035):
+* Add missing hint on vrf.json whitelist [#1035](https://github.com/lambdaclass/cairo-rs/pull/1035):
 
     `BuiltinHintProcessor` now supports the following hint:
 
@@ -153,7 +170,7 @@
     %}
     ```
 
-* Add missing hint on vrf.json lib [#1000](https://github.com/lambdaclass/cairo-rs/pull/1000):
+* Add missing hint on vrf.json whitelist [#1000](https://github.com/lambdaclass/cairo-rs/pull/1000):
 
     `BuiltinHintProcessor` now supports the following hint:
 
@@ -302,7 +319,7 @@
         ids.res.high = res_split[1]
     ```
 
-* Add missing hint on vrf.json lib [#1030](https://github.com/lambdaclass/cairo-rs/pull/1030):
+* Add missing hint on vrf.json whitelist [#1030](https://github.com/lambdaclass/cairo-rs/pull/1030):
 
     `BuiltinHintProcessor` now supports the following hint:
 

--- a/cairo_programs/compute_doubling_slope_v2.cairo
+++ b/cairo_programs/compute_doubling_slope_v2.cairo
@@ -70,7 +70,6 @@ func compute_doubling_slope{range_check_ptr}(point: EcPoint) -> (slope: BigInt3)
         x = pack(ids.point.x, PRIME)
         y = pack(ids.point.y, PRIME)
         value = slope = ec_double_slope(point=(x, y), alpha=42204101795669822316448953119945047945709099015225996174933988943478124189485, p=SECP_P)
-        print(value)
     %}
     let (slope: BigInt3) = nondet_bigint3();
     // let alpha = Uint256(

--- a/cairo_programs/compute_doubling_slope_v2.cairo
+++ b/cairo_programs/compute_doubling_slope_v2.cairo
@@ -70,6 +70,7 @@ func compute_doubling_slope{range_check_ptr}(point: EcPoint) -> (slope: BigInt3)
         x = pack(ids.point.x, PRIME)
         y = pack(ids.point.y, PRIME)
         value = slope = ec_double_slope(point=(x, y), alpha=42204101795669822316448953119945047945709099015225996174933988943478124189485, p=SECP_P)
+        print(value)
     %}
     let (slope: BigInt3) = nondet_bigint3();
     // let alpha = Uint256(
@@ -92,7 +93,7 @@ func compute_doubling_slope{range_check_ptr}(point: EcPoint) -> (slope: BigInt3)
 
 
 func main{range_check_ptr}() {
-    let point_1 = EcPoint(BigInt3(512,2412,133), BigInt3(64,0,6546));
+    let point_1 = EcPoint(BigInt3(512, 2412, 133), BigInt3(64, 0, 6546));
 
     let (slope) = compute_doubling_slope(point_1);
     assert slope = BigInt3(50745345459537348646984154, 66221251087242098185359002 ,8063180118678125382645462);

--- a/cairo_programs/compute_doubling_slope_v2.cairo
+++ b/cairo_programs/compute_doubling_slope_v2.cairo
@@ -1,0 +1,100 @@
+
+from starkware.cairo.common.cairo_secp.bigint import (
+    BigInt3,
+    UnreducedBigInt3,
+    nondet_bigint3,
+)
+
+from cairo_programs.compute_slope_v2 import verify_zero
+
+const BASE = 2 ** 86;
+const SECP_REM = 19;
+
+struct EcPoint {
+    x: BigInt3,
+    y: BigInt3,
+}
+
+func unreduced_mul(a: BigInt3, b: BigInt3) -> (res_low: UnreducedBigInt3) {
+    // The result of the product is:
+    //   sum_{i, j} a.d_i * b.d_j * BASE**(i + j)
+    // Since we are computing it mod secp256k1_prime, we replace the term
+    //   a.d_i * b.d_j * BASE**(i + j)
+    // where i + j >= 3 with
+    //   a.d_i * b.d_j * BASE**(i + j - 3) * 4 * SECP_REM
+    // since BASE ** 3 = 4 * SECP_REM (mod secp256k1_prime).
+    return (
+        UnreducedBigInt3(
+        d0=a.d0 * b.d0 + (a.d1 * b.d2 + a.d2 * b.d1) * (8 * SECP_REM),
+        d1=a.d0 * b.d1 + a.d1 * b.d0 + (a.d2 * b.d2) * (8 * SECP_REM),
+        d2=a.d0 * b.d2 + a.d1 * b.d1 + a.d2 * b.d0),
+    );
+}
+
+// Computes the square of a big integer, given in BigInt3 representation, modulo the
+// secp256k1 prime.
+//
+// Has the same guarantees as in unreduced_mul(a, a).
+func unreduced_sqr(a: BigInt3) -> (res_low: UnreducedBigInt3) {
+    tempvar twice_d0 = a.d0 * 2;
+    return (
+        UnreducedBigInt3(
+        d0=a.d0 * a.d0 + (a.d1 * a.d2) * (2 * 8 * SECP_REM),
+        d1=twice_d0 * a.d1 + (a.d2 * a.d2) * (8 * SECP_REM),
+        d2=twice_d0 * a.d2 + a.d1 * a.d1),
+    );
+}
+
+    
+// Computes the slope of the elliptic curve at a given point.
+// The slope is used to compute point + point.
+//
+// Arguments:
+//   point - the point to operate on.
+//
+// Returns:
+//   slope - the slope of the curve at point, in BigInt3 representation.
+//
+// Assumption: point != 0.
+
+func compute_doubling_slope{range_check_ptr}(point: EcPoint) -> (slope: BigInt3) {
+    alloc_locals;
+    // Note that y cannot be zero: assume that it is, then point = -point, so 2 * point = 0, which
+    // contradicts the fact that the size of the curve is odd.
+    %{
+        from starkware.python.math_utils import ec_double_slope
+        from starkware.cairo.common.cairo_secp.secp_utils import pack
+        SECP_P = 2**255-19
+
+        # Compute the slope.
+        x = pack(ids.point.x, PRIME)
+        y = pack(ids.point.y, PRIME)
+        value = slope = ec_double_slope(point=(x, y), alpha=42204101795669822316448953119945047945709099015225996174933988943478124189485, p=SECP_P)
+    %}
+    let (slope: BigInt3) = nondet_bigint3();
+    // let alpha = Uint256(
+    //     143186476941636880901214103594843510573, 124026708105846590725274683684370988502
+    // );
+    let (x_sqr: UnreducedBigInt3) = unreduced_sqr(point.x);
+    let (slope_y: UnreducedBigInt3) = unreduced_mul(slope, point.y);
+    let to_assert = UnreducedBigInt3(
+        d0=3 * x_sqr.d0 - 2 * slope_y.d0 + 44933163489768861888943917,
+        d1=3 * x_sqr.d1 - 2 * slope_y.d1 + 5088459194227531129123890,
+        d2=3 * x_sqr.d2 - 2 * slope_y.d2 + 7050102118787810395887998,
+    );
+    // let to_assert256 = bigint_to_uint256(to_assert);
+    // %{ print_u_256_info(ids.to_assert256, 'to_assert') %}
+
+    verify_zero(to_assert);
+
+    return (slope=slope);
+}
+
+
+func main{range_check_ptr}() {
+    let point_1 = EcPoint(BigInt3(512,2412,133), BigInt3(64,0,6546));
+
+    let (slope) = compute_doubling_slope(point_1);
+    assert slope = BigInt3(50745345459537348646984154, 66221251087242098185359002 ,8063180118678125382645462);
+    return ();
+    }

--- a/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -6,9 +6,7 @@ use super::{
     field_arithmetic::uint384_div,
     secp::{
         ec_utils::{
-            compute_slope_and_assing_secp_p,
-            ec_double_assign_new_y,
-            ec_negate_embedded_secp_p,
+            compute_slope_and_assing_secp_p, ec_double_assign_new_y, ec_negate_embedded_secp_p,
             ec_negate_import_secp_p,
         },
         secp_utils::{ALPHA, ALPHA_V2, SECP_P, SECP_P_V2},

--- a/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -4,7 +4,7 @@ use super::{
         ec_recover_sub_a_b,
     },
     field_arithmetic::uint384_div,
-    secp::secp_utils::{SECP_P, SECP_P_V2},
+    secp::secp_utils::{ALPHA, ALPHA_V2, SECP_P, SECP_P_V2},
     vrf::{fq::uint512_unsigned_div_rem, inv_mod_p_uint512::inv_mod_p_uint512},
 };
 use crate::{
@@ -431,12 +431,23 @@ impl HintProcessor for BuiltinHintProcessor {
             hint_code::EC_NEGATE => {
                 ec_negate(vm, exec_scopes, &hint_data.ids_data, &hint_data.ap_tracking)
             }
-            hint_code::EC_DOUBLE_SCOPE => compute_doubling_slope(
+            hint_code::EC_DOUBLE_SCOPE_V1 => compute_doubling_slope(
                 vm,
                 exec_scopes,
                 &hint_data.ids_data,
                 &hint_data.ap_tracking,
                 "point",
+                &SECP_P,
+                &ALPHA,
+            ),
+            hint_code::EC_DOUBLE_SCOPE_V2 => compute_doubling_slope(
+                vm,
+                exec_scopes,
+                &hint_data.ids_data,
+                &hint_data.ap_tracking,
+                "point",
+                &SECP_P_V2,
+                &ALPHA_V2,
             ),
             hint_code::EC_DOUBLE_SCOPE_WHITELIST => compute_doubling_slope(
                 vm,
@@ -444,6 +455,8 @@ impl HintProcessor for BuiltinHintProcessor {
                 &hint_data.ids_data,
                 &hint_data.ap_tracking,
                 "pt",
+                &SECP_P,
+                &ALPHA,
             ),
             hint_code::COMPUTE_SLOPE_V1 => compute_slope_and_assing_secp_p(
                 vm,

--- a/src/hint_processor/builtin_hint_processor/hint_code.rs
+++ b/src/hint_processor/builtin_hint_processor/hint_code.rs
@@ -547,13 +547,22 @@ y = pack(ids.point.y, PRIME) % SECP_P
 # The modulo operation in python always returns a nonnegative number.
 value = (-y) % SECP_P"#;
 
-pub const EC_DOUBLE_SCOPE: &str = r#"from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack
+pub const EC_DOUBLE_SCOPE_V1: &str = r#"from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack
 from starkware.python.math_utils import ec_double_slope
 
 # Compute the slope.
 x = pack(ids.point.x, PRIME)
 y = pack(ids.point.y, PRIME)
 value = slope = ec_double_slope(point=(x, y), alpha=0, p=SECP_P)"#;
+
+pub const EC_DOUBLE_SCOPE_V2: &str = r#"from starkware.python.math_utils import ec_double_slope
+from starkware.cairo.common.cairo_secp.secp_utils import pack
+SECP_P = 2**255-19
+
+# Compute the slope.
+x = pack(ids.point.x, PRIME)
+y = pack(ids.point.y, PRIME)
+value = slope = ec_double_slope(point=(x, y), alpha=42204101795669822316448953119945047945709099015225996174933988943478124189485, p=SECP_P)"#;
 
 pub const EC_DOUBLE_SCOPE_WHITELIST: &str = r#"from starkware.cairo.common.cairo_secp.secp_utils import SECP_P, pack
 from starkware.python.math_utils import div_mod
@@ -592,6 +601,7 @@ y0 = pack(ids.point0.y, PRIME)
 x1 = pack(ids.point1.x, PRIME)
 y1 = pack(ids.point1.y, PRIME)
 value = slope = line_slope(point1=(x0, y0), point2=(x1, y1), p=SECP_P)"#;
+
 pub const IMPORT_SECP256R1_P: &str =
     "from starkware.cairo.common.cairo_secp.secp256r1_utils import SECP256R1_P as SECP_P";
 

--- a/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
@@ -87,16 +87,14 @@ pub fn compute_doubling_slope(
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     point_alias: &str,
+    secp_p: &BigInt,
+    alpha: &BigInt,
 ) -> Result<(), HintError> {
-    exec_scopes.insert_value("SECP_P", SECP_P.clone());
+    exec_scopes.insert_value("SECP_P", secp_p.clone());
     //ids.point
     let point = EcPoint::from_var_name(point_alias, vm, ids_data, ap_tracking)?;
 
-    let value = ec_double_slope(
-        &(point.x.pack86(), point.y.pack86()),
-        &BigInt::zero(),
-        &SECP_P,
-    );
+    let value = ec_double_slope(&(point.x.pack86(), point.y.pack86()), alpha, secp_p);
     exec_scopes.insert_value("value", value.clone());
     exec_scopes.insert_value("slope", value);
     Ok(())

--- a/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
@@ -380,6 +380,7 @@ pub fn n_pair_bits(
 mod tests {
     use super::*;
     use crate::hint_processor::builtin_hint_processor::hint_code;
+    use crate::hint_processor::builtin_hint_processor::secp::secp_utils::SECP_P_V2;
     use crate::stdlib::string::ToString;
 
     use crate::{
@@ -459,6 +460,48 @@ mod tests {
             "40442433062102151071094722250325492738932110061897694430475034100717288403728"
         )
                 )
+            ]
+        );
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn run_ec_double_scope_v2_hint_ok() {
+        let hint_code = hint_code::EC_DOUBLE_SCOPE_V2;
+        let mut vm = vm_with_range_check!();
+        vm.segments = segments![
+            ((1, 0), 512),
+            ((1, 1), 2412),
+            ((1, 2), 133),
+            ((1, 3), 64),
+            ((1, 4), 0),
+            ((1, 5), 6546)
+        ];
+
+        //Initialize fp
+        vm.run_context.fp = 1;
+
+        let ids_data = ids_data!["point"];
+        let mut exec_scopes = ExecutionScopes::new();
+
+        //Execute the hint
+        assert_matches!(run_hint!(vm, ids_data, hint_code, &mut exec_scopes), Ok(()));
+        check_scope!(
+            &exec_scopes,
+            [
+                (
+                    "value",
+                    bigint_str!(
+            "48268701472940295594394094960749868325610234644833445333946260403470540790234"
+        )
+                ),
+                (
+                    "slope",
+                    bigint_str!(
+            "48268701472940295594394094960749868325610234644833445333946260403470540790234"
+        )
+                ),
+                ("SECP_P", SECP_P_V2.clone())
             ]
         );
     }

--- a/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/secp_utils.rs
@@ -33,6 +33,14 @@ lazy_static! {
         "57896044618658097711785492504343953926634992332820282019728792003956564819949"
     )
     .unwrap();
+
+    pub(crate) static ref ALPHA: BigInt = BigInt::zero();
+
+    pub(crate) static ref ALPHA_V2: BigInt = BigInt::from_str(
+        "42204101795669822316448953119945047945709099015225996174933988943478124189485"
+    )
+    .unwrap();
+
     // BASE = 2**86
     pub(crate) static ref BASE: BigUint = BigUint::from_str(
         "77371252455336267181195264"

--- a/src/tests/cairo_run_test.rs
+++ b/src/tests/cairo_run_test.rs
@@ -841,3 +841,10 @@ fn cairo_run_compute_slope_v2_test() {
     let program_data = include_bytes!("../../cairo_programs/compute_slope_v2.json");
     run_program_simple(program_data.as_slice());
 }
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn cairo_run_compute_doubling_slope_v2_test() {
+    let program_data = include_bytes!("../../cairo_programs/compute_doubling_slope_v2.json");
+    run_program_simple(program_data.as_slice());
+}


### PR DESCRIPTION
# Implement Hint #61

```
    %{
        from starkware.python.math_utils import ec_double_slope
        from starkware.cairo.common.cairo_secp.secp_utils import pack
        SECP_P = 2**255-19

        # Compute the slope.
        x = pack(ids.point.x, PRIME)
        y = pack(ids.point.y, PRIME)
        value = slope = ec_double_slope(point=(x, y), alpha=42204101795669822316448953119945047945709099015225996174933988943478124189485, p=SECP_P)
    %}
```

Issue: #979 

## Checklist
- [x] Linked to Github Issue
- [x] Unit tests added
- [x] Integration tests added.
- [x] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [x] CHANGELOG has been updated.

