### PR TITLE
feat: Add method `CairoRunner::initialize_function_runner_cairo1` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,22 @@
 
 #### Upcoming Changes
 
-* Add more hints to `Cairo1HintProcessor` [#1143](https://github.com/lambdaclass/cairo-rs/pull/1098)
+* feat: Add method `CairoRunner::run_from_entrypoint_with_builtins` [#1151](https://github.com/lambdaclass/cairo-rs/pull/1151)
+
+  * Add method `run_from_entrypoint_with_builtins(
+        &mut self,
+        entrypoint: usize,
+        args: &[&CairoArg],
+        verify_secure: bool,
+        program_segment_size: Option<usize>,
+        vm: &mut VirtualMachine,
+        hint_processor: &mut dyn HintProcessor,
+        program_builtins: Option<&[BuiltinName]>,
+    ) -> Result<(), CairoRunError>`
+
+  * BREAKING: Move field `builtins` from `SharedProgramData` to `Program`
+
+* Add more hints to `Cairo1HintProcessor` [#1143](https://github.com/lambdaclass/cairo-rs/pull/1143)
 
     * `Cairo1HintProcessor` can now run the following hints:
         * Felt252DictEntryInit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
   * BREAKING: Move field `builtins` from `SharedProgramData` to `Program`
   * BREAKING: Remove argument `add_segment_arena_builtin` from `CairoRunner::initialize_function_runner`, it is now always false
+  * BREAKING: Add `segment_arena` enum variant to `BuiltinName`
 
 * Add more hints to `Cairo1HintProcessor` [#1143](https://github.com/lambdaclass/cairo-rs/pull/1143)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Upcoming Changes
 
-* feat: Add method `CairoRunner::initialize_function_runner_cairo1` [#1151](https://github.com/lambdaclass/cairo-rs/pull/1151)
+* feat: Add method `CairoRunner::initialize_function_runner_cairo_1` [#1151](https://github.com/lambdaclass/cairo-rs/pull/1151)
 
   * Add method `pub fn initialize_function_runner_cairo_1(
         &mut self,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,9 @@
   * BREAKING: Remove argument `add_segment_arena_builtin` from `CairoRunner::initialize_function_runner`, it is now always false
   * BREAKING: Add `segment_arena` enum variant to `BuiltinName`
 
-* Add more hints to `Cairo1HintProcessor` [#1143](https://github.com/lambdaclass/cairo-rs/pull/1143)
-
 * Fix implementation of `InitSquashData` and `ShouldSkipSquashLoop`
 
-* Add more hints to `Cairo1HintProcessor` [#1143](https://github.com/lambdaclass/cairo-rs/pull/1098)
+* Add more hints to `Cairo1HintProcessor` [#1143](https://github.com/lambdaclass/cairo-rs/pull/1143)
 
     * `Cairo1HintProcessor` can now run the following hints:
         * Felt252DictEntryInit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,16 @@
 
 #### Upcoming Changes
 
-* feat: Add method `CairoRunner::run_from_entrypoint_with_builtins` [#1151](https://github.com/lambdaclass/cairo-rs/pull/1151)
+* feat: Add method `CairoRunner::initialize_function_runner_cairo1` [#1151](https://github.com/lambdaclass/cairo-rs/pull/1151)
 
-  * Add method `run_from_entrypoint_with_builtins(
+  * Add method `pub fn initialize_function_runner_cairo_1(
         &mut self,
-        entrypoint: usize,
-        args: &[&CairoArg],
-        verify_secure: bool,
-        program_segment_size: Option<usize>,
         vm: &mut VirtualMachine,
-        hint_processor: &mut dyn HintProcessor,
-        program_builtins: Option<&[BuiltinName]>,
-    ) -> Result<(), CairoRunError>`
+        program_builtins: &[BuiltinName],
+    ) -> Result<(), RunnerError>` to `CairoRunner`
 
   * BREAKING: Move field `builtins` from `SharedProgramData` to `Program`
+  * BREAKING: Remove argument `add_segment_arena_builtin` from `CairoRunner::initialize_function_runner`, it is now always false
 
 * Add more hints to `Cairo1HintProcessor` [#1143](https://github.com/lambdaclass/cairo-rs/pull/1143)
 

--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -1,5 +1,6 @@
 use crate::stdlib::{collections::HashMap, fmt, prelude::*, sync::Arc};
 
+use crate::vm::runners::builtin_runner::SEGMENT_ARENA_BUILTIN_NAME;
 use crate::{
     serde::deserialize_utils,
     types::{
@@ -31,6 +32,7 @@ pub enum BuiltinName {
     bitwise,
     ec_op,
     poseidon,
+    segment_arena,
 }
 
 impl BuiltinName {
@@ -44,6 +46,7 @@ impl BuiltinName {
             BuiltinName::bitwise => BITWISE_BUILTIN_NAME,
             BuiltinName::ec_op => EC_OP_BUILTIN_NAME,
             BuiltinName::poseidon => POSEIDON_BUILTIN_NAME,
+            BuiltinName::segment_arena => SEGMENT_ARENA_BUILTIN_NAME,
         }
     }
 }

--- a/src/serde/deserialize_program.rs
+++ b/src/serde/deserialize_program.rs
@@ -387,7 +387,6 @@ pub fn parse_program_json(
     }
 
     let shared_program_data = SharedProgramData {
-        builtins: program_json.builtins,
         data: program_json.data,
         hints: program_json.hints,
         main: entrypoint_pc,
@@ -407,6 +406,7 @@ pub fn parse_program_json(
         shared_program_data: Arc::new(shared_program_data),
         constants,
         reference_manager: program_json.reference_manager,
+        builtins: program_json.builtins,
     })
 }
 
@@ -807,7 +807,7 @@ mod tests {
             }],
         );
 
-        assert_eq!(program.shared_program_data.builtins, builtins);
+        assert_eq!(program.builtins, builtins);
         assert_eq!(program.shared_program_data.data, data);
         assert_eq!(program.shared_program_data.main, Some(0));
         assert_eq!(program.shared_program_data.hints, hints);
@@ -865,7 +865,7 @@ mod tests {
             }],
         );
 
-        assert_eq!(program.shared_program_data.builtins, builtins);
+        assert_eq!(program.builtins, builtins);
         assert_eq!(program.shared_program_data.data, data);
         assert_eq!(program.shared_program_data.main, None);
         assert_eq!(program.shared_program_data.hints, hints);

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -202,6 +202,7 @@ pub(self) fn run_cairo_1_entrypoint(
     assert_eq!(expected_retdata, &retdata);
 }
 
+#[cfg(feature = "cairo-1-hints")]
 fn get_casm_contract_builtins(
     contract_class: &CasmContractClass,
     entrypoint_offset: usize,

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -12,7 +12,7 @@ use cairo_lang_starknet::casm_contract_class::CasmContractClass;
 #[cfg(feature = "cairo-1-hints")]
 use felt::Felt252;
 
-use crate::stdlib::prelude::*;
+use crate::{serde::deserialize_program::BuiltinName, stdlib::prelude::*};
 
 use crate::{
     cairo_run::{cairo_run, CairoRunConfig},
@@ -117,28 +117,24 @@ pub(self) fn run_cairo_1_entrypoint(
     .unwrap();
     let mut vm = VirtualMachine::new(false);
 
-    runner.initialize_function_runner(&mut vm, true).unwrap();
-
-    // Get builtin bases
-    // Extract builtins from CasmContractClass entrypoint data from the entrypoint which's offset is being ran
-    let builtins: Vec<String> = contract_class
-        .entry_points_by_type
-        .external
-        .iter()
-        .find(|e| e.offset == entrypoint_offset)
-        .unwrap()
-        .builtins
-        .iter()
-        .map(|n| format!("{}_builtin", n))
-        .collect();
+    let program_builtins = get_casm_contract_builtins(&contract_class, entrypoint_offset);
+    runner
+        .initialize_function_runner_cairo_1(&mut vm, &program_builtins)
+        .unwrap();
 
     // Implicit Args
     let syscall_segment = MaybeRelocatable::from(vm.add_memory_segment());
 
+    let builtins: Vec<&'static str> = runner
+        .get_program_builtins()
+        .iter()
+        .map(|b| b.name())
+        .collect();
+
     let builtin_segment: Vec<MaybeRelocatable> = vm
         .get_builtin_runners()
         .iter()
-        .filter(|b| builtins.contains(&(b.name().to_string())))
+        .filter(|b| builtins.contains(&b.name()))
         .flat_map(|b| b.initial_stack())
         .collect();
 
@@ -204,4 +200,33 @@ pub(self) fn run_cairo_1_entrypoint(
         .map(|c| c.clone().into_owned())
         .collect();
     assert_eq!(expected_retdata, &retdata);
+}
+
+fn get_casm_contract_builtins(
+    contract_class: &CasmContractClass,
+    entrypoint_offset: usize,
+) -> Vec<BuiltinName> {
+    contract_class
+        .entry_points_by_type
+        .external
+        .iter()
+        .find(|e| e.offset == entrypoint_offset)
+        .unwrap()
+        .builtins
+        .iter()
+        .map(|n| format!("{}_builtin", n))
+        .map(|s| match &*s {
+            crate::vm::runners::builtin_runner::OUTPUT_BUILTIN_NAME => BuiltinName::output,
+            crate::vm::runners::builtin_runner::RANGE_CHECK_BUILTIN_NAME => {
+                BuiltinName::range_check
+            }
+            crate::vm::runners::builtin_runner::HASH_BUILTIN_NAME => BuiltinName::pedersen,
+            crate::vm::runners::builtin_runner::SIGNATURE_BUILTIN_NAME => BuiltinName::ecdsa,
+            crate::vm::runners::builtin_runner::KECCAK_BUILTIN_NAME => BuiltinName::keccak,
+            crate::vm::runners::builtin_runner::BITWISE_BUILTIN_NAME => BuiltinName::bitwise,
+            crate::vm::runners::builtin_runner::EC_OP_BUILTIN_NAME => BuiltinName::ec_op,
+            crate::vm::runners::builtin_runner::POSEIDON_BUILTIN_NAME => BuiltinName::poseidon,
+            _ => panic!("Invalid builtin {}", s),
+        })
+        .collect()
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -228,6 +228,9 @@ fn get_casm_contract_builtins(
             crate::vm::runners::builtin_runner::BITWISE_BUILTIN_NAME => BuiltinName::bitwise,
             crate::vm::runners::builtin_runner::EC_OP_BUILTIN_NAME => BuiltinName::ec_op,
             crate::vm::runners::builtin_runner::POSEIDON_BUILTIN_NAME => BuiltinName::poseidon,
+            crate::vm::runners::builtin_runner::SEGMENT_ARENA_BUILTIN_NAME => {
+                BuiltinName::segment_arena
+            }
             _ => panic!("Invalid builtin {}", s),
         })
         .collect()

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -12,7 +12,7 @@ use cairo_lang_starknet::casm_contract_class::CasmContractClass;
 #[cfg(feature = "cairo-1-hints")]
 use felt::Felt252;
 
-use crate::{serde::deserialize_program::BuiltinName, stdlib::prelude::*};
+use crate::stdlib::prelude::*;
 
 use crate::{
     cairo_run::{cairo_run, CairoRunConfig},

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -24,6 +24,9 @@ use crate::{
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_test::*;
 
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
+use alloc::{string::String, vec::Vec};
+
 mod bitwise_test;
 
 #[cfg(feature = "cairo-1-hints")]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "cairo-1-hints")]
 use crate::{
     hint_processor::cairo_1_hint_processor::hint_processor::Cairo1HintProcessor,
+    serde::deserialize_program::BuiltinName,
     types::relocatable::MaybeRelocatable,
     vm::{
         runners::cairo_runner::{CairoArg, CairoRunner},

--- a/src/types/program.rs
+++ b/src/types/program.rs
@@ -39,7 +39,6 @@ use std::path::Path;
 // Fields in `Program` (other than `SharedProgramData` itself) are used by the main logic.
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
 pub(crate) struct SharedProgramData {
-    pub(crate) builtins: Vec<BuiltinName>,
     pub(crate) data: Vec<MaybeRelocatable>,
     pub(crate) hints: HashMap<usize, Vec<HintParams>>,
     pub(crate) main: Option<usize>,
@@ -55,6 +54,7 @@ pub(crate) struct SharedProgramData {
 pub struct Program {
     pub(crate) shared_program_data: Arc<SharedProgramData>,
     pub(crate) constants: HashMap<String, Felt252>,
+    pub(crate) builtins: Vec<BuiltinName>,
     pub(crate) reference_manager: ReferenceManager,
 }
 
@@ -81,7 +81,6 @@ impl Program {
             }
         }
         let shared_program_data = SharedProgramData {
-            builtins,
             data,
             hints,
             main,
@@ -95,6 +94,7 @@ impl Program {
             shared_program_data: Arc::new(shared_program_data),
             constants,
             reference_manager,
+            builtins,
         })
     }
 
@@ -114,7 +114,7 @@ impl Program {
     }
 
     pub fn iter_builtins(&self) -> impl Iterator<Item = &BuiltinName> {
-        self.shared_program_data.builtins.iter()
+        self.builtins.iter()
     }
 
     pub fn iter_data(&self) -> impl Iterator<Item = &MaybeRelocatable> {
@@ -145,6 +145,7 @@ impl Default for Program {
             reference_manager: ReferenceManager {
                 references: Vec::new(),
             },
+            builtins: Vec::new(),
         }
     }
 }
@@ -235,7 +236,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(program.shared_program_data.builtins, builtins);
+        assert_eq!(program.builtins, builtins);
         assert_eq!(program.shared_program_data.data, data);
         assert_eq!(program.shared_program_data.main, None);
         assert_eq!(program.shared_program_data.identifiers, HashMap::new());
@@ -297,7 +298,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(program.shared_program_data.builtins, builtins);
+        assert_eq!(program.builtins, builtins);
         assert_eq!(program.shared_program_data.data, data);
         assert_eq!(program.shared_program_data.main, None);
         assert_eq!(program.shared_program_data.identifiers, identifiers);
@@ -685,7 +686,7 @@ mod tests {
             },
         );
 
-        assert_eq!(program.shared_program_data.builtins, builtins);
+        assert_eq!(program.builtins, builtins);
         assert_eq!(program.shared_program_data.data, data);
         assert_eq!(program.shared_program_data.main, Some(0));
         assert_eq!(program.shared_program_data.identifiers, identifiers);
@@ -784,7 +785,7 @@ mod tests {
             },
         );
 
-        assert_eq!(program.shared_program_data.builtins, builtins);
+        assert_eq!(program.builtins, builtins);
         assert_eq!(program.shared_program_data.data, data);
         assert_eq!(program.shared_program_data.main, None);
         assert_eq!(program.shared_program_data.identifiers, identifiers);
@@ -837,7 +838,6 @@ mod tests {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn default_program() {
         let shared_program_data = SharedProgramData {
-            builtins: Vec::new(),
             data: Vec::new(),
             hints: HashMap::new(),
             main: None,
@@ -853,6 +853,7 @@ mod tests {
             reference_manager: ReferenceManager {
                 references: Vec::new(),
             },
+            builtins: Vec::new(),
         };
 
         assert_eq!(program, Program::default());

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -334,7 +334,7 @@ pub mod test_utils {
                 constants: Default::default(),
                 builtins: Default::default(),
                 reference_manager: crate::serde::deserialize_program::ReferenceManager {
-                    references: Vec::new(),
+                    references: crate::utils::Vec::new(),
                 },
             }
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -309,10 +309,13 @@ pub mod test_utils {
             >,
         >,
         pub(crate) identifiers: crate::stdlib::collections::HashMap<
-            String,
+            crate::stdlib::string::String,
             crate::serde::deserialize_program::Identifier,
         >,
-        pub(crate) constants: crate::stdlib::collections::HashMap<String, crate::utils::Felt252>,
+        pub(crate) constants: crate::stdlib::collections::HashMap<
+            crate::stdlib::string::String,
+            crate::utils::Felt252,
+        >,
         pub(crate) builtins: crate::utils::Vec<crate::serde::deserialize_program::BuiltinName>,
         pub(crate) reference_manager: crate::serde::deserialize_program::ReferenceManager,
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -291,16 +291,17 @@ pub mod test_utils {
     pub(crate) use program;
 
     pub(crate) struct ProgramFlat {
-        pub(crate) data: Vec<MaybeRelocatable>,
+        pub(crate) data: crate::utils::Vec<MaybeRelocatable>,
         pub(crate) hints: crate::stdlib::collections::HashMap<
             usize,
-            Vec<crate::serde::deserialize_program::HintParams>,
+            crate::utils::Vec<crate::serde::deserialize_program::HintParams>,
         >,
         pub(crate) main: Option<usize>,
         //start and end labels will only be used in proof-mode
         pub(crate) start: Option<usize>,
         pub(crate) end: Option<usize>,
-        pub(crate) error_message_attributes: Vec<crate::serde::deserialize_program::Attribute>,
+        pub(crate) error_message_attributes:
+            crate::utils::Vec<crate::serde::deserialize_program::Attribute>,
         pub(crate) instruction_locations: Option<
             crate::stdlib::collections::HashMap<
                 usize,
@@ -312,7 +313,7 @@ pub mod test_utils {
             crate::serde::deserialize_program::Identifier,
         >,
         pub(crate) constants: crate::stdlib::collections::HashMap<String, crate::utils::Felt252>,
-        pub(crate) builtins: Vec<crate::serde::deserialize_program::BuiltinName>,
+        pub(crate) builtins: crate::utils::Vec<crate::serde::deserialize_program::BuiltinName>,
         pub(crate) reference_manager: crate::serde::deserialize_program::ReferenceManager,
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -292,7 +292,7 @@ pub mod test_utils {
 
     pub(crate) struct ProgramFlat {
         pub(crate) data: Vec<MaybeRelocatable>,
-        pub(crate) hints: crate::with_std::collections::HashMap<
+        pub(crate) hints: crate::stdlib::collections::HashMap<
             usize,
             Vec<crate::serde::deserialize_program::HintParams>,
         >,
@@ -302,16 +302,16 @@ pub mod test_utils {
         pub(crate) end: Option<usize>,
         pub(crate) error_message_attributes: Vec<crate::serde::deserialize_program::Attribute>,
         pub(crate) instruction_locations: Option<
-            crate::with_std::collections::HashMap<
+            crate::stdlib::collections::HashMap<
                 usize,
                 crate::serde::deserialize_program::InstructionLocation,
             >,
         >,
-        pub(crate) identifiers: crate::with_std::collections::HashMap<
+        pub(crate) identifiers: crate::stdlib::collections::HashMap<
             String,
             crate::serde::deserialize_program::Identifier,
         >,
-        pub(crate) constants: crate::with_std::collections::HashMap<String, crate::utils::Felt252>,
+        pub(crate) constants: crate::stdlib::collections::HashMap<String, crate::utils::Felt252>,
         pub(crate) builtins: Vec<crate::serde::deserialize_program::BuiltinName>,
         pub(crate) reference_manager: crate::serde::deserialize_program::ReferenceManager,
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -336,22 +336,22 @@ pub mod test_utils {
         }
     }
 
-    impl Into<Program> for ProgramFlat {
-        fn into(self) -> Program {
+    impl From<ProgramFlat> for Program {
+        fn from(val: ProgramFlat) -> Self {
             Program {
                 shared_program_data: Arc::new(SharedProgramData {
-                    data: self.data,
-                    hints: self.hints,
-                    main: self.main,
-                    start: self.start,
-                    end: self.end,
-                    error_message_attributes: self.error_message_attributes,
-                    instruction_locations: self.instruction_locations,
-                    identifiers: self.identifiers,
+                    data: val.data,
+                    hints: val.hints,
+                    main: val.main,
+                    start: val.start,
+                    end: val.end,
+                    error_message_attributes: val.error_message_attributes,
+                    instruction_locations: val.instruction_locations,
+                    identifiers: val.identifiers,
                 }),
-                constants: self.constants,
-                builtins: self.builtins,
-                reference_manager: self.reference_manager,
+                constants: val.constants,
+                builtins: val.builtins,
+                reference_manager: val.reference_manager,
             }
         }
     }

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -3970,7 +3970,8 @@ mod tests {
         let program = program![
             BuiltinName::pedersen,
             BuiltinName::range_check,
-            BuiltinName::ecdsa
+            BuiltinName::ecdsa,
+            BuiltinName::segment_arena
         ];
 
         let cairo_runner = cairo_runner!(program);
@@ -3985,11 +3986,11 @@ mod tests {
         assert_eq!(given_output[0].name(), HASH_BUILTIN_NAME);
         assert_eq!(given_output[1].name(), RANGE_CHECK_BUILTIN_NAME);
         assert_eq!(given_output[2].name(), SIGNATURE_BUILTIN_NAME);
-        assert_eq!(given_output[3].name(), OUTPUT_BUILTIN_NAME);
+        assert_eq!(given_output[3].name(), SEGMENT_ARENA_BUILTIN_NAME);
         assert_eq!(given_output[4].name(), BITWISE_BUILTIN_NAME);
         assert_eq!(given_output[5].name(), EC_OP_BUILTIN_NAME);
         assert_eq!(given_output[6].name(), KECCAK_BUILTIN_NAME);
-        assert_eq!(given_output[8].name(), SEGMENT_ARENA_BUILTIN_NAME);
+        assert_eq!(given_output[8].name(), OUTPUT_BUILTIN_NAME);
     }
 
     #[test]

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -247,7 +247,11 @@ impl CairoRunner {
             BuiltinName::poseidon,
         ];
 
-        fn initialize_builtin(name: BuiltinName, vm: &mut VirtualMachine) {
+        fn initialize_builtin(
+            name: BuiltinName,
+            vm: &mut VirtualMachine,
+            add_segment_arena_builtin: bool,
+        ) {
             match name {
                 BuiltinName::pedersen => vm
                     .builtin_runners
@@ -274,20 +278,22 @@ impl CairoRunner {
                 BuiltinName::poseidon => vm
                     .builtin_runners
                     .push(PoseidonBuiltinRunner::new(Some(1), true).into()),
+                BuiltinName::segment_arena => {
+                    if add_segment_arena_builtin {
+                        vm.builtin_runners
+                            .push(SegmentArenaBuiltinRunner::new(true).into())
+                    }
+                }
             }
         }
 
         for builtin_name in &self.program.builtins {
-            initialize_builtin(*builtin_name, vm);
+            initialize_builtin(*builtin_name, vm, add_segment_arena_builtin);
         }
         for builtin_name in starknet_preset_builtins {
             if !self.program.builtins.contains(&builtin_name) {
-                initialize_builtin(builtin_name, vm)
+                initialize_builtin(builtin_name, vm, add_segment_arena_builtin)
             }
-        }
-        if add_segment_arena_builtin {
-            vm.builtin_runners
-                .push(SegmentArenaBuiltinRunner::new(true).into())
         }
         Ok(())
     }

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -149,14 +149,10 @@ impl CairoRunner {
             BuiltinName::keccak,
             BuiltinName::poseidon,
         ];
-        if !is_subsequence(
-            &self.program.shared_program_data.builtins,
-            &builtin_ordered_list,
-        ) {
+        if !is_subsequence(&self.program.builtins, &builtin_ordered_list) {
             return Err(RunnerError::DisorderedBuiltins);
         };
-        let mut program_builtins: HashSet<&BuiltinName> =
-            self.program.shared_program_data.builtins.iter().collect();
+        let mut program_builtins: HashSet<&BuiltinName> = self.program.builtins.iter().collect();
         let mut builtin_runners = Vec::<BuiltinRunner>::new();
 
         if self.layout.builtins.output {
@@ -281,16 +277,11 @@ impl CairoRunner {
             }
         }
 
-        for builtin_name in &self.program.shared_program_data.builtins {
+        for builtin_name in &self.program.builtins {
             initialize_builtin(*builtin_name, vm);
         }
         for builtin_name in starknet_preset_builtins {
-            if !self
-                .program
-                .shared_program_data
-                .builtins
-                .contains(&builtin_name)
-            {
+            if !self.program.builtins.contains(&builtin_name) {
                 initialize_builtin(builtin_name, vm)
             }
         }
@@ -513,7 +504,7 @@ impl CairoRunner {
     }
 
     pub fn get_program_builtins(&self) -> &Vec<BuiltinName> {
-        &self.program.shared_program_data.builtins
+        &self.program.builtins
     }
 
     pub fn run_until_pc(
@@ -4157,10 +4148,7 @@ mod tests {
         );
         let runner = cairo_runner!(program);
 
-        assert_eq!(
-            &program.shared_program_data.builtins,
-            runner.get_program_builtins()
-        );
+        assert_eq!(&program.builtins, runner.get_program_builtins());
     }
 
     #[test]

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -4042,20 +4042,20 @@ mod tests {
         let mut vm = vm!();
 
         cairo_runner
-            .initialize_function_runner_cairo_1(&mut vm, &[])
+            .initialize_function_runner_cairo_1(&mut vm, &[BuiltinName::segment_arena])
             .expect("initialize_function_runner failed.");
 
         let builtin_runners = vm.get_builtin_runners();
 
-        assert_eq!(builtin_runners[0].name(), HASH_BUILTIN_NAME);
-        assert_eq!(builtin_runners[1].name(), RANGE_CHECK_BUILTIN_NAME);
-        assert_eq!(builtin_runners[2].name(), OUTPUT_BUILTIN_NAME);
-        assert_eq!(builtin_runners[3].name(), SIGNATURE_BUILTIN_NAME);
-        assert_eq!(builtin_runners[4].name(), BITWISE_BUILTIN_NAME);
-        assert_eq!(builtin_runners[5].name(), EC_OP_BUILTIN_NAME);
-        assert_eq!(builtin_runners[6].name(), KECCAK_BUILTIN_NAME);
-        assert_eq!(builtin_runners[7].name(), POSEIDON_BUILTIN_NAME);
-        assert_eq!(builtin_runners[8].name(), SEGMENT_ARENA_BUILTIN_NAME);
+        assert_eq!(builtin_runners[0].name(), SEGMENT_ARENA_BUILTIN_NAME);
+        assert_eq!(builtin_runners[1].name(), HASH_BUILTIN_NAME);
+        assert_eq!(builtin_runners[2].name(), RANGE_CHECK_BUILTIN_NAME);
+        assert_eq!(builtin_runners[3].name(), OUTPUT_BUILTIN_NAME);
+        assert_eq!(builtin_runners[4].name(), SIGNATURE_BUILTIN_NAME);
+        assert_eq!(builtin_runners[5].name(), BITWISE_BUILTIN_NAME);
+        assert_eq!(builtin_runners[6].name(), EC_OP_BUILTIN_NAME);
+        assert_eq!(builtin_runners[7].name(), KECCAK_BUILTIN_NAME);
+        assert_eq!(builtin_runners[8].name(), POSEIDON_BUILTIN_NAME);
 
         assert_eq!(
             cairo_runner.program_base,

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -873,9 +873,7 @@ impl CairoRunner {
     /// Runs a cairo program from a give entrypoint, indicated by its pc offset, with the given arguments.
     /// If `verify_secure` is set to true, [verify_secure_runner] will be called to run extra verifications.
     /// `program_segment_size` is only used by the [verify_secure_runner] function and will be ignored if `verify_secure` is set to false.
-    /// If `program_builtins` is some, the program's builtins field will be swapped for this value
-    /// This should only be used when running cairo 1 contract entrypoints
-    pub fn run_from_entrypoint_with_builtins(
+    pub fn run_from_entrypoint(
         &mut self,
         entrypoint: usize,
         args: &[&CairoArg],
@@ -883,11 +881,7 @@ impl CairoRunner {
         program_segment_size: Option<usize>,
         vm: &mut VirtualMachine,
         hint_processor: &mut dyn HintProcessor,
-        program_builtins: Option<&[BuiltinName]>,
     ) -> Result<(), CairoRunError> {
-        if let Some(builtins) = program_builtins {
-            self.program.builtins = builtins.to_vec();
-        }
         let stack = args
             .iter()
             .map(|arg| vm.segments.gen_cairo_arg(arg))
@@ -908,28 +902,6 @@ impl CairoRunner {
         Ok(())
     }
 
-    /// Runs a cairo program from a give entrypoint, indicated by its pc offset, with the given arguments.
-    /// If `verify_secure` is set to true, [verify_secure_runner] will be called to run extra verifications.
-    /// `program_segment_size` is only used by the [verify_secure_runner] function and will be ignored if `verify_secure` is set to false.
-    pub fn run_from_entrypoint(
-        &mut self,
-        entrypoint: usize,
-        args: &[&CairoArg],
-        verify_secure: bool,
-        program_segment_size: Option<usize>,
-        vm: &mut VirtualMachine,
-        hint_processor: &mut dyn HintProcessor,
-    ) -> Result<(), CairoRunError> {
-        self.run_from_entrypoint_with_builtins(
-            entrypoint,
-            args,
-            verify_secure,
-            program_segment_size,
-            vm,
-            hint_processor,
-            None,
-        )
-    }
 
     // Returns Ok(()) if there are enough allocated cells for the builtins.
     // If not, the number of steps should be increased or a different layout should be used.

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -4035,7 +4035,7 @@ mod tests {
         let mut vm = vm!();
 
         cairo_runner
-            .initialize_function_runner_cairo_1(&mut vm, &vec![])
+            .initialize_function_runner_cairo_1(&mut vm, &[])
             .expect("initialize_function_runner failed.");
 
         let builtin_runners = vm.get_builtin_runners();

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -968,9 +968,9 @@ impl CairoRunner {
 
     /// Intitializes the runner in order to run cairo 1 contract entrypoints
     /// Initializes builtins & segments
-    /// All builtins are initialized regardless of use following program ordering then starknet ordering
+    /// All builtins are initialized regardless of use
     /// Swaps the program's builtins field with program_builtins
-    /// Adds the segment_arena builtin
+    /// Adds the segment_arena builtin if present in the program_builtins
     pub fn initialize_function_runner_cairo_1(
         &mut self,
         vm: &mut VirtualMachine,
@@ -984,7 +984,7 @@ impl CairoRunner {
 
     /// Intitializes the runner in order to run cairo 0 contract entrypoints
     /// Initializes builtins & segments
-    /// All builtins are initialized regardless of use following program ordering then starknet ordering
+    /// All builtins are initialized regardless of use
     pub fn initialize_function_runner(
         &mut self,
         vm: &mut VirtualMachine,

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -3987,10 +3987,10 @@ mod tests {
         assert_eq!(given_output[1].name(), RANGE_CHECK_BUILTIN_NAME);
         assert_eq!(given_output[2].name(), SIGNATURE_BUILTIN_NAME);
         assert_eq!(given_output[3].name(), SEGMENT_ARENA_BUILTIN_NAME);
-        assert_eq!(given_output[4].name(), BITWISE_BUILTIN_NAME);
-        assert_eq!(given_output[5].name(), EC_OP_BUILTIN_NAME);
-        assert_eq!(given_output[6].name(), KECCAK_BUILTIN_NAME);
-        assert_eq!(given_output[8].name(), OUTPUT_BUILTIN_NAME);
+        assert_eq!(given_output[4].name(), OUTPUT_BUILTIN_NAME);
+        assert_eq!(given_output[5].name(), BITWISE_BUILTIN_NAME);
+        assert_eq!(given_output[6].name(), EC_OP_BUILTIN_NAME);
+        assert_eq!(given_output[7].name(), KECCAK_BUILTIN_NAME);
     }
 
     #[test]


### PR DESCRIPTION
This PR aims to solve the issue of `CasmContractClass` having the builtins stored by entrypoint instead of a universal builtin field.
In order to fix this, the method `CairoRunner::initialize_function_runner_cairo1` was added which allows setting the program builtins
## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

