### PR TITLE
ci: improve caching by using make and restoring mtimes

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,19 @@
+name: QA Canary Workflow
+
+on:
+  workflow_run:
+    workflows: [QA]
+    types:
+    - completed
+
+jobs:
+  on-qa-success:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+    - run: exit 0
+  on-qa-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+    - run: exit 1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - name: Fetch from cache
       uses: actions/cache@v3
@@ -29,6 +31,11 @@ jobs:
         path: cairo_programs/**/*.json
         key: ${{ matrix.program-target }}-cache-${{ hashFiles( 'cairo_programs/**/*.cairo' ) }}
         restore-keys: ${{ matrix.program-target }}-cache-
+
+    # This is not pretty, but we need `make` to see the compiled programs are
+    # actually newer than the sources, otherwise it will try to rebuild them
+    - name: Restore timestamps
+      uses: chetan/git-restore-mtime-action@v1
 
     - name: Python3 Build
       if: ${{ steps.cache-programs.outputs.cache-hit != 'true' }}
@@ -138,7 +145,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
       with:
-        depth: 0
+        fetch-depth: 0
     # This is not pretty, but we need `make` to see the compiled programs are
     # actually newer than the sources, otherwise it will try to rebuild them
     - name: Restore timestamps
@@ -207,19 +214,19 @@ jobs:
       matrix:
         include:
         - program-target: cairo_proof_programs
-          programs-dir: cairo_programs/proof_programs
+          trace-target: cairo_proof_trace
           nprocs: 1
-          extra-args: '--proof_mode'
         - program-target: cairo_test_programs
-          programs-dir: cairo_programs
+          trace-target: cairo_trace
           nprocs: 2
-          extra-args: ''
     name: Compute memory and execution traces with cairo-lang
     needs: build-programs
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - name: Check cache
       uses: actions/cache@v3
@@ -248,14 +255,14 @@ jobs:
         key: ${{ matrix.program-target }}-cache-${{ hashFiles( 'cairo_programs/**/*.cairo' ) }}
         fail-on-cache-miss: true
 
+    # This is not pretty, but we need `make` to see the compiled programs are
+    # actually newer than the sources, otherwise it will try to rebuild them
+    - name: Restore timestamps
+      uses: chetan/git-restore-mtime-action@v1
+
     - name: Generate traces
       if: ${{ steps.trace-cache.outputs.cache-hit != 'true' }}
-      run: |
-        ls ${{ matrix.programs-dir }}/*.json | cut -f1 -d'.' | \
-        xargs -P ${{ matrix.nprocs }} -I '{program}' \
-        cairo-run --program '{program}'.json --layout starknet_with_keccak \
-        --memory_file '{program}'.memory --trace_file '{program}'.trace \
-        ${{ matrix.extra-args }}
+      run: make -j ${{ matrix.nprocs }} ${{ matrix.trace-target }}
 
 
   run-cairo-release:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -236,6 +236,7 @@ jobs:
           cairo_programs/**/*.memory
           cairo_programs/**/*.trace
         key: ${{ matrix.program-target }}-reference-trace-cache-${{ hashFiles( 'cairo_programs/**/*.cairo' ) }}
+        restore-keys: ${{ matrix.program-target }}-reference-trace-cache-
 
     - name: Python3 Build
       if: steps.trace-cache.outputs.cache-hit != 'true'

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ DBGBIN:=target/debug/cairo-rs-run
 	compare_vm_output compare_trace_memory compare_trace compare_memory \
 	compare_trace_memory_proof compare_trace_proof compare_memory_proof \
 	cairo_bench_programs cairo_proof_programs cairo_test_programs \
-	cairo_trace cairo-rs_trace $(RELBIN) $(DBGBIN)
+	cairo_trace cairo-rs_trace cairo_proof_trace cairo-rs_proof_trace \
+	$(RELBIN) $(DBGBIN)
 
 # Proof mode consumes too much memory with cairo-lang to execute
 # two instances at the same time in the CI without getting killed
@@ -133,6 +134,9 @@ check:
 cairo_test_programs: $(COMPILED_TESTS) $(COMPILED_BAD_TESTS) $(COMPILED_NORETROCOMPAT_TESTS)
 cairo_proof_programs: $(COMPILED_PROOF_TESTS)
 cairo_bench_programs: $(COMPILED_BENCHES)
+
+cairo_proof_trace: $(CAIRO_TRACE_PROOF) $(CAIRO_MEM_PROOF)
+cairo-rs_proof_trace: $(CAIRO_RS_TRACE_PROOF) $(CAIRO_RS_MEM_PROOF)
 
 cairo_trace: $(CAIRO_TRACE) $(CAIRO_MEM)
 cairo-rs_trace: $(CAIRO_RS_TRACE) $(CAIRO_RS_MEM)


### PR DESCRIPTION
This applies @MegaRedHand recommendation of using deep checkouts and restoring mtimes to reduce run times, specially those of added programs for computing the trace in proof mode.
It also adds a canary workflow to group all the jobs in QA as a single check.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

