### PR TITLE
Cairo program to test for `TestLessThan`/`TestLessThanOrEqual`

### DIFF
--- a/cairo_programs/cairo-1-contracts/test_less_than.cairo
+++ b/cairo_programs/cairo-1-contracts/test_less_than.cairo
@@ -1,0 +1,17 @@
+#[contract]
+mod TestLessThan {
+use integer::upcast;
+use integer::downcast;
+use option::OptionTrait;
+
+    // tests whether the input (u128) can be downcast to an u8
+    #[external]
+    fn test_less_than_with_downcast(number: u128) -> bool {
+        let downcast_test: Option<u8> = downcast(number);
+
+        match downcast_test {
+            Option::Some(_) => { return true; },
+            Option::None(_) => { return false; }
+        }
+    }
+}

--- a/src/tests/cairo_1_run_from_entrypoint_tests.rs
+++ b/src/tests/cairo_1_run_from_entrypoint_tests.rs
@@ -2,6 +2,32 @@ use crate::tests::*;
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_less_than_or_equal() {
+    let program_data = include_bytes!("../../cairo_programs/cairo-1-contracts/test_less_than.casm");
+    run_cairo_1_entrypoint(
+        program_data.as_slice(),
+        0,
+        &[8_usize.into()],
+        &[1_u8.into()],
+    );
+
+    run_cairo_1_entrypoint(
+        program_data.as_slice(),
+        0,
+        &[290_usize.into()],
+        &[0_u8.into()],
+    );
+
+    run_cairo_1_entrypoint(
+        program_data.as_slice(),
+        0,
+        &[250_usize.into()],
+        &[1_u8.into()],
+    );
+}
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn fibonacci_1() {
     let program_data = include_bytes!("../../cairo_programs/cairo-1-contracts/fib.casm");
     run_cairo_1_entrypoint(


### PR DESCRIPTION
# Cairo program to test for `TestLessThan`/`TestLessThanOrEqual`

## Description

- Add test program that generates `TestLesstThan`/`TestLesstThanOrEqual` and tests that execute the program

## Checklist
- [X] Linked to Github Issue
- [X] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

Closes #1119 