### PR TITLE
ping README.md Path in the Cargo.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Upcoming Changes
 
+* Add path to cairo-vm README.md [#1276](https://github.com/lambdaclass/cairo-rs/pull/1276)
+
 * fix: change error returned when subtracting two `MaybeRelocatable`s to better reflect the cause [#1271](https://github.com/lambdaclass/cairo-rs/pull/1271)
 
 * fix: CLI error message when using --help [#1270](https://github.com/lambdaclass/cairo-rs/pull/1270)

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 description = "Blazing fast Cairo interpreter"
 repository = "https://github.com/lambdaclass/cairo-rs/"
+readme= "../README.md"
 
 [features]
 default = ["std", "with_mimalloc"]


### PR DESCRIPTION
# TITLE

## Description
Since we make some modifications in the crates organization, now in crates.io the Readme is not visible
https://crates.io/crates/cairo-vm

Description of the pull request changes and motivation.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

