### PR TITLE
fix(security): DoS in parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* fix(security): avoid denial of service on malicious input exploiting the scientific notation parser [#1239](https://github.com/lambdaclass/cairo-rs/pull/1239)
+
 * perf: accumulate `min` and `max` instruction offsets during run to speed up range check [#1080](https://github.com/lambdaclass/cairo-rs/pull/)
   BREAKING: `Cairo_runner::get_perm_range_check_limits` no longer returns an error when called without trace enabled, as it no longer depends on it
 

--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -495,7 +495,7 @@ impl<const PH: u128, const PL: u128> Pow<u32> for FeltBigInt<PH, PL> {
     type Output = Self;
     fn pow(self, rhs: u32) -> Self {
         FeltBigInt {
-            val: self.val.pow(rhs).mod_floor(&CAIRO_PRIME_BIGUINT),
+            val: self.val.modpow(&BigUint::from(rhs), &CAIRO_PRIME_BIGUINT),
         }
     }
 }
@@ -505,7 +505,7 @@ impl<'a, const PH: u128, const PL: u128> Pow<u32> for &'a FeltBigInt<PH, PL> {
     #[allow(clippy::needless_borrow)] // the borrow of self.val is necessary becase it's of the type BigUInt, which doesn't implement the Copy trait
     fn pow(self, rhs: u32) -> Self::Output {
         FeltBigInt {
-            val: (&self.val).pow(rhs).mod_floor(&CAIRO_PRIME_BIGUINT),
+            val: self.val.modpow(&BigUint::from(rhs), &CAIRO_PRIME_BIGUINT),
         }
     }
 }

--- a/felt/src/bigint_felt.rs
+++ b/felt/src/bigint_felt.rs
@@ -502,7 +502,6 @@ impl<const PH: u128, const PL: u128> Pow<u32> for FeltBigInt<PH, PL> {
 
 impl<'a, const PH: u128, const PL: u128> Pow<u32> for &'a FeltBigInt<PH, PL> {
     type Output = FeltBigInt<PH, PL>;
-    #[allow(clippy::needless_borrow)] // the borrow of self.val is necessary becase it's of the type BigUInt, which doesn't implement the Copy trait
     fn pow(self, rhs: u32) -> Self::Output {
         FeltBigInt {
             val: self.val.modpow(&BigUint::from(rhs), &CAIRO_PRIME_BIGUINT),

--- a/vm/src/serde/deserialize_program.rs
+++ b/vm/src/serde/deserialize_program.rs
@@ -1450,7 +1450,6 @@ mod tests {
             String::from_utf8(vec![b'9'; 1000]).unwrap(),
             u32::MAX
         );
-        dbg!(malicious_input);
         let f = serde_json::from_str::<Test>(malicious_input)
             .unwrap()
             .f

--- a/vm/src/serde/deserialize_program.rs
+++ b/vm/src/serde/deserialize_program.rs
@@ -1436,4 +1436,32 @@ mod tests {
             )
         );
     }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn test_felt_from_number_with_scientific_notation_big_exponent() {
+        #[derive(Deserialize, Debug, PartialEq)]
+        struct Test {
+            #[serde(deserialize_with = "felt_from_number")]
+            f: Option<Felt252>,
+        }
+        let malicious_input = &format!(
+            "{{ \"f\": {}e{} }}",
+            String::from_utf8(vec![b'9'; 1000]).unwrap(),
+            u32::MAX
+        );
+        dbg!(malicious_input);
+        let f = serde_json::from_str::<Test>(malicious_input)
+            .unwrap()
+            .f
+            .unwrap();
+        assert_eq!(
+            f,
+            Felt252::from_str_radix(
+                "2471602022505793130446032259107029522557827898253184929958153020344968292412",
+                10
+            )
+            .unwrap()
+        );
+    }
 }


### PR DESCRIPTION
Malicious input can cause a denial of service by exponentiating a number
to a huge power and taking the CPU for galactic amounts of time, as well
as exponentially increasing memory usage.
The added test can trigger it before this commit even in release mode. I
aborted the run after 40 minutes and over 2GB of memory.
This was found by the fuzzer using the externally reachable parser, even
though the test only attacks the culprit here.

The cause of this issue is the following:
- Recently we added support for scientific notation numbers in the
  `data` section of an input program;
- `NumBigUint` only supports `modpow` when all arguments are `BigUint`;
- `FeltBigInt` for primitive-type exponents tried to avoid creating a
  new `BigUint` as an attempt at optimization, so it used
  `pow`+`mod_floor` instead;
- This combination with a huge exponent means an ever increasing number
  of allocations.

The fix consists in building the `BigUint` and using `modpow` instead.
This uses constant space because internally it uses the Montgomery
exponentiation algorithm. With this the test finishes in 11ms on my
machine.

## Checklist
- [ ] Linked to Github Issue
- [x] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [x] CHANGELOG has been updated.

