### PR TITLE
Fix `U256SquareRoot` hint

### DIFF
--- a/src/tests/cairo_1_run_from_entrypoint_tests.rs
+++ b/src/tests/cairo_1_run_from_entrypoint_tests.rs
@@ -378,7 +378,7 @@ fn u256_sqrt_zero() {
 fn u256_sqrt_max_num() {
     let program_data = include_bytes!("../../cairo_programs/cairo-1-contracts/u256_sqrt.casm");
 
-    run_cairo_1_entrypoint(program_data.as_slice(), 257, &vec![], &vec![1.into()]);
+    run_cairo_1_entrypoint(program_data.as_slice(), 257, &[], &[1.into()]);
 }
 
 #[test]

--- a/src/tests/cairo_1_run_from_entrypoint_tests.rs
+++ b/src/tests/cairo_1_run_from_entrypoint_tests.rs
@@ -375,6 +375,14 @@ fn u256_sqrt_zero() {
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn u256_sqrt_max_num() {
+    let program_data = include_bytes!("../../cairo_programs/cairo-1-contracts/u256_sqrt.casm");
+
+    run_cairo_1_entrypoint(program_data.as_slice(), 257, &vec![], &vec![1.into()]);
+}
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn u256_sqrt_big_num() {
     let program_data = include_bytes!("../../cairo_programs/cairo-1-contracts/u256_sqrt.casm");
     run_cairo_1_entrypoint(


### PR DESCRIPTION
# Fix `U256SquareRoot` hint

## Description

Fixes `U256SquareRoot` hint for the case of u256::max and adds a test for that case. The error originally came from the fact that the implementation used Felt252 which is not enough to hold the value, so the fix is to change the implementation to use BigUint.

## Checklist
- [X] Linked to Github Issue
- [X] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

Closes #1126 
