### PR TITLE
perf: use proof mode for Hyperfine benchmarks

### DIFF
--- a/.github/workflows/hyperfine.yml
+++ b/.github/workflows/hyperfine.yml
@@ -159,7 +159,7 @@ jobs:
         hyperfine -N -r 10 --export-markdown "target_programs/{program}.md" \
         -L bin "$BINS" -n "{bin} {program}" \
         -s "cat ./bin/cairo-vm-cli-{bin} target_programs/{program}.json" \
-        "./bin/cairo-vm-cli-{bin} --layout starknet_with_keccak \
+        "./bin/cairo-vm-cli-{bin} --proof_mode --layout starknet_with_keccak \
          --memory_file /dev/null --trace_file /dev/null target_programs/{program}.json"
         echo "benchmark_count=$(ls target_programs/*.md | wc -l)" >> $GITHUB_OUTPUT
 

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,9 @@ NORETROCOMPAT_DIR:=cairo_programs/noretrocompat
 NORETROCOMPAT_FILES:=$(wildcard $(NORETROCOMPAT_DIR)/*.cairo)
 COMPILED_NORETROCOMPAT_TESTS:=$(patsubst $(NORETROCOMPAT_DIR)/%.cairo, $(NORETROCOMPAT_DIR)/%.json, $(NORETROCOMPAT_FILES))
 
+$(BENCH_DIR)/%.json: $(BENCH_DIR)/%.cairo
+	cairo-compile --cairo_path="$(TEST_DIR):$(BENCH_DIR)" $< --output $@ --proof_mode
+
 $(TEST_DIR)/%.json: $(TEST_DIR)/%.cairo
 	cairo-compile --cairo_path="$(TEST_DIR):$(BENCH_DIR)" $< --output $@
 
@@ -73,9 +76,6 @@ $(TEST_DIR)/%.rs.trace $(TEST_DIR)/%.rs.memory: $(TEST_DIR)/%.json $(RELBIN)
 
 $(TEST_DIR)/%.trace $(TEST_DIR)/%.memory: $(TEST_DIR)/%.json
 	cairo-run --layout starknet_with_keccak --program $< --trace_file $@ --memory_file $(@D)/$(*F).memory
-
-$(BENCH_DIR)/%.json: $(BENCH_DIR)/%.cairo
-	cairo-compile --cairo_path="$(TEST_DIR):$(BENCH_DIR)" $< --output $@
 
 $(NORETROCOMPAT_DIR)/%.json: $(NORETROCOMPAT_DIR)/%.cairo
 	cairo-compile --cairo_path="$(TEST_DIR):$(BENCH_DIR):$(NORETROCOMPAT_DIR)" $< --output $@


### PR DESCRIPTION
Proof mode will be the main way to run cairo-rs. Thus, that's the performance that matters the most. So, that's what we need to keep an eye on.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

