### PR TITLE
Catch possible subtraction error in `QUAD_BIT` & `DI_BIT` hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 #### Upcoming Changes
 
+* Fix possible sustraction overflow in `QUAD_BIT` & `DI_BIT` hints [#1185](https://github.com/lambdaclass/cairo-rs/pull/1185)
+
+  * Hints now return an error when ids.m equals zero
+
 * Add `CairoRunner::run_until_pc_with_steps_limit method` [#1181](https://github.com/lambdaclass/cairo-rs/pull/1181)
 
 * fix: felt_from_number not properly returning parse errors [#1012](https://github.com/lambdaclass/cairo-rs/pull/1012)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Fix possible subtraction overflow in `QUAD_BIT` & `DI_BIT` hints [#1185](https://github.com/lambdaclass/cairo-rs/pull/1185)
 
-  * Hints now return an error when ids.m equals zero
+  * These hints now return an error when ids.m equals zero
 
 * Add `CairoRunner::run_until_pc_with_steps_limit method` [#1181](https://github.com/lambdaclass/cairo-rs/pull/1181)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Upcoming Changes
 
-* Fix possible sustraction overflow in `QUAD_BIT` & `DI_BIT` hints [#1185](https://github.com/lambdaclass/cairo-rs/pull/1185)
+* Fix possible subtraction overflow in `QUAD_BIT` & `DI_BIT` hints [#1185](https://github.com/lambdaclass/cairo-rs/pull/1185)
 
   * Hints now return an error when ids.m equals zero
 

--- a/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
+++ b/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
@@ -487,6 +487,9 @@ pub fn n_pair_bits(
     if m >= 253 {
         return insert_value_from_var_name("quad_bit", 0, vm, ids_data, ap_tracking);
     }
+    if m.is_zero() {
+        return Err(HintError::NPairBitsMZero);
+    }
 
     let one = &Felt252::one();
     let two = &Felt252::from(2);
@@ -1279,6 +1282,29 @@ mod tests {
 
         // Check hint memory inserts
         check_memory![vm.segments.memory, ((1, 3), 2)];
+    }
+
+    #[test]
+    fn run_di_bit_m_zero() {
+        let hint_code = hint_code::DI_BIT;
+        let mut vm = vm_with_range_check!();
+
+        let scalar_u = 0b10101111001110000;
+        let scalar_v = 0b101101000111011111100;
+        let m = 0;
+        // Insert ids.scalar into memory
+        vm.segments = segments![((1, 0), scalar_u), ((1, 1), scalar_v), ((1, 2), m)];
+
+        // Initialize RunContext
+        run_context!(vm, 0, 4, 4);
+
+        let ids_data = ids_data!["scalar_u", "scalar_v", "m", "dibit"];
+
+        // Execute the hint
+        assert_matches!(
+            run_hint!(vm, ids_data, hint_code),
+            Err(HintError::NPairBitsMZero)
+        );
     }
 
     #[test]

--- a/src/vm/errors/hint_errors.rs
+++ b/src/vm/errors/hint_errors.rs
@@ -179,4 +179,6 @@ pub enum HintError {
     RecoverYPointNotOnCurve(Felt252),
     #[error("Invalid value for {0}. Got: {1}. Expected: {2}")]
     InvalidValue(&'static str, Felt252, Felt252),
+    #[error("Attempt to subtract with overflow: ids.m - 1")]
+    NPairBitsMZero,
 }


### PR DESCRIPTION
Now returns an error if ids.m is zero

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

