### PR TITLE
ci: run test_install action on PRs

### DIFF
--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -1,8 +1,11 @@
 name: Test dependencies and cairo-rs install
 
 on:
+  merge_group:
   push:
-    branches-ignore: [ 'main' ]
+    branches: [ main ]
+  pull_request:
+    branches: [ '*' ]
 
 jobs:
   install:


### PR DESCRIPTION
This fixes issues to merge PRs from external contributors. As is, the workflow won't attempt to run because the pushes aren't on our repo but on a fork.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

