### PR TITLE
build(vm): remove unused implicit features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* build: remove unused implicit features from cairo-vm
+
 #### [0.6.1] - 2023-6-23
 
 * fix: updated the `custom_hint_example` and added it to the workspace [#1258](https://github.com/lambdaclass/cairo-rs/pull/1258)

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -18,9 +18,9 @@ std = [
     "starknet-crypto/std",
     "parse-hyperlinks/std",
     "felt/std",
-    "num-prime",
+    "dep:num-prime",
 ]
-cairo-1-hints = ["cairo-lang-starknet", "cairo-lang-casm", "ark-ff", "ark-std"]
+cairo-1-hints = ["dep:cairo-lang-starknet", "dep:cairo-lang-casm", "dep:ark-ff", "dep:ark-std"]
 
 
 # Note that these features are not retro-compatible with the cairo Python VM.


### PR DESCRIPTION
## Description

As stated in the [rust doc](https://doc.rust-lang.org/cargo/reference/features.html#optional-dependencies)
`In some cases, you may not want to expose a feature that has the same name as the optional dependency. For example, perhaps the optional dependency is an internal detail, or you want to group multiple optional dependencies together, or you just want to use a better name. If you specify the optional dependency with the dep: prefix anywhere in the [features] table, that disables the implicit feature.`

This makes sure no implicit features are created for the optional crates that are imported only to be used in another feature.

