### PR TITLE
fix: pin Cairo compiler version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* fix: pin Cairo compiler version [#1220](https://github.com/lambdaclass/cairo-rs/pull/1220)
+
 * perf: make `inner_rc_bound` a constant, improving performance of the range-check builtin
 
 #### [0.5.1] - 2023-6-7

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ cairo-repo-dir = cairo
 build-cairo-1-compiler: | $(cairo-repo-dir)
 
 $(cairo-repo-dir):
-	git clone https://github.com/starkware-libs/cairo.git
+	git clone --depth 1 -b v1.1.0 https://github.com/starkware-libs/cairo.git
 	cd cairo; cargo b --release --bin starknet-compile --bin starknet-sierra-compile
 
 cargo-deps:


### PR DESCRIPTION
Pins the compiler version to avoid build errors.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [x] CHANGELOG has been updated.

