### PR TITLE
perf: migrate to iai-callgrind

### DIFF
--- a/.github/workflows/iai_main.yml
+++ b/.github/workflows/iai_main.yml
@@ -25,6 +25,7 @@ jobs:
         pip install -r requirements.txt
         sudo apt update
         sudo apt install -y valgrind
+        cargo install --version 0.3.1 iai-callgrind-runner
     # NB: this should never result in a hit, but rather just populate for PRs
     - name: Initialize IAI cache for ${{ github.sha }}
       uses: actions/cache@v3

--- a/.github/workflows/iai_pr.yml
+++ b/.github/workflows/iai_pr.yml
@@ -27,6 +27,7 @@ jobs:
         pip install -r requirements.txt
         sudo apt update
         sudo apt install -y valgrind
+        cargo install --version 0.3.1 iai-callgrind-runner
     - name: Initialize IAI cache for ${{ github.event.pull_request.base.sha }}
       uses: actions/cache@v3
       id: cache-iai-results
@@ -61,6 +62,7 @@ jobs:
         pip install -r requirements.txt
         sudo apt update
         sudo apt install -y valgrind
+        cargo install --version 0.3.1 iai-callgrind-runner
     - name: Initialize IAI cache for ${{ github.event.pull_request.base.sha }}
       uses: actions/cache@v3
       id: cache-iai-results

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,7 +695,7 @@ dependencies = [
  "generic-array",
  "hashbrown 0.13.2",
  "hex",
- "iai",
+ "iai-callgrind",
  "keccak",
  "lazy_static",
  "mimalloc",
@@ -1426,10 +1426,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
-name = "iai"
-version = "0.1.1"
+name = "iai-callgrind"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71a816c97c42258aa5834d07590b718b4c9a598944cd39a52dc25b351185d678"
+checksum = "76579762a383d5da364779d780704f93898c620703c27087b766700a87e5a8c2"
 
 [[package]]
 name = "id-arena"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ rstest = { version = "0.17.0", default-features = false }
 wasm-bindgen-test = "0.3.34"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-iai = "0.1"
+iai-callgrind = "0.3.1"
 rusty-hook = "0.11"
 criterion = { version = "0.3", features = ["html_reports"] }
 proptest = "1.0.0"

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,7 @@ $(cairo-repo-dir):
 	cd cairo; cargo b --release --bin starknet-compile --bin starknet-sierra-compile
 
 cargo-deps:
+	cargo install --version 0.3.1 iai-callgrind-runner
 	cargo install --version 1.1.0 cargo-criterion
 	cargo install --version 0.6.1 flamegraph
 	cargo install --version 1.14.0 hyperfine


### PR DESCRIPTION
iai-callgrind seems to be actively maintained as opposed to iai, it's more efficient in how long valgrind emulation runs and is able to filter out setup from the measure, making it more accurate and representative. Filtering out expensive setup also allows for less iterations on the relevant tests.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

