### PR TITLE
fix: substraction between relocatables should be signed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 #### [0.5.1] - 2023-6-7
 
+* fix: substraction of `MaybeRelocatable` always behaves as signed [#1218](https://github.com/lambdaclass/cairo-rs/pull/1218)
+
 * fix: fix overflow for `QUAD_BIT` and `DI_BIT` hints [#1209](https://github.com/lambdaclass/cairo-rs/pull/1209)
   Fixes [#1205](https://github.com/lambdaclass/cairo-rs/issue/1205)
 

--- a/cairo_programs/if_reloc_equal.cairo
+++ b/cairo_programs/if_reloc_equal.cairo
@@ -1,0 +1,16 @@
+from starkware.cairo.common.alloc import alloc
+
+func main{}() {
+    let arr: felt* = alloc();
+
+    assert arr[0] = 1;
+    assert arr[5] = 2;
+
+    let end = arr + 5;
+
+    if (arr == end) {
+        ret;
+    }
+
+    ret;
+}

--- a/src/tests/cairo_run_test.rs
+++ b/src/tests/cairo_run_test.rs
@@ -970,9 +970,6 @@ fn cairo_run_reduce() {
 
 #[test]
 fn cairo_run_if_reloc_equal() {
-    const PROGRAM_DATA: &[u8] = include_bytes!(concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/cairo_programs/if_reloc_equal.json",
-    ));
-    run_program_simple(PROGRAM_DATA);
+    let program_data = include_bytes!("../../cairo_programs/if_reloc_equal.json");
+    run_program_simple_with_memory_holes(program_data, 4);
 }

--- a/src/tests/cairo_run_test.rs
+++ b/src/tests/cairo_run_test.rs
@@ -967,3 +967,12 @@ fn cairo_run_reduce() {
     let program_data = include_bytes!("../../cairo_programs/reduce.json");
     run_program_simple(program_data.as_slice());
 }
+
+#[test]
+fn cairo_run_if_reloc_equal() {
+    const PROGRAM_DATA: &[u8] = include_bytes!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/cairo_programs/if_reloc_equal.json",
+    ));
+    run_program_simple(PROGRAM_DATA);
+}

--- a/src/types/relocatable.rs
+++ b/src/types/relocatable.rs
@@ -256,7 +256,9 @@ impl MaybeRelocatable {
                 MaybeRelocatable::RelocatableValue(rel_b),
             ) => {
                 if rel_a.segment_index == rel_b.segment_index {
-                    return Ok(MaybeRelocatable::from(Felt252::new((*rel_a - *rel_b)?)));
+                    return Ok(MaybeRelocatable::from(Felt252::from(
+                        rel_a.offset as i128 - rel_b.offset as i128,
+                    )));
                 }
                 Err(MathError::RelocatableSubDiffIndex(Box::new((
                     *rel_a, *rel_b,

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -230,6 +230,7 @@ impl VirtualMachine {
                 ) if !num_op1.is_zero() => {
                     Ok((Some(MaybeRelocatable::Int(num_dst / num_op1)), dst.cloned()))
                 }
+                // FIXME: missing case: div by 0 should return error
                 _ => Ok((None, None)),
             },
             _ => Ok((None, None)),
@@ -382,6 +383,8 @@ impl VirtualMachine {
         Ok(())
     }
 
+    // TODO: TEST: run_instruction with update JmpNz, operation Add, (dst, op1) = (Rel, Rel) and
+    // op1 > dst
     fn run_instruction(&mut self, instruction: &Instruction) -> Result<(), VirtualMachineError> {
         let (operands, operands_addresses, deduced_operands) =
             self.compute_operands(instruction)?;
@@ -449,6 +452,7 @@ impl VirtualMachine {
             *instruction = Some(self.decode_current_instruction()?);
         }
         let instruction = instruction.as_ref().unwrap();
+        dbg!(instruction);
         if !self.skip_instruction_execution {
             self.run_instruction(instruction)?;
         } else {

--- a/src/vm/vm_core.rs
+++ b/src/vm/vm_core.rs
@@ -230,7 +230,6 @@ impl VirtualMachine {
                 ) if !num_op1.is_zero() => {
                     Ok((Some(MaybeRelocatable::Int(num_dst / num_op1)), dst.cloned()))
                 }
-                // FIXME: missing case: div by 0 should return error
                 _ => Ok((None, None)),
             },
             _ => Ok((None, None)),
@@ -383,8 +382,6 @@ impl VirtualMachine {
         Ok(())
     }
 
-    // TODO: TEST: run_instruction with update JmpNz, operation Add, (dst, op1) = (Rel, Rel) and
-    // op1 > dst
     fn run_instruction(&mut self, instruction: &Instruction) -> Result<(), VirtualMachineError> {
         let (operands, operands_addresses, deduced_operands) =
             self.compute_operands(instruction)?;
@@ -452,7 +449,6 @@ impl VirtualMachine {
             *instruction = Some(self.decode_current_instruction()?);
         }
         let instruction = instruction.as_ref().unwrap();
-        dbg!(instruction);
         if !self.skip_instruction_execution {
             self.run_instruction(instruction)?;
         } else {


### PR DESCRIPTION
It is valid as per the reference implementation to substract two relocatables `a - b` where `b.offset > a.offset`. The current code returns an error due to negative result in that case.
The fix consists in not using the trait as implemented for `Relocatable` (where it represents a positive distance between pointers) but to promote the offsets to `i128` and only substract them for `MaybeRelocatable`, as those are the language-level types.

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

