### PR TITLE
feat!: expose writer trait and common impls

### DIFF
--- a/src/cairo_run.rs
+++ b/src/cairo_run.rs
@@ -7,9 +7,9 @@ use crate::{
         security::verify_secure_runner,
         vm_core::VirtualMachine,
     },
+    write::Writer,
 };
 
-use bincode::enc::write::Writer;
 use felt::Felt252;
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
Re-exports `bincode::enc::write::{Writer, SliceWriter}` and implements
two ad-hoc writers for common use cases, `VecWriter` and `BufWriter`,
for writing to memory and an arbitrary `std::io::Write` (in a buffered
fashion), the latter enabled only with `feature = std`.

BREAKING: `write_encoded_trace` and `write_encoded_memory` use the new
trait.

# TITLE

## Description

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

