### PR TITLE
perf: eager resize for ´load_data´

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* perf: insert elements from the tail in `load_data` so reallocation happens only once [#1117](https://github.com/lambdaclass/cairo-rs/pull/1117)
+
 * Use to_signed_felt as function for felt252 as BigInt within [-P/2, P/2] range and use to_bigint as function for representation as BigInt. [#1100](https://github.com/lambdaclass/cairo-rs/pull/1100)
 
 * Implement hint on field_arithmetic lib [#1090](https://github.com/lambdaclass/cairo-rs/pull/1090)

--- a/src/vm/vm_memory/memory_segments.rs
+++ b/src/vm/vm_memory/memory_segments.rs
@@ -55,7 +55,9 @@ impl MemorySegmentManager {
         ptr: Relocatable,
         data: &Vec<MaybeRelocatable>,
     ) -> Result<Relocatable, MemoryError> {
-        for (num, value) in data.iter().enumerate() {
+        // Starting from the end ensures any necessary resize
+        // is performed once with enough room for everything
+        for (num, value) in data.iter().enumerate().rev() {
             self.memory.insert((ptr + num)?, value)?;
         }
         (ptr + data.len()).map_err(MemoryError::Math)


### PR DESCRIPTION
Some of the overhead during runner/vm initialization (relevant for sequencers that recycle a single program) comes from multiple resizes when calling `load_data`.
Reversing the iterator ensures the resize happens only once, as the biggest offset will be inserted first.

According to criterion benchmarks, initialization takes 29.5% less time.

NOTE: there seems to be a minimal (<0.02+-0.02) performance hit on runtime, presumably due to zeroing out cells to later overwrite them. While more complex, an option would be to `.try_reserve` instead and then pushing in forward order. For now, I think the complexity/performance trade off balances quite highly in favor of not adding such code.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [x] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [x] CHANGELOG has been updated.

