### PR TITLE
Fix and tests for `Uint256DivMod`

### DIFF
--- a/cairo_programs/cairo-1-contracts/uint256_div_mod.cairo
+++ b/cairo_programs/cairo-1-contracts/uint256_div_mod.cairo
@@ -5,16 +5,31 @@ mod TestUint256DivMod {
     use zeroable::NonZero;
     use core::traits::Into;
     use traits::TryInto;
+    use integer::BoundedInt;
     
     #[external]
-    fn test_uint256_div_mod(a:u128, b:u128) -> felt252 {
-        let a = as_u256(8_u128,0);
-        let b = as_u256(2_u128,0);
+    fn test_uint256_div_mod_max() {
+        let a = BoundedInt::max();
+
+        let b = as_u256(1_u128, 0);
         let b = integer::u256_as_non_zero(b);
 
         let (res, _) = integer::u256_safe_divmod(a, b);
 
-        res.low.into()
+        assert(a==res, 'div failed')
+    }
+
+
+    #[external]
+    fn test_uint256_div_mod(a:u128, b:u128) -> felt252 {
+        let a = as_u256(a, 0);
+        let b = as_u256(b, 0);
+
+        let b = integer::u256_as_non_zero(b);
+
+        let (res, _) = integer::u256_safe_divmod(a, b);
+
+        return res.low.into();
     }
 
     #[internal]

--- a/src/hint_processor/cairo_1_hint_processor/hint_processor.rs
+++ b/src/hint_processor/cairo_1_hint_processor/hint_processor.rs
@@ -424,10 +424,10 @@ impl Cairo1HintProcessor {
         let dividend_high = res_operand_get_val(vm, dividend_high)?.to_biguint();
         let divisor_low = res_operand_get_val(vm, divisor_low)?.to_biguint();
         let divisor_high = res_operand_get_val(vm, divisor_high)?.to_biguint();
-        let dividend = dividend_low + dividend_high * pow_2_128;
-        let divisor = divisor_low + divisor_high * pow_2_128;
-        let quotient = dividend / divisor;
-        let remainder = dividend % divisor;
+        let dividend = dividend_low + dividend_high * &pow_2_128;
+        let divisor = divisor_low + &divisor_high * &pow_2_128;
+        let quotient = &dividend / &divisor;
+        let remainder = dividend % &divisor;
 
         // Guess quotient limbs.
         let (quotient, limb) = quotient.div_rem(&pow_2_64);
@@ -457,7 +457,7 @@ impl Cairo1HintProcessor {
         // Guess remainder limbs.
         vm.insert_value(
             cell_ref_to_relocatable(remainder_low, vm)?,
-            Felt252::from(remainder % pow_2_128),
+            Felt252::from(remainder.clone() % pow_2_128.clone()),
         )?;
         vm.insert_value(
             cell_ref_to_relocatable(remainder_high, vm)?,

--- a/src/hint_processor/cairo_1_hint_processor/hint_processor.rs
+++ b/src/hint_processor/cairo_1_hint_processor/hint_processor.rs
@@ -22,7 +22,7 @@ use cairo_lang_casm::{
     operand::{CellRef, ResOperand},
 };
 use core::any::Any;
-use core::ops::Mul;
+
 use num_bigint::BigUint;
 use num_integer::Integer;
 use num_traits::{cast::ToPrimitive, Zero};
@@ -418,47 +418,50 @@ impl Cairo1HintProcessor {
         remainder_low: &CellRef,
         remainder_high: &CellRef,
     ) -> Result<(), HintError> {
-        let pow_2_128 = Felt252::from(u128::MAX) + 1u32;
-        let pow_2_64 = Felt252::from(u64::MAX) + 1u32;
-        let dividend_low = res_operand_get_val(vm, dividend_low)?;
-        let dividend_high = res_operand_get_val(vm, dividend_high)?;
-        let divisor_low = res_operand_get_val(vm, divisor_low)?;
-        let divisor_high = res_operand_get_val(vm, divisor_high)?;
-        let dividend = dividend_low + dividend_high.mul(pow_2_128.clone());
-        let divisor = divisor_low + (&divisor_high * &pow_2_128);
-        let quotient = &dividend / &divisor;
+        let pow_2_128 = BigUint::from(u128::MAX) + 1u32;
+        let pow_2_64 = BigUint::from(u64::MAX) + 1u32;
+        let dividend_low = res_operand_get_val(vm, dividend_low)?.to_biguint();
+        let dividend_high = res_operand_get_val(vm, dividend_high)?.to_biguint();
+        let divisor_low = res_operand_get_val(vm, divisor_low)?.to_biguint();
+        let divisor_high = res_operand_get_val(vm, divisor_high)?.to_biguint();
+        let dividend = dividend_low + dividend_high * pow_2_128.clone();
+        let divisor = divisor_low + divisor_high.clone() * pow_2_128.clone();
+        let quotient = dividend.clone() / divisor.clone();
         let remainder = dividend % divisor.clone();
 
         // Guess quotient limbs.
         let (quotient, limb) = quotient.div_rem(&pow_2_64);
-        vm.insert_value(cell_ref_to_relocatable(quotient0, vm)?, limb)?;
+        vm.insert_value(cell_ref_to_relocatable(quotient0, vm)?, Felt252::from(limb))?;
         let (quotient, limb) = quotient.div_rem(&pow_2_64);
-        vm.insert_value(cell_ref_to_relocatable(quotient1, vm)?, limb)?;
+        vm.insert_value(cell_ref_to_relocatable(quotient1, vm)?, Felt252::from(limb))?;
         let (quotient, limb) = quotient.div_rem(&pow_2_64);
         if divisor_high.is_zero() {
-            vm.insert_value(cell_ref_to_relocatable(extra0, vm)?, limb)?;
-            vm.insert_value(cell_ref_to_relocatable(extra1, vm)?, quotient)?;
+            vm.insert_value(cell_ref_to_relocatable(extra0, vm)?, Felt252::from(limb))?;
+            vm.insert_value(
+                cell_ref_to_relocatable(extra1, vm)?,
+                Felt252::from(quotient),
+            )?;
         }
 
         // Guess divisor limbs.
         let (divisor, limb) = divisor.div_rem(&pow_2_64);
-        vm.insert_value(cell_ref_to_relocatable(divisor0, vm)?, limb)?;
+        vm.insert_value(cell_ref_to_relocatable(divisor0, vm)?, Felt252::from(limb))?;
         let (divisor, limb) = divisor.div_rem(&pow_2_64);
-        vm.insert_value(cell_ref_to_relocatable(divisor1, vm)?, limb)?;
+        vm.insert_value(cell_ref_to_relocatable(divisor1, vm)?, Felt252::from(limb))?;
         let (divisor, limb) = divisor.div_rem(&pow_2_64);
         if !divisor_high.is_zero() {
-            vm.insert_value(cell_ref_to_relocatable(extra0, vm)?, limb)?;
-            vm.insert_value(cell_ref_to_relocatable(extra1, vm)?, divisor)?;
+            vm.insert_value(cell_ref_to_relocatable(extra0, vm)?, Felt252::from(limb))?;
+            vm.insert_value(cell_ref_to_relocatable(extra1, vm)?, Felt252::from(divisor))?;
         }
 
         // Guess remainder limbs.
         vm.insert_value(
             cell_ref_to_relocatable(remainder_low, vm)?,
-            remainder.clone() % pow_2_128.clone(),
+            Felt252::from(remainder.clone() % pow_2_128.clone()),
         )?;
         vm.insert_value(
             cell_ref_to_relocatable(remainder_high, vm)?,
-            remainder / pow_2_128,
+            Felt252::from(remainder / pow_2_128),
         )?;
         Ok(())
     }

--- a/src/hint_processor/cairo_1_hint_processor/hint_processor.rs
+++ b/src/hint_processor/cairo_1_hint_processor/hint_processor.rs
@@ -424,10 +424,10 @@ impl Cairo1HintProcessor {
         let dividend_high = res_operand_get_val(vm, dividend_high)?.to_biguint();
         let divisor_low = res_operand_get_val(vm, divisor_low)?.to_biguint();
         let divisor_high = res_operand_get_val(vm, divisor_high)?.to_biguint();
-        let dividend = dividend_low + dividend_high * pow_2_128.clone();
-        let divisor = divisor_low + divisor_high.clone() * pow_2_128.clone();
-        let quotient = dividend.clone() / divisor.clone();
-        let remainder = dividend % divisor.clone();
+        let dividend = dividend_low + dividend_high * pow_2_128;
+        let divisor = divisor_low + divisor_high * pow_2_128;
+        let quotient = dividend / divisor;
+        let remainder = dividend % divisor;
 
         // Guess quotient limbs.
         let (quotient, limb) = quotient.div_rem(&pow_2_64);
@@ -457,7 +457,7 @@ impl Cairo1HintProcessor {
         // Guess remainder limbs.
         vm.insert_value(
             cell_ref_to_relocatable(remainder_low, vm)?,
-            Felt252::from(remainder.clone() % pow_2_128.clone()),
+            Felt252::from(remainder % pow_2_128),
         )?;
         vm.insert_value(
             cell_ref_to_relocatable(remainder_high, vm)?,

--- a/src/tests/cairo_1_run_from_entrypoint_tests.rs
+++ b/src/tests/cairo_1_run_from_entrypoint_tests.rs
@@ -23,15 +23,24 @@ fn dict_hint_test() {
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_uint256_div_mod_hint_max_value() {
+    let program_data =
+        include_bytes!("../../cairo_programs/cairo-1-contracts/uint256_div_mod.casm");
+
+    run_cairo_1_entrypoint(program_data.as_slice(), 0, &[], &[]);
+}
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_uint256_div_mod_hint() {
     let program_data =
         include_bytes!("../../cairo_programs/cairo-1-contracts/uint256_div_mod.casm");
 
     run_cairo_1_entrypoint(
         program_data.as_slice(),
-        0,
-        &[8_usize.into(), 2_usize.into()],
-        &[Felt252::from(4_usize)],
+        118,
+        &[36_usize.into(), 2_usize.into()],
+        &[Felt252::from(18_usize)],
     );
 }
 


### PR DESCRIPTION
# Fix and tests for `Uint256DivMod`

## Description

Previous implementation used Felt252 (similar to the problem that sqrt had) which was not enough for all values of u256, so this PR fixes that and adds a test case.

## Checklist
- [ ] Linked to Github Issue
- [X] Unit tests added
- [X] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

