### PR TITLE
fix: typo in error message

### DIFF
--- a/src/hint_processor/builtin_hint_processor/ec_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/ec_utils.rs
@@ -39,7 +39,7 @@ impl EcPoint<'_> {
                 .map_err(|_| HintError::IdentifierHasNoMember(name.to_string(), "x".to_string()))?,
             y: vm
                 .get_integer((point_addr + 1)?)
-                .map_err(|_| HintError::IdentifierHasNoMember(name.to_string(), "x".to_string()))?,
+                .map_err(|_| HintError::IdentifierHasNoMember(name.to_string(), "y".to_string()))?,
         })
     }
 }


### PR DESCRIPTION
When a hint for ECs fails to get `y`, the error message says `x` is missing instead.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

