### PR TITLE
Add CI flags to `run_benchmarks` script

### DIFF
--- a/bench/run_benchmarks.sh
+++ b/bench/run_benchmarks.sh
@@ -9,7 +9,7 @@ for file in $(ls $tests_path | grep .cairo | sed -E 's/\.cairo//'); do
     export PATH="$(pyenv root)/shims:$PATH"
 
     hyperfine \
-	    -n "Cairo VM (CPython)" "PYENV_VERSION=3.9.15 cairo-run --layout starknet_with_keccak --program $tests_path/$file.json" \
-	    -n "Cairo VM (PyPy)" "PYENV_VERSION=pypy3.9-7.3.9 cairo-run --layout starknet_with_keccak --program $tests_path/$file.json" \
-	    -n "cairo-rs (Rust)" "../target/release/cairo-vm-cli $tests_path/$file.json --layout starknet_with_keccak"
+	    -n "Cairo VM (CPython)" "PYENV_VERSION=3.9.15 cairo-run --proof_mode --memory_file /dev/null --trace_file /dev/null --layout starknet_with_keccak --program $tests_path/$file.json" \
+	    -n "Cairo VM (PyPy)" "PYENV_VERSION=pypy3.9-7.3.9 cairo-run --proof_mode --memory_file /dev/null --trace_file /dev/null --layout starknet_with_keccak --program $tests_path/$file.json" \
+	    -n "cairo-rs (Rust)" "../target/release/cairo-vm-cli $tests_path/$file.json --proof_mode --memory_file /dev/null --trace_file /dev/null --layout starknet_with_keccak"
 done


### PR DESCRIPTION
## Description

This PR adds option flags (_proof mode_ and trace/memory dumping) to the benchmarks script, to mimic the CI benches.

