### PR TITLE
Run benchmarks serially in the CI

### DIFF
--- a/.github/workflows/hyperfine.yml
+++ b/.github/workflows/hyperfine.yml
@@ -156,7 +156,7 @@ jobs:
           done
         fi
         find target_programs -name '*.json' -exec basename -s .json '{}' '+' | \
-        sort | xargs -P 2 -I '{program}' \
+        sort | xargs -I '{program}' \
         hyperfine -N -r 10 --export-markdown "target_programs/{program}.md" \
         -L bin "$BINS" -n "{bin} {program}" \
         -s "cat ./bin/cairo-vm-cli-{bin} target_programs/{program}.json" \


### PR DESCRIPTION
## Description

The benchmarks consume a lot of memory. Since we disabled swap memory usage, the bench runs fail sporadically because of OOM errors. This makes them run with 1 process instead of 2 in parallel.

## Checklist
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] Integration tests added.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
  - [ ] CHANGELOG has been updated.

