### PR TITLE
move no_std changelog entry from 0.5.2 to incomming changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@
   * `HintProcessor::compile_hint` now receies a `&[HintReference]` rather than `&HashMap<usize, HintReference>`
   * Public `CairoRunner::get_reference_list` has been removed
 
+* move the vm in it's own directory and crate, different from the workspace
+
+* add a `ensure-no_std` crate that will be used by the CI to check that new changes are not reverting `no_std` support
+
+* replace the use of `num-prime::is_prime` by a custom implementation, therefore restoring `no_std` compatibility
+
 #### [0.5.2] - 2023-6-12
 
 * BREAKING: Compute `ExecutionResources.n_steps` without requiring trace [#1222](https://github.com/lambdaclass/cairo-rs/pull/1222)
@@ -39,12 +45,6 @@
 * perf: make `inner_rc_bound` a constant, improving performance of the range-check builtin
 
 * fix: substraction of `MaybeRelocatable` always behaves as signed [#1218](https://github.com/lambdaclass/cairo-rs/pull/1218)
-
-* move the vm in it's own directory and crate, different from the workspace
-
-* add a `ensure-no_std` crate that will be used by the CI to check that new changes are not reverting `no_std` support
-
-* replace the use of `num-prime::is_prime` by a custom implementation, therefore restoring `no_std` compatibility
 
 #### [0.5.1] - 2023-6-7
 


### PR DESCRIPTION
I messed up my changelog entries, putting them under 0.5.2, when they will rather be published int the next

