### PR TITLE
fix: `dibit` shouldn't fail when `m` is zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* fix: `dibit` hint no longer fails when called with an `m` of zero [#1247](https://github.com/lambdaclass/cairo-rs/pull/1247)
+
 * fix(security): avoid denial of service on malicious input exploiting the scientific notation parser [#1239](https://github.com/lambdaclass/cairo-rs/pull/1239)
 
 * perf: accumulate `min` and `max` instruction offsets during run to speed up range check [#1080](https://github.com/lambdaclass/cairo-rs/pull/)

--- a/vm/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
@@ -498,7 +498,7 @@ pub fn n_pair_bits(
     if m >= 253 {
         return insert_value_from_var_name(result_name, 0, vm, ids_data, ap_tracking);
     }
-    if m.is_zero() {
+    if m + 1 < number_of_pairs {
         return Err(HintError::NPairBitsMZero);
     }
 

--- a/vm/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
@@ -499,7 +499,7 @@ pub fn n_pair_bits(
         return insert_value_from_var_name(result_name, 0, vm, ids_data, ap_tracking);
     }
     if m + 1 < number_of_pairs {
-        return Err(HintError::NPairBitsMZero);
+        return Err(HintError::NPairBitsTooLowM);
     }
 
     let (scalar_v, scalar_u) = (scalar_v.to_biguint(), scalar_u.to_biguint());

--- a/vm/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
@@ -1423,12 +1423,12 @@ mod tests {
     }
 
     #[test]
-    fn run_di_bit_m_zero() {
+    fn run_di_bit_m_zero_ok() {
         let hint_code = hint_code::DI_BIT;
         let mut vm = vm_with_range_check!();
 
-        let scalar_u = 0b10101111001110000;
-        let scalar_v = 0b101101000111011111100;
+        let scalar_u = 0b00;
+        let scalar_v = 0b01;
         let m = 0;
         // Insert ids.scalar into memory
         vm.segments = segments![((1, 0), scalar_u), ((1, 1), scalar_v), ((1, 2), m)];
@@ -1439,10 +1439,10 @@ mod tests {
         let ids_data = ids_data!["scalar_u", "scalar_v", "m", "dibit"];
 
         // Execute the hint
-        assert_matches!(
-            run_hint!(vm, ids_data, hint_code),
-            Err(HintError::NPairBitsMZero)
-        );
+        assert_matches!(run_hint!(vm, ids_data, hint_code), Ok(()));
+
+        // Check hint memory inserts
+        check_memory![vm.segments.memory, ((1, 3), 0b10)];
     }
 
     #[test]

--- a/vm/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/secp/ec_utils.rs
@@ -1329,7 +1329,7 @@ mod tests {
     }
 
     #[test]
-    fn run_quad_bit_for_m_1() {
+    fn run_quad_bit_for_m_1_ok() {
         let hint_code = hint_code::QUAD_BIT;
         let mut vm = vm_with_range_check!();
 
@@ -1349,6 +1349,29 @@ mod tests {
 
         // Check hint memory inserts
         check_memory![vm.segments.memory, ((1, 3), 0)];
+    }
+
+    #[test]
+    fn run_quad_bit_for_m_0() {
+        let hint_code = hint_code::QUAD_BIT;
+        let mut vm = vm_with_range_check!();
+
+        let scalar_u = 0b1010101;
+        let scalar_v = 0b1010101;
+        let m = 0;
+        // Insert ids.scalar into memory
+        vm.segments = segments![((1, 0), scalar_u), ((1, 1), scalar_v), ((1, 2), m)];
+
+        // Initialize RunContext
+        run_context!(vm, 0, 4, 4);
+
+        let ids_data = ids_data!["scalar_u", "scalar_v", "m", "quad_bit"];
+
+        // Execute the hint
+        assert_matches!(
+            run_hint!(vm, ids_data, hint_code),
+            Err(HintError::NPairBitsTooLowM)
+        );
     }
 
     #[test]

--- a/vm/src/vm/errors/hint_errors.rs
+++ b/vm/src/vm/errors/hint_errors.rs
@@ -184,7 +184,7 @@ pub enum HintError {
     #[error("Invalid value for {}. Got: {}. Expected: {}", (*.0).0, (*.0).1, (*.0).2)]
     InvalidValue(Box<(&'static str, Felt252, Felt252)>),
     #[error("Attempt to subtract with overflow: ids.m - 1")]
-    NPairBitsMZero,
+    NPairBitsTooLowM,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes: #1245

## Description

This PR fixes a check in the `n_pair_bits` function called from the `dibit` hint that was only correct for the `quad_bit` hint.

## Checklist
- [X] Linked to Github Issue
- [X] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [X] CHANGELOG has been updated.

