### PR TITLE
Compute `ExecutionResources.n_steps` without requiring trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 #### Upcoming Changes
 
+* BREAKING: Compute `ExecutionResources.n_steps` without requiring trace [#1222](https://github.com/lambdaclass/cairo-rs/pull/1222)
+
+  * `CairoRunner::get_execution_resources` return's `n_steps` field value is now set to `vm.current_step` instead of `0` if both `original_steps` and `trace` are set to `None`
+
 * perf: make `inner_rc_bound` a constant, improving performance of the range-check builtin
 
 #### [0.5.1] - 2023-6-7

--- a/src/vm/runners/cairo_runner.rs
+++ b/src/vm/runners/cairo_runner.rs
@@ -855,7 +855,11 @@ impl CairoRunner {
     ) -> Result<ExecutionResources, TraceError> {
         let n_steps = match self.original_steps {
             Some(x) => x,
-            None => vm.trace.as_ref().map(|x| x.len()).unwrap_or(0),
+            None => vm
+                .trace
+                .as_ref()
+                .map(|x| x.len())
+                .unwrap_or(vm.current_step),
         };
         let n_memory_holes = self.get_memory_holes(vm)?;
 
@@ -1234,6 +1238,7 @@ impl MulAssign<usize> for ExecutionResources {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cairo_run::{cairo_run, CairoRunConfig};
     use crate::stdlib::collections::{HashMap, HashSet};
     use crate::vm::runners::builtin_runner::{
         BITWISE_BUILTIN_NAME, EC_OP_BUILTIN_NAME, HASH_BUILTIN_NAME, KECCAK_BUILTIN_NAME,
@@ -3488,17 +3493,52 @@ mod tests {
         let program = program!();
 
         let cairo_runner = cairo_runner!(program);
-        let mut vm = vm!();
+        let mut vm: VirtualMachine = vm!();
 
         vm.segments.segment_used_sizes = Some(vec![4]);
+        vm.current_step = 10;
         assert_eq!(
             cairo_runner.get_execution_resources(&vm),
             Ok(ExecutionResources {
-                n_steps: 0,
+                n_steps: 10,
                 n_memory_holes: 0,
                 builtin_instance_counter: HashMap::new(),
             }),
         );
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn get_execution_resources_run_program() {
+        let program_data = include_bytes!("../../../cairo_programs/fibonacci.json");
+        let cairo_run_config = CairoRunConfig {
+            entrypoint: "main",
+            trace_enabled: true,
+            relocate_mem: false,
+            layout: "all_cairo",
+            proof_mode: false,
+            secure_run: Some(false),
+        };
+        let mut hint_executor = BuiltinHintProcessor::new_empty();
+        let (runner, vm) = cairo_run(program_data, &cairo_run_config, &mut hint_executor).unwrap();
+        assert_eq!(runner.get_execution_resources(&vm).unwrap().n_steps, 80);
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn get_execution_resources_run_program_no_trace() {
+        let program_data = include_bytes!("../../../cairo_programs/fibonacci.json");
+        let cairo_run_config = CairoRunConfig {
+            entrypoint: "main",
+            trace_enabled: false,
+            relocate_mem: false,
+            layout: "all_cairo",
+            proof_mode: false,
+            secure_run: Some(false),
+        };
+        let mut hint_executor = BuiltinHintProcessor::new_empty();
+        let (runner, vm) = cairo_run(program_data, &cairo_run_config, &mut hint_executor).unwrap();
+        assert_eq!(runner.get_execution_resources(&vm).unwrap().n_steps, 80);
     }
 
     #[test]


### PR DESCRIPTION
Currently, if original steps is not set and trace is not enabled the number of steps in the `ExecutionResources` returned by `CairoRunner::get_execution_resources` is always 0. There are cases, such as starknet_in_rust, where execution resources are used but there is no use for the trace. In order to not slow down other projects that have no use for the trace, `CairoRunner::get_execution_resources` will now use `vm.current_step` as n_steps if original steps or trace are not available

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

